### PR TITLE
switched from srun to sbatch --wrap to avoid process spamming

### DIFF
--- a/start.R
+++ b/start.R
@@ -93,7 +93,7 @@ runOutputs <- function(runscripts=NULL, submit=NULL) {
       }
 
       cat("Executing",name,"\n")
-      srun_command <- paste0("srun --job-name=",rout," --output=",rout,"-%j.out --mail-type=END")
+      sbatch_command <- paste0("sbatch --job-name=",rout," --output=",rout,"-%j.out --mail-type=END --wrap=\"Rscript ",name,"\"")
       if(submit=="direct") {
         tmp.env <- new.env()
         tmp.error <- try(sys.source(name,envir=tmp.env))
@@ -103,10 +103,10 @@ runOutputs <- function(runscripts=NULL, submit=NULL) {
         log <- format(Sys.time(), paste0(rout,"-%Y-%H-%M-%S-%OS3.log"))
         system2("Rscript",name, stderr = log, stdout = log, wait=FALSE)
       } else if(submit=="slurmpriority") {
-        system(paste0(srun_command," --qos=priority Rscript ",name), wait=FALSE)
+        system(paste(sbatch_command,"--qos=priority"))
         Sys.sleep(1)
       } else if(submit=="slurmstandby") {
-        system(paste0(srun_command," --qos=standby Rscript ",name), wait=FALSE)
+        system(paste(sbatch_command,"--qos=standby"))
         Sys.sleep(1)
       } else if(submit=="debug") {
         tmp.env <- new.env()


### PR DESCRIPTION
I replaced srun statements in the code with sbatch --wrap statements as it turned out that the srun-based commands will stay active on the login node for each submitted job until job termination. sbatch --wrap spawns jobs without the need of an active process on the login node.