### PR TITLE
added new realization for natveg module to resolve infeasiblites 

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -269,8 +269,9 @@ cfg$gms$urban   <- "static"                # def = static
 # ***---------------------    35_natveg    --------------------------------------
 # * 35_natveg includes primforest, secdforest and other land
 # * (static):               static natveg land
-# * (dynamic_may18): 		dynamic natveg land
-cfg$gms$natveg  <- "dynamic_may18"           # def = dynamic_may18
+# * (dynamic_may18): 		dynamic natveg land with aggregated age-classes
+# * (dynamic_oct19): 		dynamic natveg land with detailed age-classes
+cfg$gms$natveg  <- "dynamic_oct19"           # def = dynamic_oct19
 
 # * protected areas (primforest,secdforest,other land)
 # * (WDPA) WDPA IUCN catI+II

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -223,6 +223,14 @@ sets
                     ac205,ac210,ac215,ac220,ac225,ac230,ac235,ac240,ac245,ac250,
                     ac255,ac260,ac265,ac270,ac275,ac280,ac285,ac290,ac295,acx /
 
+  ac_sub(ac) age classes
+  / ac5,ac10,ac15,ac20,ac25,ac30,ac35,ac40,ac45,ac50,
+  ac55,ac60,ac65,ac70,ac75,ac80,ac85,ac90,ac95,ac100,
+  ac105,ac110,ac115,ac120,ac125,ac130,ac135,ac140,ac145,ac150,
+  ac155,ac160,ac165,ac170,ac175,ac180,ac185,ac190,ac195,ac200,
+  ac205,ac210,ac215,ac220,ac225,ac230,ac235,ac240,ac245,ac250,
+  ac255,ac260,ac265,ac270,ac275,ac280,ac285,ac290,ac295,acx /
+
    when Temporal location relative to optimization / before, after /
 
    chap_par Chapman-richards parameters / k,m /

--- a/modules/35_natveg/dynamic_may18/postsolve.gms
+++ b/modules/35_natveg/dynamic_may18/postsolve.gms
@@ -19,7 +19,7 @@ else
         v35_other.l(j,"new")$(ord(ac) = 1)
         + sum(ac_land35(ac,land35)$(not sameas(land35,"new") AND pc35_other(j,land35) > 0),(v35_other.l(j,land35)/pc35_other(j,land35))*p35_other(t,j,ac,"before"))$(ord(ac) > 1);
 *account for cases of pc35_other(j,land35) = 0
-	p35_other(t,j,"ac5","after") = sum(land35,v35_other.l(j,land35))-sum(ac, p35_other(t,j,ac,"after"));
+	p35_other(t,j,"ac5","after") = p35_other(t,j,"ac5","after") + sum(land35,v35_other.l(j,land35))-sum(ac, p35_other(t,j,ac,"after"));
 );
 
 *secdforest age class calculation
@@ -27,7 +27,7 @@ p35_secdforest(t,j,ac,"after") =
         v35_secdforest.l(j,"new")$(ord(ac) = 1)
         + sum(ac_land35(ac,land35)$(not sameas(land35,"new") AND pc35_secdforest(j,land35) > 0),(v35_secdforest.l(j,land35)/pc35_secdforest(j,land35))*p35_secdforest(t,j,ac,"before"))$(ord(ac) > 1);
 *account for cases of pc35_secdforest(j,land35) = 0
-p35_secdforest(t,j,"ac30","after") = sum(land35,v35_secdforest.l(j,land35))-sum(ac, p35_secdforest(t,j,ac,"after"));
+p35_secdforest(t,j,"ac30","after") = p35_secdforest(t,j,"ac30","after") + sum(land35,v35_secdforest.l(j,land35))-sum(ac, p35_secdforest(t,j,ac,"after"));
 
 *#################### R SECTION START (OUTPUT DEFINITIONS) #####################
  ov35_secdforest(t,j,land35,"marginal")           = v35_secdforest.m(j,land35);

--- a/modules/35_natveg/dynamic_may18/postsolve.gms
+++ b/modules/35_natveg/dynamic_may18/postsolve.gms
@@ -18,12 +18,16 @@ else
 	p35_other(t,j,ac,"after") =
         v35_other.l(j,"new")$(ord(ac) = 1)
         + sum(ac_land35(ac,land35)$(not sameas(land35,"new") AND pc35_other(j,land35) > 0),(v35_other.l(j,land35)/pc35_other(j,land35))*p35_other(t,j,ac,"before"))$(ord(ac) > 1);
+*account for cases of pc35_other(j,land35) = 0
+	p35_other(t,j,"ac5","after") = sum(land35,v35_other.l(j,land35))-sum(ac, p35_other(t,j,ac,"after"));
 );
 
 *secdforest age class calculation
 p35_secdforest(t,j,ac,"after") =
         v35_secdforest.l(j,"new")$(ord(ac) = 1)
         + sum(ac_land35(ac,land35)$(not sameas(land35,"new") AND pc35_secdforest(j,land35) > 0),(v35_secdforest.l(j,land35)/pc35_secdforest(j,land35))*p35_secdforest(t,j,ac,"before"))$(ord(ac) > 1);
+*account for cases of pc35_secdforest(j,land35) = 0
+p35_secdforest(t,j,"ac30","after") = sum(land35,v35_secdforest.l(j,land35))-sum(ac, p35_secdforest(t,j,ac,"after"));
 
 *#################### R SECTION START (OUTPUT DEFINITIONS) #####################
  ov35_secdforest(t,j,land35,"marginal")           = v35_secdforest.m(j,land35);

--- a/modules/35_natveg/dynamic_oct19/declarations.gms
+++ b/modules/35_natveg/dynamic_oct19/declarations.gms
@@ -1,0 +1,77 @@
+*** |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: magpie@pik-potsdam.de
+
+scalars
+ s35_shift number of 5-year age-classes corresponding to current time step length (1)
+;
+
+parameters
+ i35_secdforest(j,ac)							   Inital secdforest (mio. ha)
+ i35_other(j,ac)								   Inital other land (mio. ha)
+ p35_secdforest(t,j,ac)  	Secdforest per age class before and after optimization (mio. ha)
+ p35_other(t,j,ac)   	  	Other land per age class before and after optimization (mio. ha)
+ pc35_secdforest(j,ac)    	Secdforest per aggregated age class (mio. ha)
+ pc35_other(j,ac)   	  	Other land per aggregated age class (mio. ha)
+ p35_protect_shr(t,j,prot_type) Protection share for primforest secdforest and other land (1)
+ p35_save_primforest(t,j) 		Primforest protection (mio. ha)
+ p35_save_secdforest(t,j)		Secdforest protection (mio. ha)
+ p35_save_other(t,j)			Other land protection (mio. ha)
+ p35_recovered_forest(t,j,ac) 	Recovered forest (mio. ha)
+ p35_min_forest(t,j) 			Minimum forest stock [land protection policies] (Mha)
+ p35_min_other(t,j)      		Minimum other land stock [land protection policies] (Mha)
+ p35_carbon_density_secdforest(t,j,ac,ag_pools) Carbon density secdforest (tC per ha)
+ p35_carbon_density_other(t,j,ac,ag_pools) 	   Carbon density other land (tC per ha)
+;
+
+equations
+ q35_land_secdforest(j)       		   Secdforest land pool calculation (mio. ha)
+ q35_land_other(j)       		       Other land pool calculation (mio. ha)
+ q35_carbon_primforest(j,ag_pools)      Primforest carbon stock calculation (mio tC)
+ q35_carbon_secdforest(j,ag_pools)      Secdforest carbon stock calculation (mio tC)
+ q35_carbon_other(j,ag_pools)      	   Other land carbon stock calculation (mio tC)
+ q35_landdiff              			   Difference in natveg land (mio. ha)
+ q35_other_expansion(j,ac)		   Other land expansion (mio. ha)
+ q35_other_reduction(j,ac)		   Other land reduction (mio. ha)
+ q35_secdforest_reduction(j,ac)    Secdforest reduction (mio. ha)
+ q35_primforest_reduction(j)   	       Primforest reduction (mio. ha)
+ q35_min_forest(j)					   Minimum forest land constraint (mio. ha)
+ q35_min_other(j)              		   Minimum other land constraint (mio. ha)
+;
+
+positive variables
+  v35_secdforest(j,ac) Detailed stock of secdforest (mio. ha)
+  v35_other(j,ac)      Detailed stock of other land (mio. ha)
+  vm_landdiff_natveg       Aggregated difference in natveg land compared to previous timestep (mio. ha)
+  v35_other_expansion(j,ac) Other land expansion compared to previous timestep (mio. ha)
+  v35_other_reduction(j,ac) Other land reduction compared to previous timestep (mio. ha)
+  v35_secdforest_reduction(j,ac) Secdforest reduction compared to previous timestep (mio. ha)
+  v35_primforest_reduction(j) Primforest reduction compared to previous timestep (mio. ha)
+;
+
+*#################### R SECTION START (OUTPUT DECLARATIONS) ####################
+parameters
+ ov35_secdforest(t,j,ac,type)              Detailed stock of secdforest (mio. ha)
+ ov35_other(t,j,ac,type)                   Detailed stock of other land (mio. ha)
+ ov_landdiff_natveg(t,type)                Aggregated difference in natveg land compared to previous timestep (mio. ha)
+ ov35_other_expansion(t,j,ac,type)         Other land expansion compared to previous timestep (mio. ha)
+ ov35_other_reduction(t,j,ac,type)         Other land reduction compared to previous timestep (mio. ha)
+ ov35_secdforest_reduction(t,j,ac,type)    Secdforest reduction compared to previous timestep (mio. ha)
+ ov35_primforest_reduction(t,j,type)       Primforest reduction compared to previous timestep (mio. ha)
+ oq35_land_secdforest(t,j,type)            Secdforest land pool calculation (mio. ha)
+ oq35_land_other(t,j,type)                 Other land pool calculation (mio. ha)
+ oq35_carbon_primforest(t,j,ag_pools,type) Primforest carbon stock calculation (mio tC)
+ oq35_carbon_secdforest(t,j,ag_pools,type) Secdforest carbon stock calculation (mio tC)
+ oq35_carbon_other(t,j,ag_pools,type)      Other land carbon stock calculation (mio tC)
+ oq35_landdiff(t,type)                     Difference in natveg land (mio. ha)
+ oq35_other_expansion(t,j,ac,type)         Other land expansion (mio. ha)
+ oq35_other_reduction(t,j,ac,type)         Other land reduction (mio. ha)
+ oq35_secdforest_reduction(t,j,ac,type)    Secdforest reduction (mio. ha)
+ oq35_primforest_reduction(t,j,type)       Primforest reduction (mio. ha)
+ oq35_min_forest(t,j,type)                 Minimum forest land constraint (mio. ha)
+ oq35_min_other(t,j,type)                  Minimum other land constraint (mio. ha)
+;
+*##################### R SECTION END (OUTPUT DECLARATIONS) #####################

--- a/modules/35_natveg/dynamic_oct19/equations.gms
+++ b/modules/35_natveg/dynamic_oct19/equations.gms
@@ -1,0 +1,68 @@
+*** |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: magpie@pik-potsdam.de
+
+*' @equations
+*' The interface `vm_land` provides aggregated natveg land pools (`ac`) to other modules.
+
+ q35_land_secdforest(j2) .. vm_land(j2,"secdforest") =e= sum(ac, v35_secdforest(j2,ac));
+
+ q35_land_other(j2) .. vm_land(j2,"other") =e= sum(ac, v35_other(j2,ac));
+
+*' Carbon stocks for primary forest, secondary forest or other natural land are calculated
+*' as the product of respective area and carbon density.
+*' Carbon stocks decline if the area decreases
+*' (e.g. due to cropland expansion into forests).
+*' In case of abandoned agricultural land (increase of other natural land),
+*' natural succession, represented by age-class growth, results in increasing carbon stocks.
+
+ q35_carbon_primforest(j2,ag_pools) .. vm_carbon_stock(j2,"primforest",ag_pools) =e=
+           vm_land(j2,"primforest")
+           *sum(ct, fm_carbon_density(ct,j2,"primforest",ag_pools));
+
+ q35_carbon_secdforest(j2,ag_pools) .. vm_carbon_stock(j2,"secdforest",ag_pools) =e=
+           sum(ac, v35_secdforest(j2,ac)
+           *sum(ct, pm_carbon_density_ac(ct,j2,ac,ag_pools)));
+
+ q35_carbon_other(j2,ag_pools)  .. vm_carbon_stock(j2,"other",ag_pools) =e=
+           sum(ac, v35_other(j2,ac)
+           *sum(ct, pm_carbon_density_ac(ct,j2,ac,ag_pools)));
+
+
+*' NPI/NDC land protection policies are implemented as minium forest land and other land stock.
+
+ q35_min_forest(j2) .. vm_land(j2,"primforest") + vm_land(j2,"secdforest") =g=
+ 									sum(ct, p35_min_forest(ct,j2));
+
+ q35_min_other(j2) .. vm_land(j2,"other") =g= sum(ct, p35_min_other(ct,j2));
+
+*' The following technical calculations are needed for reducing differences in land-use patterns between time steps.
+*' The gross change in natural vegetation is calculated based on land expansion and
+*' land contraction of other land, and land reduction of primary and secondary forest.
+*' This information is then passed to the land module ([10_land]):
+
+ q35_landdiff .. vm_landdiff_natveg =e=
+ 					sum((j2,ac),
+ 							v35_other_expansion(j2,ac)
+ 						  + v35_other_reduction(j2,ac)
+ 						  + v35_secdforest_reduction(j2,ac)
+ 						  + v35_primforest_reduction(j2));
+
+ q35_other_expansion(j2,ac) ..
+ 	v35_other_expansion(j2,ac) =g=
+ 		v35_other(j2,ac) - pc35_other(j2,ac);
+
+ q35_other_reduction(j2,ac) ..
+ 	v35_other_reduction(j2,ac) =g=
+ 		pc35_other(j2,ac) - v35_other(j2,ac);
+
+ q35_secdforest_reduction(j2,ac) ..
+ 	v35_secdforest_reduction(j2,ac) =g=
+ 		pc35_secdforest(j2,ac) - v35_secdforest(j2,ac);
+
+ q35_primforest_reduction(j2) ..
+ 	v35_primforest_reduction(j2) =g=
+ 		pcm_land(j2,"primforest") - vm_land(j2,"primforest");

--- a/modules/35_natveg/dynamic_oct19/input.gms
+++ b/modules/35_natveg/dynamic_oct19/input.gms
@@ -1,0 +1,22 @@
+*** |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: magpie@pik-potsdam.de
+
+$setglobal c35_protect_scenario  WDPA
+$setglobal c35_ad_policy  npi
+$setglobal c35_aolc_policy  npi
+
+table f35_protect_area(j,prot_type) Conservation priority areas (mio. ha)
+$ondelim
+$include "./modules/35_natveg/input/protect_area.cs3"
+$offdelim
+;
+
+table f35_min_land_stock(t_all,j,pol35,pol_stock35) Land protection policies [minimum land stock] (Mha)
+$ondelim
+$include "./modules/35_natveg/input/npi_ndc_ad_aolc_pol.cs3"
+$offdelim
+;

--- a/modules/35_natveg/dynamic_oct19/not_used.txt
+++ b/modules/35_natveg/dynamic_oct19/not_used.txt
@@ -1,0 +1,6 @@
+# |  (C) 2008-2018 Potsdam Institute for Climate Impact Research (PIK),
+# |  authors, and contributors see AUTHORS file
+# |  This file is part of MAgPIE and licensed under GNU AGPL Version 3
+# |  or later. See LICENSE file or go to http://www.gnu.org/licenses/
+# |  Contact: magpie@pik-potsdam.de
+name,type,reason

--- a/modules/35_natveg/dynamic_oct19/postsolve.gms
+++ b/modules/35_natveg/dynamic_oct19/postsolve.gms
@@ -1,0 +1,91 @@
+*** |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: magpie@pik-potsdam.de
+
+*secdforest age class calculation
+p35_secdforest(t,j,ac) = v35_secdforest.l(j,ac);
+
+*other land age class calculation
+p35_other(t,j,ac) = v35_other.l(j,ac);
+
+*#################### R SECTION START (OUTPUT DEFINITIONS) #####################
+ ov35_secdforest(t,j,ac,"marginal")              = v35_secdforest.m(j,ac);
+ ov35_other(t,j,ac,"marginal")                   = v35_other.m(j,ac);
+ ov_landdiff_natveg(t,"marginal")                = vm_landdiff_natveg.m;
+ ov35_other_expansion(t,j,ac,"marginal")         = v35_other_expansion.m(j,ac);
+ ov35_other_reduction(t,j,ac,"marginal")         = v35_other_reduction.m(j,ac);
+ ov35_secdforest_reduction(t,j,ac,"marginal")    = v35_secdforest_reduction.m(j,ac);
+ ov35_primforest_reduction(t,j,"marginal")       = v35_primforest_reduction.m(j);
+ oq35_land_secdforest(t,j,"marginal")            = q35_land_secdforest.m(j);
+ oq35_land_other(t,j,"marginal")                 = q35_land_other.m(j);
+ oq35_carbon_primforest(t,j,ag_pools,"marginal") = q35_carbon_primforest.m(j,ag_pools);
+ oq35_carbon_secdforest(t,j,ag_pools,"marginal") = q35_carbon_secdforest.m(j,ag_pools);
+ oq35_carbon_other(t,j,ag_pools,"marginal")      = q35_carbon_other.m(j,ag_pools);
+ oq35_landdiff(t,"marginal")                     = q35_landdiff.m;
+ oq35_other_expansion(t,j,ac,"marginal")         = q35_other_expansion.m(j,ac);
+ oq35_other_reduction(t,j,ac,"marginal")         = q35_other_reduction.m(j,ac);
+ oq35_secdforest_reduction(t,j,ac,"marginal")    = q35_secdforest_reduction.m(j,ac);
+ oq35_primforest_reduction(t,j,"marginal")       = q35_primforest_reduction.m(j);
+ oq35_min_forest(t,j,"marginal")                 = q35_min_forest.m(j);
+ oq35_min_other(t,j,"marginal")                  = q35_min_other.m(j);
+ ov35_secdforest(t,j,ac,"level")                 = v35_secdforest.l(j,ac);
+ ov35_other(t,j,ac,"level")                      = v35_other.l(j,ac);
+ ov_landdiff_natveg(t,"level")                   = vm_landdiff_natveg.l;
+ ov35_other_expansion(t,j,ac,"level")            = v35_other_expansion.l(j,ac);
+ ov35_other_reduction(t,j,ac,"level")            = v35_other_reduction.l(j,ac);
+ ov35_secdforest_reduction(t,j,ac,"level")       = v35_secdforest_reduction.l(j,ac);
+ ov35_primforest_reduction(t,j,"level")          = v35_primforest_reduction.l(j);
+ oq35_land_secdforest(t,j,"level")               = q35_land_secdforest.l(j);
+ oq35_land_other(t,j,"level")                    = q35_land_other.l(j);
+ oq35_carbon_primforest(t,j,ag_pools,"level")    = q35_carbon_primforest.l(j,ag_pools);
+ oq35_carbon_secdforest(t,j,ag_pools,"level")    = q35_carbon_secdforest.l(j,ag_pools);
+ oq35_carbon_other(t,j,ag_pools,"level")         = q35_carbon_other.l(j,ag_pools);
+ oq35_landdiff(t,"level")                        = q35_landdiff.l;
+ oq35_other_expansion(t,j,ac,"level")            = q35_other_expansion.l(j,ac);
+ oq35_other_reduction(t,j,ac,"level")            = q35_other_reduction.l(j,ac);
+ oq35_secdforest_reduction(t,j,ac,"level")       = q35_secdforest_reduction.l(j,ac);
+ oq35_primforest_reduction(t,j,"level")          = q35_primforest_reduction.l(j);
+ oq35_min_forest(t,j,"level")                    = q35_min_forest.l(j);
+ oq35_min_other(t,j,"level")                     = q35_min_other.l(j);
+ ov35_secdforest(t,j,ac,"upper")                 = v35_secdforest.up(j,ac);
+ ov35_other(t,j,ac,"upper")                      = v35_other.up(j,ac);
+ ov_landdiff_natveg(t,"upper")                   = vm_landdiff_natveg.up;
+ ov35_other_expansion(t,j,ac,"upper")            = v35_other_expansion.up(j,ac);
+ ov35_other_reduction(t,j,ac,"upper")            = v35_other_reduction.up(j,ac);
+ ov35_secdforest_reduction(t,j,ac,"upper")       = v35_secdforest_reduction.up(j,ac);
+ ov35_primforest_reduction(t,j,"upper")          = v35_primforest_reduction.up(j);
+ oq35_land_secdforest(t,j,"upper")               = q35_land_secdforest.up(j);
+ oq35_land_other(t,j,"upper")                    = q35_land_other.up(j);
+ oq35_carbon_primforest(t,j,ag_pools,"upper")    = q35_carbon_primforest.up(j,ag_pools);
+ oq35_carbon_secdforest(t,j,ag_pools,"upper")    = q35_carbon_secdforest.up(j,ag_pools);
+ oq35_carbon_other(t,j,ag_pools,"upper")         = q35_carbon_other.up(j,ag_pools);
+ oq35_landdiff(t,"upper")                        = q35_landdiff.up;
+ oq35_other_expansion(t,j,ac,"upper")            = q35_other_expansion.up(j,ac);
+ oq35_other_reduction(t,j,ac,"upper")            = q35_other_reduction.up(j,ac);
+ oq35_secdforest_reduction(t,j,ac,"upper")       = q35_secdforest_reduction.up(j,ac);
+ oq35_primforest_reduction(t,j,"upper")          = q35_primforest_reduction.up(j);
+ oq35_min_forest(t,j,"upper")                    = q35_min_forest.up(j);
+ oq35_min_other(t,j,"upper")                     = q35_min_other.up(j);
+ ov35_secdforest(t,j,ac,"lower")                 = v35_secdforest.lo(j,ac);
+ ov35_other(t,j,ac,"lower")                      = v35_other.lo(j,ac);
+ ov_landdiff_natveg(t,"lower")                   = vm_landdiff_natveg.lo;
+ ov35_other_expansion(t,j,ac,"lower")            = v35_other_expansion.lo(j,ac);
+ ov35_other_reduction(t,j,ac,"lower")            = v35_other_reduction.lo(j,ac);
+ ov35_secdforest_reduction(t,j,ac,"lower")       = v35_secdforest_reduction.lo(j,ac);
+ ov35_primforest_reduction(t,j,"lower")          = v35_primforest_reduction.lo(j);
+ oq35_land_secdforest(t,j,"lower")               = q35_land_secdforest.lo(j);
+ oq35_land_other(t,j,"lower")                    = q35_land_other.lo(j);
+ oq35_carbon_primforest(t,j,ag_pools,"lower")    = q35_carbon_primforest.lo(j,ag_pools);
+ oq35_carbon_secdforest(t,j,ag_pools,"lower")    = q35_carbon_secdforest.lo(j,ag_pools);
+ oq35_carbon_other(t,j,ag_pools,"lower")         = q35_carbon_other.lo(j,ag_pools);
+ oq35_landdiff(t,"lower")                        = q35_landdiff.lo;
+ oq35_other_expansion(t,j,ac,"lower")            = q35_other_expansion.lo(j,ac);
+ oq35_other_reduction(t,j,ac,"lower")            = q35_other_reduction.lo(j,ac);
+ oq35_secdforest_reduction(t,j,ac,"lower")       = q35_secdforest_reduction.lo(j,ac);
+ oq35_primforest_reduction(t,j,"lower")          = q35_primforest_reduction.lo(j);
+ oq35_min_forest(t,j,"lower")                    = q35_min_forest.lo(j);
+ oq35_min_other(t,j,"lower")                     = q35_min_other.lo(j);
+*##################### R SECTION END (OUTPUT DEFINITIONS) ######################

--- a/modules/35_natveg/dynamic_oct19/preloop.gms
+++ b/modules/35_natveg/dynamic_oct19/preloop.gms
@@ -1,0 +1,24 @@
+*** |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: magpie@pik-potsdam.de
+
+*** Assuming all secdf in acx for initialization
+i35_secdforest(j,ac) = 0;
+i35_secdforest(j,"acx") = pcm_land(j,"secdforest");
+
+i35_other(j,ac) = 0;
+i35_other(j,"acx") = pcm_land(j,"other");
+
+p35_protect_shr(t,j,prot_type) = 0;
+
+p35_recovered_forest(t,j,ac) = 0;
+
+p35_min_forest(t,j) = f35_min_land_stock(t,j,"%c35_ad_policy%","forest");
+p35_min_other(t,j) = f35_min_land_stock(t,j,"%c35_ad_policy%","other");
+
+*initialize parameter
+p35_other(t,j,ac) = 0;
+p35_secdforest(t,j,ac) = 0;

--- a/modules/35_natveg/dynamic_oct19/presolve.gms
+++ b/modules/35_natveg/dynamic_oct19/presolve.gms
@@ -1,0 +1,120 @@
+*** |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: magpie@pik-potsdam.de
+
+* Regrowth of natural vegetation (natural succession) is modelled by shifting age-classes according to time step length.
+s35_shift = m_yeardiff(t)/5;
+if((ord(t) = 1),
+	p35_secdforest(t,j,ac) = i35_secdforest(j,ac);
+	p35_other(t,j,ac) = i35_other(j,ac);
+else
+* example: ac10 in t = ac5 (ac10-1) in t-1 for a 5 yr time step (s35_shift = 1)
+    p35_other(t,j,ac)$(ord(ac) > s35_shift) = p35_other(t-1,j,ac-s35_shift);
+* account for cases at the end of the age class set (s35_shift > 1) which are not shifted by the above calculation
+    p35_other(t,j,"acx") = p35_other(t,j,"acx")
+                  + sum(ac$(ord(ac) > card(ac)-s35_shift), p35_other(t-1,j,ac));
+
+* example: ac10 in t = ac5 (ac10-1) in t-1 for a 5 yr time step (s35_shift = 1)
+    p35_secdforest(t,j,ac)$(ord(ac) > s35_shift) = p35_secdforest(t-1,j,ac-s35_shift);
+* account for cases at the end of the age class set (s35_shift > 1) which are not shifted by the above calculation
+    p35_secdforest(t,j,"acx") = p35_secdforest(t,j,"acx")
+                  + sum(ac$(ord(ac) > card(ac)-s35_shift), p35_secdforest(t-1,j,ac));
+);
+
+*' @code
+*' If the vegetation carbon density in a simulation unit due to regrowth
+*' exceeds a threshold of 20 tC/ha the respective area is shifted from other natural land to secondary forest.
+p35_recovered_forest(t,j,ac)$(not sameas(ac,"acx")) =
+			p35_other(t,j,ac)$(pm_carbon_density_ac(t,j,ac,"vegc") > 20);
+p35_other(t,j,ac) = p35_other(t,j,ac) - p35_recovered_forest(t,j,ac);
+p35_secdforest(t,j,ac) =
+			p35_secdforest(t,j,ac) + p35_recovered_forest(t,j,ac);
+*' @stop
+
+pc35_secdforest(j,ac) = p35_secdforest(t,j,ac);
+v35_secdforest.l(j,ac) = pc35_secdforest(j,ac);
+vm_land.l(j,"secdforest") = sum(ac, pc35_secdforest(j,ac));
+pcm_land(j,"secdforest") = sum(ac, pc35_secdforest(j,ac));
+
+pc35_other(j,ac) = p35_other(t,j,ac);
+v35_other.l(j,ac) = pc35_other(j,ac);
+vm_land.l(j,"other") = sum(ac, pc35_other(j,ac));
+pcm_land(j,"other") = sum(ac, pc35_other(j,ac));
+
+*** Forest protection (WDPA areas and different conservation priority areas)
+* calc protection share for primforest, secdforest and other land
+p35_protect_shr(t,j,prot_type)$(sum(land_natveg, pm_land_start(j,land_natveg)) > 0) = f35_protect_area(j,prot_type)/sum(land_natveg, pm_land_start(j,land_natveg));
+p35_protect_shr(t,j,prot_type)$(p35_protect_shr(t,j,prot_type) > 1) = 1;
+p35_protect_shr(t,j,prot_type)$(p35_protect_shr(t,j,prot_type) < 0) = 0;
+
+* protection scenarios
+$ifthen "%c35_protect_scenario%" == "none"
+  p35_save_primforest(t,j) = 0;
+  p35_save_secdforest(t,j) = 0;
+  p35_save_other(t,j) = 0;
+$elseif "%c35_protect_scenario%" == "full"
+  p35_save_primforest(t,j) = vm_land.l(j,"primforest");
+  p35_save_secdforest(t,j) = vm_land.l(j,"secdforest");
+  p35_save_other(t,j) = vm_land.l(j,"other");
+$elseif "%c35_protect_scenario%" == "forest"
+  p35_save_primforest(t,j) = vm_land.l(j,"primforest");
+  p35_save_secdforest(t,j) = vm_land.l(j,"secdforest");
+  p35_save_other(t,j) = 0;
+$elseif "%c35_protect_scenario%" == "WDPA"
+  p35_save_primforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"primforest");
+  p35_save_secdforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"secdforest");
+  p35_save_other(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"other");
+$else
+* conservation priority scenarios start in 2020, in addition to WDPA protection
+  if ((sameas(t,"y1995") or sameas(t,"y2000") or sameas(t,"y2005") or sameas(t,"y2010") or sameas(t,"y2015")),
+  p35_save_primforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"primforest");
+  p35_save_secdforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"secdforest");
+  p35_save_other(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"other");
+  else
+  p35_save_primforest(t,j) = (p35_protect_shr(t,j,"WDPA")+p35_protect_shr(t,j,"%c35_protect_scenario%"))*pm_land_start(j,"primforest");
+  p35_save_secdforest(t,j) = (p35_protect_shr(t,j,"WDPA")+p35_protect_shr(t,j,"%c35_protect_scenario%"))*pm_land_start(j,"secdforest");
+  p35_save_other(t,j) = (p35_protect_shr(t,j,"WDPA")+p35_protect_shr(t,j,"%c35_protect_scenario%"))*pm_land_start(j,"other");
+  p35_save_primforest(t,j)$(p35_save_primforest(t,j) > vm_land.l(j,"primforest")) = vm_land.l(j,"primforest");
+  p35_save_secdforest(t,j)$(p35_save_secdforest(t,j) > pc35_secdforest(j,ac)) = pc35_secdforest(j,ac);
+  p35_save_other(t,j)$(p35_save_other(t,j) > pc35_other(j,ac)) = pc35_other(j,ac);
+  );
+$endif
+
+* Within the optimization, primary and secondary forests can only decrease
+* (e.g. for cropland expansion).
+* In contrast, other natural land can decrease and increase within the optimization.
+* For instance, other natural land increases if agricultural land is abandoned.
+vm_land.lo(j,"primforest") = p35_save_primforest(t,j);
+vm_land.up(j,"primforest") = vm_land.l(j,"primforest");
+
+v35_secdforest.fx(j,"ac0") = 0;
+v35_secdforest.lo(j,"acx") = p35_save_secdforest(t,j);
+v35_secdforest.up(j,ac_sub) = pc35_secdforest(j,ac_sub);
+
+v35_other.lo(j,"acx") = p35_save_other(t,j);
+v35_other.up(j,ac_sub) = pc35_other(j,ac_sub);
+
+* calculate carbon density
+* highest carbon density 1st time step to account for reshuffling
+if((ord(t) = 1),
+	p35_carbon_density_secdforest(t,j,ac,ag_pools) = pm_carbon_density_ac(t,j,"acx",ag_pools);
+	p35_carbon_density_other(t,j,ac,ag_pools) = pm_carbon_density_ac(t,j,"acx",ag_pools);
+else
+	p35_carbon_density_secdforest(t,j,ac,ag_pools) = pm_carbon_density_ac(t,j,ac,ag_pools);
+	p35_carbon_density_other(t,j,ac,ag_pools) = pm_carbon_density_ac(t,j,ac,ag_pools);
+);
+
+* update pcm_carbon_stock. Needed for shifting from other land to secdforest (p35_recovered_forest).
+pcm_carbon_stock(j,"secdforest",ag_pools) =
+           sum(ac, pc35_secdforest(j,ac)
+           * p35_carbon_density_secdforest(t,j,ac,ag_pools));
+
+pcm_carbon_stock(j,"other",ag_pools) =
+           sum(ac, pc35_other(j,ac)
+           * p35_carbon_density_other(t,j,ac,ag_pools));
+
+p35_min_forest(t,j)$(p35_min_forest(t,j) > vm_land.l(j,"primforest") + vm_land.l(j,"secdforest")) = vm_land.l(j,"primforest") + vm_land.l(j,"secdforest");
+p35_min_other(t,j)$(p35_min_other(t,j) > vm_land.l(j,"other")) = vm_land.l(j,"other");

--- a/modules/35_natveg/dynamic_oct19/realization.gms
+++ b/modules/35_natveg/dynamic_oct19/realization.gms
@@ -1,0 +1,26 @@
+*** |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: magpie@pik-potsdam.de
+
+*' @description This realization is similar to the dynamic_may18 realization, with the 
+*' difference that age classes are not aggregated and instead exist during optimazation
+*' @stop
+
+
+*'
+*' @limitations Initialization of both primary ans secondary forest in highest age class
+*' and wood harvest in natural forests is not accounted for.
+
+*####################### R SECTION START (PHASES) ##############################
+$Ifi "%phase%" == "sets" $include "./modules/35_natveg/dynamic_oct19/sets.gms"
+$Ifi "%phase%" == "declarations" $include "./modules/35_natveg/dynamic_oct19/declarations.gms"
+$Ifi "%phase%" == "input" $include "./modules/35_natveg/dynamic_oct19/input.gms"
+$Ifi "%phase%" == "equations" $include "./modules/35_natveg/dynamic_oct19/equations.gms"
+$Ifi "%phase%" == "scaling" $include "./modules/35_natveg/dynamic_oct19/scaling.gms"
+$Ifi "%phase%" == "preloop" $include "./modules/35_natveg/dynamic_oct19/preloop.gms"
+$Ifi "%phase%" == "presolve" $include "./modules/35_natveg/dynamic_oct19/presolve.gms"
+$Ifi "%phase%" == "postsolve" $include "./modules/35_natveg/dynamic_oct19/postsolve.gms"
+*######################## R SECTION END (PHASES) ###############################

--- a/modules/35_natveg/dynamic_oct19/scaling.gms
+++ b/modules/35_natveg/dynamic_oct19/scaling.gms
@@ -1,0 +1,8 @@
+*** |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: magpie@pik-potsdam.de
+
+vm_landdiff_natveg.scale = 10e3;

--- a/modules/35_natveg/dynamic_oct19/sets.gms
+++ b/modules/35_natveg/dynamic_oct19/sets.gms
@@ -1,0 +1,19 @@
+*** |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+*** |  authors, and contributors see CITATION.cff file. This file is part
+*** |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+*** |  AGPL-3.0, you are granted additional permissions described in the
+*** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+*** |  Contact: magpie@pik-potsdam.de
+
+sets
+  pol35 Land protection policy
+  / none, npi, ndc /
+
+  prot_type Conservation priority areas
+  / BH, CPD, FF, LW, WDPA /
+
+  pol_stock35 Land types for land protection policies
+  / forest, other /
+;
+
+alias(ac,ac2);

--- a/modules/35_natveg/module.gms
+++ b/modules/35_natveg/module.gms
@@ -17,5 +17,6 @@
 
 *###################### R SECTION START (MODULETYPES) ##########################
 $Ifi "%natveg%" == "dynamic_may18" $include "./modules/35_natveg/dynamic_may18/realization.gms"
+$Ifi "%natveg%" == "dynamic_oct19" $include "./modules/35_natveg/dynamic_oct19/realization.gms"
 $Ifi "%natveg%" == "static" $include "./modules/35_natveg/static/realization.gms"
 *###################### R SECTION END (MODULETYPES) ############################

--- a/scripts/start/ssp1_bugfix.R
+++ b/scripts/start/ssp1_bugfix.R
@@ -1,0 +1,49 @@
+# |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+# |  Contact: magpie@pik-potsdam.de
+
+
+######################################
+#### Script to start a MAgPIE run ####
+######################################
+
+library(lucode)
+library(magclass)
+library(gdx)
+
+# Load start_run(cfg) function which is needed to start MAgPIE runs
+source("scripts/start_functions.R")
+
+#start MAgPIE run
+source("config/default.cfg")
+
+#cfg$force_download <- TRUE
+
+cfg$results_folder <- "output/:title:"
+
+getInput <- function(gdx,ghg_price=TRUE,biodem=TRUE) {
+  if(ghg_price) {
+    a <- readGDX(gdx,"f56_pollutant_prices_coupling")
+    write.magpie(a,"modules/56_ghg_policy/input/f56_pollutant_prices_coupling.cs3")
+  }
+  if(biodem) {
+    a <- readGDX(gdx,"f60_bioenergy_dem_coupling")
+    write.magpie(a,"modules/60_bioenergy/input/reg.2ndgen_bioenergy_demand.csv")
+  }
+}
+
+cfg <- setScenario(cfg,c("SSP1","NDC"))
+cfg$gms$c56_pollutant_prices <- "coupling"
+cfg$gms$c60_2ndgen_biodem <- "coupling"
+getInput("/p/projects/landuse/users/florianh/bugfix/infes-matrix-REMIND_SSP1-PkBudg1300-mag-2/fulldata.gdx")
+
+cfg$title <- "SSP1-PkBudg1300_oct19"
+cfg$gms$natveg  <- "dynamic_oct19"
+start_run(cfg,codeCheck=FALSE)
+
+cfg$title <- "SSP1-PkBudg1300_may18"
+cfg$gms$natveg  <- "dynamic_may18"
+start_run(cfg,codeCheck=FALSE)


### PR DESCRIPTION
In the dynamic_may18 realization age-classes are aggregated for the optimization, and dissagreated in postsolve. However, rounding errors (v35_other.l(j,land35)/pc35_other(j,land35)) can result in infeasiblites.
In the new default dynamic_oct19 realization, this aggression/disagregation is no longer needed. 