### PR TITLE
new start script: publish_data

### DIFF
--- a/scripts/start/publish_data.R
+++ b/scripts/start/publish_data.R
@@ -8,7 +8,7 @@
 
 require(lucode)
 
-# publish data which is defined in default.cfg on https://rse.pik-potsdam.de/data/magpie/intern
+# publish data which is defined in default.cfg on https://rse.pik-potsdam.de/data/magpie/intern or magpie/public
 
 source("config/default.cfg")
-lucode::publish_data(cfg,target = "dataupload@rse.pik-potsdam.de:/magpie/intern")
+lucode::publish_data(cfg,target = "dataupload@rse.pik-potsdam.de:/magpie/intern|dataupload@rse.pik-potsdam.de:/magpie/public")

--- a/scripts/start/publish_data.R
+++ b/scripts/start/publish_data.R
@@ -1,0 +1,14 @@
+# |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+# |  Contact: magpie@pik-potsdam.de
+
+
+require(lucode)
+
+# publish data which is defined in default.cfg on https://rse.pik-potsdam.de/data/magpie/intern
+
+source("config/default.cfg")
+lucode::publish_data(cfg,target = "dataupload@rse.pik-potsdam.de:/magpie/intern")


### PR DESCRIPTION
added start script which allows to publish input files as currently defined in default.cfg on https://rse.pik-potsdam.de/data/magpie/intern to make it accessible to externals