### PR TITLE
Food Demand Paper version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2020-03-09
+
+This version provides the model version used for the publication starved, stuffed and wasteful. It provides a few technical updates compared to the 4.1 release, which include
+
+### added
+- **scripts** a startscript that allows the exchange of model parameters as a sensitivity analysis
+ 
+### changed
+- **core** allow for flexible calibration period of the model, which allows for uncalibrated runs of the past for validation purposes
+- **15_food** Parameters for bodyheight regressions were included explicitly as input parameters
+- **config** updated input data of the drivers and food demand regressions
+
+### fixed
+- **15_food** Precision of iteration convergence criterium for magpie-demandmodel-iteration is calculated more precisely, avoiding unnecessary iterations.
 
 ## [4.1.0] - 2019-05-02
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -76,8 +76,8 @@ authors:
     email: popp@pik-potsdam.de
 
 title: MAgPIE - An Open Source land-use modeling framework
-version: 4.1
-date-released: 2019-05-02
+version: 4.1.1
+date-released: 2020-03-09
 repository-code: https://github.com/magpiemodel/magpie
 keywords:
   - landuse

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -23,7 +23,8 @@ cfg$model <- "main.gms"   #def = "main.gms"
 
 # which input data sets should be used?
 
-cfg$input <- "magpie4.1.1_default_mar20.tgz" 
+cfg$input <- c("magpie4.1_default_apr19.tgz",
+               "patch_magpie4.1.1_mar20.tgz") 
 
 
 #a list of repositories (please pay attention to the list format!) in which the

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -23,7 +23,12 @@ cfg$model <- "main.gms"   #def = "main.gms"
 
 # which input data sets should be used?
 
-cfg$input <- c("magpie4.1_default_apr19.tgz")
+cfg$input <- c("isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev34_c200_690d3718e151be1b450b394c1064b1c5.tgz", 
+"rev4.34_690d3718e151be1b450b394c1064b1c5_magpie.tgz", 
+"rev4.34_690d3718e151be1b450b394c1064b1c5_validation.tgz",
+"calibration_H12_c200_12Sep18.tgz",
+"additional_data_rev3.73.tgz")
+
 
 #a list of repositories (please pay attention to the list format!) in which the
 #files should be searched for. Files will be searched in all repositories until
@@ -170,6 +175,12 @@ cfg$gms$c15_food_scenario <- "SSP2"        # def = SSP2
 # * ruminant meat share scenario
 # *   options:   constant, halving2050, mixed
 cfg$gms$c15_rumscen <- "mixed"             # def = mixed
+
+
+# * calibration to historical values
+# *   options:   0, 1
+cfg$gms$s15_calibrate <- 1             # def = 1
+
 
 # ***---------------------    16_demand    -------------------------------------
 # * (sector_may15): default for flexible regions

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -79,6 +79,9 @@ cfg$gms <- list()
 # Set number of time steps (1-16) or type "less_TS" for remind time steps
 cfg$gms$c_timesteps <- "coup2100"
 
+# Set historic period for calibration like "till_1965", "till_1975", "till_1995" or "till_2010".
+cfg$gms$c_past <- "till_2010" # def = "till_2010"
+
 # use of gdx files
 cfg$gms$s_use_gdx <- 2  # def = 2
 #*                   0:  gdx will not be loaded

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -23,11 +23,7 @@ cfg$model <- "main.gms"   #def = "main.gms"
 
 # which input data sets should be used?
 
-cfg$input <- c("isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev34_c200_690d3718e151be1b450b394c1064b1c5.tgz", 
-"rev4.34_690d3718e151be1b450b394c1064b1c5_magpie.tgz", 
-"rev4.34_690d3718e151be1b450b394c1064b1c5_validation.tgz",
-"calibration_H12_c200_12Sep18.tgz",
-"additional_data_rev3.73.tgz")
+cfg$input <- "magpie4.1.1_default_mar20.tgz" 
 
 
 #a list of repositories (please pay attention to the list format!) in which the

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -138,12 +138,14 @@ sets time_annual Annual extended time steps
       y2095, y2100, y2105, y2110, y2115, y2120, y2125, y2130, y2135, y2140,
       y2145, y2150 /
 
-    t_past(t_all) Timesteps with observed data
-        / y1965, y1970, y1975,
-         y1980, y1985, y1990,
-         y1995, y2000, y2005, y2010
-        /
 ;
+
+set t_past(t_all) Timesteps with observed data 
+$If "%c_past%"== "till_2010" /y1965, y1970, y1975, y1980, y1985, y1990,y1995, y2000, y2005, y2010/;
+$If "%c_past%"== "till_1965" /y1965/;
+$If "%c_past%"== "till_1975" /y1965, y1970, y1975/;
+$If "%c_past%"== "till_1995" /y1965, y1970, y1975, y1980, y1985, y1990, y1995/;
+
 
 set t(t_all) Simulated time periods
 $If "%c_timesteps%"== "less_TS" /y1995,y2000,y2005,y2010,y2015,y2020,y2025,y2030,y2035,y2040,y2045,y2050,y2055,y2060,y2070,y2080,y2090,y2100,y2110,y2130,y2150/;

--- a/main.gms
+++ b/main.gms
@@ -93,7 +93,7 @@ $title magpie
 *##################### R SECTION START (VERSION INFO) ##########################
 * 
 * Used data set: magpie4.1_default_apr19.tgz
-* md5sum: ea3959be0d5a45cf50cfc232571dc9bd
+* md5sum: 5c38bb1083bd66010c2104c9d40553f4
 * Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
 * Low resolution: c200
@@ -127,7 +127,7 @@ $title magpie
 * 
 * 
 * 
-* Last modification (input data): Sat Apr 27 13:45:25 2019
+* Last modification (input data): Tue Nov 05 08:36:47 2019
 * 
 *###################### R SECTION END (VERSION INFO) ###########################
 
@@ -152,6 +152,7 @@ $offlisting
 *                    Key parameters during model runs
 
 $setglobal c_timesteps  coup2100
+$setglobal c_past  till_2010
 
 scalars
   s_use_gdx   use of gdx files                                       / 2 /

--- a/main.gms
+++ b/main.gms
@@ -92,7 +92,11 @@ $title magpie
 
 *##################### R SECTION START (VERSION INFO) ##########################
 * 
-* Used data set: magpie4.1.1_default_mar20.tgz
+* Used data set: magpie4.1_default_apr19.tgz
+* md5sum: NA
+* Repository: https://rse.pik-potsdam.de/data/magpie/public
+* 
+* Used data set: patch_magpie4.1.1_mar20.tgz
 * md5sum: NA
 * Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
@@ -107,7 +111,7 @@ $title magpie
 * 
 * Regionscode: 690d3718e151be1b450b394c1064b1c5
 * 
-* Regions data revision: 4.34
+* Regions data revision: 4.18
 * 
 * lpj2magpie settings:
 * * LPJmL data folder: /p/projects/landuse/data/input/lpj_input/isimip_rcp/IPSL_CM5A_LR/rcp2p6/co2
@@ -127,7 +131,7 @@ $title magpie
 * 
 * 
 * 
-* Last modification (input data): Thu Mar  5 14:22:55 2020
+* Last modification (input data): Fri Mar  6 15:04:16 2020
 * 
 *###################### R SECTION END (VERSION INFO) ###########################
 

--- a/main.gms
+++ b/main.gms
@@ -92,25 +92,9 @@ $title magpie
 
 *##################### R SECTION START (VERSION INFO) ##########################
 * 
-* Used data set: isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev34_c200_690d3718e151be1b450b394c1064b1c5.tgz
-* md5sum: b88ddae2ac42d76603bd988337115c64
-* Repository: scp://cluster.pik-potsdam.de/p/projects/landuse/data/input/archive
-* 
-* Used data set: rev4.34_690d3718e151be1b450b394c1064b1c5_magpie.tgz
-* md5sum: 996b4ca100a0ecc81d2708c189de1085
-* Repository: scp://cluster.pik-potsdam.de/p/projects/rd3mod/inputdata/output
-* 
-* Used data set: rev4.34_690d3718e151be1b450b394c1064b1c5_validation.tgz
-* md5sum: fe19b32c5954eb9099ef111b98d8b7f6
-* Repository: scp://cluster.pik-potsdam.de/p/projects/rd3mod/inputdata/output
-* 
-* Used data set: calibration_H12_c200_12Sep18.tgz
-* md5sum: 0a7d88e902918eb6a5263faaf066cc5d
-* Repository: scp://cluster.pik-potsdam.de/p/projects/landuse/data/input/calibration
-* 
-* Used data set: additional_data_rev3.73.tgz
-* md5sum: 3ce07e85c937a937bee759a40fd50b8a
-* Repository: scp://cluster.pik-potsdam.de/p/projects/landuse/data/input/archive
+* Used data set: magpie4.1.1_default_mar20.tgz
+* md5sum: NA
+* Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
 * Low resolution: c200
 * High resolution: 0.5
@@ -143,7 +127,7 @@ $title magpie
 * 
 * 
 * 
-* Last modification (input data): Fri Dec 06 10:25:07 2019
+* Last modification (input data): Thu Mar  5 14:22:55 2020
 * 
 *###################### R SECTION END (VERSION INFO) ###########################
 

--- a/main.gms
+++ b/main.gms
@@ -92,9 +92,25 @@ $title magpie
 
 *##################### R SECTION START (VERSION INFO) ##########################
 * 
-* Used data set: magpie4.1_default_apr19.tgz
-* md5sum: 5c38bb1083bd66010c2104c9d40553f4
-* Repository: https://rse.pik-potsdam.de/data/magpie/public
+* Used data set: isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev34_c200_690d3718e151be1b450b394c1064b1c5.tgz
+* md5sum: b88ddae2ac42d76603bd988337115c64
+* Repository: scp://cluster.pik-potsdam.de/p/projects/landuse/data/input/archive
+* 
+* Used data set: rev4.34_690d3718e151be1b450b394c1064b1c5_magpie.tgz
+* md5sum: 996b4ca100a0ecc81d2708c189de1085
+* Repository: scp://cluster.pik-potsdam.de/p/projects/rd3mod/inputdata/output
+* 
+* Used data set: rev4.34_690d3718e151be1b450b394c1064b1c5_validation.tgz
+* md5sum: fe19b32c5954eb9099ef111b98d8b7f6
+* Repository: scp://cluster.pik-potsdam.de/p/projects/rd3mod/inputdata/output
+* 
+* Used data set: calibration_H12_c200_12Sep18.tgz
+* md5sum: 0a7d88e902918eb6a5263faaf066cc5d
+* Repository: scp://cluster.pik-potsdam.de/p/projects/landuse/data/input/calibration
+* 
+* Used data set: additional_data_rev3.73.tgz
+* md5sum: 3ce07e85c937a937bee759a40fd50b8a
+* Repository: scp://cluster.pik-potsdam.de/p/projects/landuse/data/input/archive
 * 
 * Low resolution: c200
 * High resolution: 0.5
@@ -107,7 +123,7 @@ $title magpie
 * 
 * Regionscode: 690d3718e151be1b450b394c1064b1c5
 * 
-* Regions data revision: 4.18
+* Regions data revision: 4.34
 * 
 * lpj2magpie settings:
 * * LPJmL data folder: /p/projects/landuse/data/input/lpj_input/isimip_rcp/IPSL_CM5A_LR/rcp2p6/co2
@@ -127,7 +143,7 @@ $title magpie
 * 
 * 
 * 
-* Last modification (input data): Tue Nov 05 08:36:47 2019
+* Last modification (input data): Fri Dec 06 10:25:07 2019
 * 
 *###################### R SECTION END (VERSION INFO) ###########################
 

--- a/modules/09_drivers/aug17/sets.gms
+++ b/modules/09_drivers/aug17/sets.gms
@@ -8,10 +8,12 @@ sets
 
    pop_scen09  Population scenario
        / SSP1, SSP2, SSP3, SSP4, SSP5,
+		SDP,
          a1, a2, b1, b2 /
 
    gdp_scen09  GDP scenario
        / SSP1, SSP2, SSP3, SSP4, SSP5,
+	   SDP,
        a1,a2,b1,b2 /
 
    age Population age groups

--- a/modules/15_food/anthropometrics_jan18/input.gms
+++ b/modules/15_food/anthropometrics_jan18/input.gms
@@ -17,9 +17,9 @@ $setglobal c15_calibscen  constant
 $setglobal c15_rumscen  mixed
 *   options:   constant, halving2050, mixed
 
-scalar s15_elastic_demand  Elastic demand switch (1=elastic 0=exogenous) (1) / 0 /;
+scalar s15_elastic_demand  Elastic demand switch (1=elastic 0=exogenous) (1) / 1 /;
 
-scalar s15_calibrate Calibration switch (1=calibrated 0=pure regression outcomes) (1) / 0 /;
+scalar s15_calibrate Calibration switch (1=calibrated 0=pure regression outcomes) (1) / 1 /;
 * only for per-capita calories, not for e.g. calibration of transformation parameters between per-capita calories in dm
 
 scalar s15_maxiter Scalar defining maximum number of iterations (1) / 5 /;

--- a/modules/15_food/anthropometrics_jan18/input.gms
+++ b/modules/15_food/anthropometrics_jan18/input.gms
@@ -17,9 +17,9 @@ $setglobal c15_calibscen  constant
 $setglobal c15_rumscen  mixed
 *   options:   constant, halving2050, mixed
 
-scalar s15_elastic_demand  Elastic demand switch (1=elastic 0=exogenous) (1) / 1 /;
+scalar s15_elastic_demand  Elastic demand switch (1=elastic 0=exogenous) (1) / 0 /;
 
-scalar s15_calibrate Calibration switch (1=calibrated 0=pure regression outcomes) (1) / 1 /;
+scalar s15_calibrate Calibration switch (1=calibrated 0=pure regression outcomes) (1) / 0 /;
 * only for per-capita calories, not for e.g. calibration of transformation parameters between per-capita calories in dm
 
 scalar s15_maxiter Scalar defining maximum number of iterations (1) / 5 /;

--- a/modules/15_food/anthropometrics_jan18/input.gms
+++ b/modules/15_food/anthropometrics_jan18/input.gms
@@ -17,9 +17,9 @@ $setglobal c15_calibscen  constant
 $setglobal c15_rumscen  mixed
 *   options:   constant, halving2050, mixed
 
-scalar s15_elastic_demand  Elastic demand switch (1=elastic 0=exogenous) (1) / 1 /;
+scalar s15_elastic_demand  Elastic demand switch (1=elastic 0=exogenous) (1) / 0 /;
 
-scalar s15_calibrate Calibration switch (1=calibrated 0=pure regression outcomes) (1) / 1 /;
+scalar s15_calibrate Calibration switch (1=calibrated 0=pure regression outcomes) (1) / 0 /;
 * only for per-capita calories, not for e.g. calibration of transformation parameters between per-capita calories in dm
 
 scalar s15_maxiter Scalar defining maximum number of iterations (1) / 5 /;
@@ -110,12 +110,15 @@ $ondelim
 $include "./modules/15_food/input/f15_bodyheight_historical.cs3"
 $offdelim;
 
+table f15_bodyheight_regr_paras(sex,paras_h15)   Body height regression parameters (X)
+$ondelim
+$include "./modules/15_food/input/f15_bodyheight_regr_paras.cs3"
+$offdelim;
+
 table f15_schofield(sex,age, paras_s15) Schofield equation parameters in kcal per capita per day or kcal per capita per day per weight (X)
 $ondelim
 $include "./modules/15_food/input/f15_schofield_parameters.cs3"
 $offdelim
 ;
-
-
 
 *** EOF input.gms ***

--- a/modules/15_food/anthropometrics_jan18/intersolve.gms
+++ b/modules/15_food/anthropometrics_jan18/intersolve.gms
@@ -55,7 +55,16 @@ if(( p15_modelstat(t)) > 2 and (p15_modelstat(t) ne 7 ),
                                  im_pop_iso(t,iso)
                              );
 
- p15_delta_income(t,i) = p15_income_pc_real_ppp(t,i) / im_gdp_pc_ppp(t,i);
+
+
+ p15_delta_income(t,i) = p15_income_pc_real_ppp(t,i) /
+						( sum(i_to_iso(i,iso),
+                               im_gdp_pc_ppp_iso(t,iso)
+                               * im_pop_iso(t,iso)
+                             ) / sum(i_to_iso(i,iso),
+                                 im_pop_iso(t,iso))
+                        );
+
 
 * estimate convergence measure for deciding to stop iteration
 
@@ -139,4 +148,3 @@ if (s15_elastic_demand * (1-sum(sameas(t_past,t),1)) =1,
 else
 display "exogenous demand information is used" ;
 );
-

--- a/modules/15_food/anthropometrics_jan18/postsolve.gms
+++ b/modules/15_food/anthropometrics_jan18/postsolve.gms
@@ -13,11 +13,15 @@
            i15_bmi_shr_calib(t,iso,sex,age,bmi_group15);
 
 *' The BMI shares are not allowed to exceed the bounds 0 and 1. Values are corrected to the bounds.
-   o15_bmi_shr(t,iso,sex,age,bmi_group15)$(o15_bmi_shr(t,iso,sex,age,bmi_group15)<0) = 0;
+   o15_bmi_shr(t,iso,sex,age,bmi_group15)$(o15_bmi_shr(t,iso,sex,age,bmi_group15)<=0) = 0.000001;
    o15_bmi_shr(t,iso,sex,age,bmi_group15)$(o15_bmi_shr(t,iso,sex,age,bmi_group15)>1) = 1;
-*' The mismatch is balanced by moving the exceeding quantities into the middle BMI group.
+*' In case that the bmi groups, due to calibration, exceed 1, we rescale to 1.
+   o15_bmi_shr(t,iso,sex,age,bmi_group15)$(sum(bmi_group15_2, o15_bmi_shr(t,iso,sex,age,bmi_group15_2))>1) =
+      o15_bmi_shr(t,iso,sex,age,bmi_group15)/sum(bmi_group15_2, o15_bmi_shr(t,iso,sex,age,bmi_group15_2));
+*' The mismatch below one is balanced by moving the exceeding quantities into the middle BMI group.
    o15_bmi_shr(t,iso,sex,age,"medium")=
       1 - (sum(bmi_group15, o15_bmi_shr(t,iso,sex,age,bmi_group15)) - o15_bmi_shr(t,iso,sex,age,"medium"));
+
 
 *' We recalculate the intake with the new values.
    o15_kcal_intake_total(t,iso) =
@@ -66,18 +70,13 @@ For (s15_count = 1 to s15_yeardiff,
 *' using the body height regressions and the food consumption of the last 15
 *' years.
 
-   p15_bodyheight(t,iso,"F","15--19","final") =
-                     126.4*
+   p15_bodyheight(t,iso,sex,"15--19","final") =
+                     f15_bodyheight_regr_paras(sex,"slope")*
                      (sum(underaged15,
                        p15_kcal_growth_food(t,iso,underaged15)
-                     )/3)**0.03467
+                     )/3)**f15_bodyheight_regr_paras(sex,"exponent")
                      ;
-   p15_bodyheight(t,iso,"M","15--19","final") =
-                     131.8*
-                     (sum(underaged15,
-                       p15_kcal_growth_food(t,iso,underaged15)
-                     )/3)**0.03978
-                     ;
+
 *' @stop
 );
 

--- a/modules/15_food/anthropometrics_jan18/presolve.gms
+++ b/modules/15_food/anthropometrics_jan18/presolve.gms
@@ -130,18 +130,13 @@ else
           p15_bodyheight(t,iso,sex,age++1,"preliminary") = p15_bodyheight(t,iso,sex,age,"preliminary");
 
 * replace age groups of 18 year old
-          p15_bodyheight(t,iso,"F","15--19","preliminary") =
-                 126.4*
+          p15_bodyheight(t,iso,sex,"15--19","preliminary") =
+                 f15_bodyheight_regr_paras(sex,"slope")*
                  (sum(underaged15,
                    p15_kcal_growth_food(t,iso,underaged15)
-                 )/3)**0.03467
+                 )/3)**f15_bodyheight_regr_paras(sex,"exponent")
                  ;
-          p15_bodyheight(t,iso,"M","15--19","preliminary") =
-                 131.8*
-                 (sum(underaged15,
-                   p15_kcal_growth_food(t,iso,underaged15)
-                 )/3)**0.03978
-                 ;
+
      );
 *adjust body height of kids proportional to over18 population
      p15_bodyheight(t,iso,"M","0--4","preliminary")=p15_bodyheight(t,iso,"M","15--19","preliminary")/176*92;

--- a/modules/15_food/anthropometrics_jan18/sets.gms
+++ b/modules/15_food/anthropometrics_jan18/sets.gms
@@ -65,6 +65,9 @@ sets
    paras_b15 Intake equation parameters
    /saturation,halfsaturation,intercept/
 
+   paras_h15 Bodyheight equation parameters
+   /slope, exponent/
+
    kfo(kall) All products in the sectoral version
    /
    tece,maiz,trce,rice_pro,soybean,rapeseed,groundnut,sunflower,puls_pro,
@@ -138,6 +141,7 @@ sets
 ;
 
 alias(kst,kst2);
+alias(bmi_group15,bmi_group15_2);
 alias(kfo,kfo2);
 alias(kfo_ap,kfo_ap2);
 alias(kfo_st,kfo_st2);

--- a/modules/15_food/input/files
+++ b/modules/15_food/input/files
@@ -13,7 +13,7 @@ f15_ruminant_fadeout.csv
 f15_bodyheight_historical.cs3
 f15_schofield_parameters.cs3
 f15_schofield_parameters_height.cs3
-f15_intake_bodyheight_regr_paras.cs3
+f15_bodyheight_regr_paras.cs3
 f15_household_balanceflow.cs3
 f15_nutrition_attributes.cs3
 

--- a/modules/15_food/input/files
+++ b/modules/15_food/input/files
@@ -13,7 +13,7 @@ f15_ruminant_fadeout.csv
 f15_bodyheight_historical.cs3
 f15_schofield_parameters.cs3
 f15_schofield_parameters_height.cs3
-f15_intake_regression_parameters.cs3
+f15_intake_bodyheight_regr_paras.cs3
 f15_household_balanceflow.cs3
 f15_nutrition_attributes.cs3
 

--- a/scripts/start/demand_standalone.R
+++ b/scripts/start/demand_standalone.R
@@ -1,0 +1,110 @@
+# |  (C) 2008-2019 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+# |  Contact: magpie@pik-potsdam.de
+
+
+######################################
+#### Script to start a MAgPIE run ####
+######################################
+
+#setwd("C:/Users/bodirsky/Desktop/articles/demand model/manuscript_from_starved_to_stuffed/magpie")
+
+# Load start_run(cfg) function which is needed to start MAgPIE runs
+source("scripts/start_functions.R")
+
+#start MAgPIE run
+source("config/default.cfg")
+cfg$model <- "standalone/demand_model.gms"  
+cfg$recalibrate=FALSE
+cfg$gms$c_timesteps="pastandfuture"
+
+cfg$title <- "demand_ssp1"
+cfg$gms$c09_pop_scenario  <- "SSP1"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP1"    # def = SSP2
+start_run(cfg=cfg)
+
+cfg$title <- "demand_ssp2"
+cfg$gms$c09_pop_scenario  <- "SSP2"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP2"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp3"
+cfg$gms$c09_pop_scenario  <- "SSP3"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP3"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp4"
+cfg$gms$c09_pop_scenario  <- "SSP4"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP4"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp5"
+cfg$gms$c09_pop_scenario  <- "SSP5"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP5"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+
+### calib till 1975
+
+cfg$gms$c_past <- "till_1975"
+
+cfg$title <- "demand_ssp1_calib1975"
+cfg$gms$c09_pop_scenario  <- "SSP1"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP1"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp2_calib1975"
+cfg$gms$c09_pop_scenario  <- "SSP2"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP2"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp3_calib1975"
+cfg$gms$c09_pop_scenario  <- "SSP3"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP3"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp4_calib1975"
+cfg$gms$c09_pop_scenario  <- "SSP4"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP4"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp5_calib1975"
+cfg$gms$c09_pop_scenario  <- "SSP5"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP5"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+
+### no calib
+
+cfg$gms$s15_calibrate = 0
+
+cfg$title <- "demand_ssp1_nocalib"
+cfg$gms$c09_pop_scenario  <- "SSP1"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP1"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp2_nocalib"
+cfg$gms$c09_pop_scenario  <- "SSP2"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP2"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp3_nocalib"
+cfg$gms$c09_pop_scenario  <- "SSP3"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP3"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp4_nocalib"
+cfg$gms$c09_pop_scenario  <- "SSP4"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP4"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+cfg$title <- "demand_ssp5_nocalib"
+cfg$gms$c09_pop_scenario  <- "SSP5"    # def = SSP2
+cfg$gms$c09_gdp_scenario  <- "SSP5"    # def = SSP2
+start_run(cfg=cfg,codeCheck = FALSE)
+
+
+cfg$gms$s15_calibrate = 1

--- a/scripts/start/demand_standalone.R
+++ b/scripts/start/demand_standalone.R
@@ -20,6 +20,13 @@ source("config/default.cfg")
 cfg$model <- "standalone/demand_model.gms"  
 cfg$recalibrate=FALSE
 cfg$gms$c_timesteps="pastandfuture"
+cfg$gms$s15_calibrate = 1
+cfg$gms$s15_elastic_demand = 0;
+
+from= "crossvalidation/k_default/"
+to="modules/15_food/input/"
+files <- list.files(from, pattern="*.*")
+file.copy(from =paste0(from,files),to = to, overwrite = TRUE)
 
 cfg$title <- "demand_ssp1"
 cfg$gms$c09_pop_scenario  <- "SSP1"    # def = SSP2
@@ -46,65 +53,42 @@ cfg$gms$c09_pop_scenario  <- "SSP5"    # def = SSP2
 cfg$gms$c09_gdp_scenario  <- "SSP5"    # def = SSP2
 start_run(cfg=cfg,codeCheck = FALSE)
 
+### k-fold cross validation for historical period
+
+crossvalid=c("k1","k2","k3","k4","k5","k_default")
 
 ### calib till 1975
 
 cfg$gms$c_past <- "till_1975"
-
-cfg$title <- "demand_ssp1_calib1975"
-cfg$gms$c09_pop_scenario  <- "SSP1"    # def = SSP2
-cfg$gms$c09_gdp_scenario  <- "SSP1"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
-
-cfg$title <- "demand_ssp2_calib1975"
 cfg$gms$c09_pop_scenario  <- "SSP2"    # def = SSP2
 cfg$gms$c09_gdp_scenario  <- "SSP2"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
 
-cfg$title <- "demand_ssp3_calib1975"
-cfg$gms$c09_pop_scenario  <- "SSP3"    # def = SSP2
-cfg$gms$c09_gdp_scenario  <- "SSP3"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
-
-cfg$title <- "demand_ssp4_calib1975"
-cfg$gms$c09_pop_scenario  <- "SSP4"    # def = SSP2
-cfg$gms$c09_gdp_scenario  <- "SSP4"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
-
-cfg$title <- "demand_ssp5_calib1975"
-cfg$gms$c09_pop_scenario  <- "SSP5"    # def = SSP2
-cfg$gms$c09_gdp_scenario  <- "SSP5"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
-
-
+for (i in crossvalid){
+  cfg$title <- paste0("demand_ssp2_calib1975_",i)
+  from= paste0("crossvalidation/",i,"/")
+  to="modules/15_food/input/"
+  files <- list.files(from, pattern="*.*")
+  file.copy(from =paste0(from,files),to = to, overwrite = TRUE)
+  cat(paste0(from,files))
+  start_run(cfg=cfg,codeCheck = FALSE)
+}
 ### no calib
 
 cfg$gms$s15_calibrate = 0
 
-cfg$title <- "demand_ssp1_nocalib"
-cfg$gms$c09_pop_scenario  <- "SSP1"    # def = SSP2
-cfg$gms$c09_gdp_scenario  <- "SSP1"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
-
 cfg$title <- "demand_ssp2_nocalib"
 cfg$gms$c09_pop_scenario  <- "SSP2"    # def = SSP2
 cfg$gms$c09_gdp_scenario  <- "SSP2"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
 
-cfg$title <- "demand_ssp3_nocalib"
-cfg$gms$c09_pop_scenario  <- "SSP3"    # def = SSP2
-cfg$gms$c09_gdp_scenario  <- "SSP3"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
-
-cfg$title <- "demand_ssp4_nocalib"
-cfg$gms$c09_pop_scenario  <- "SSP4"    # def = SSP2
-cfg$gms$c09_gdp_scenario  <- "SSP4"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
-
-cfg$title <- "demand_ssp5_nocalib"
-cfg$gms$c09_pop_scenario  <- "SSP5"    # def = SSP2
-cfg$gms$c09_gdp_scenario  <- "SSP5"    # def = SSP2
-start_run(cfg=cfg,codeCheck = FALSE)
-
+for (i in crossvalid){
+  cfg$title <- paste0("demand_ssp2_nocalib_",i)
+  from= paste0("crossvalidation/",i,"/")
+  to="modules/15_food/input/"
+  files <- list.files(from, pattern="*.*")
+  file.copy(from =paste0(from,files),to = to, overwrite = TRUE)
+  start_run(cfg=cfg,codeCheck = FALSE)
+}
 
 cfg$gms$s15_calibrate = 1
+
+cfg$gms$c_past <- "till_2010"

--- a/scripts/start/demand_standalone.R
+++ b/scripts/start/demand_standalone.R
@@ -15,18 +15,29 @@
 # Load start_run(cfg) function which is needed to start MAgPIE runs
 source("scripts/start_functions.R")
 
+# download supplementary data, if not yet available
+if(!dir.exists("crossvalidation")) {
+  dir.create("crossvalidation")
+  download.file("http://rse.pik-potsdam.de/data/magpie/public/crossvalidation_trade_paper.tgz","crossvalidation/data.tgz")
+  setwd("crossvalidation")
+  untar("data.tgz")
+  unlink("data.tgz")
+  setwd("..")
+}
+
 #start MAgPIE run
 source("config/default.cfg")
-cfg$model <- "standalone/demand_model.gms"  
-cfg$recalibrate=FALSE
-cfg$gms$c_timesteps="pastandfuture"
-cfg$gms$s15_calibrate = 1
-cfg$gms$s15_elastic_demand = 0;
+cfg$model                   <- "standalone/demand_model.gms"  
+cfg$recalibrate             <- FALSE
+cfg$gms$c_timesteps         <- "pastandfuture"
+cfg$gms$s15_calibrate       <- 1
+cfg$gms$s15_elastic_demand  <- 0
 
-from= "crossvalidation/k_default/"
-to="modules/15_food/input/"
+from  <- "crossvalidation/k_default/"
+to    <- "modules/15_food/input/"
+
 files <- list.files(from, pattern="*.*")
-file.copy(from =paste0(from,files),to = to, overwrite = TRUE)
+file.copy(from=paste0(from,files),to=to, overwrite=TRUE)
 
 cfg$title <- "demand_ssp1"
 cfg$gms$c09_pop_scenario  <- "SSP1"    # def = SSP2
@@ -55,7 +66,7 @@ start_run(cfg=cfg,codeCheck = FALSE)
 
 ### k-fold cross validation for historical period
 
-crossvalid=c("k1","k2","k3","k4","k5","k_default")
+crossvalid <- c("k1","k2","k3","k4","k5","k_default")
 
 ### calib till 1975
 
@@ -65,10 +76,10 @@ cfg$gms$c09_gdp_scenario  <- "SSP2"    # def = SSP2
 
 for (i in crossvalid){
   cfg$title <- paste0("demand_ssp2_calib1975_",i)
-  from= paste0("crossvalidation/",i,"/")
-  to="modules/15_food/input/"
-  files <- list.files(from, pattern="*.*")
-  file.copy(from =paste0(from,files),to = to, overwrite = TRUE)
+  from      <- paste0("crossvalidation/",i,"/")
+  to        <- "modules/15_food/input/"
+  files     <- list.files(from, pattern="*.*")
+  file.copy(from=paste0(from,files),to = to, overwrite = TRUE)
   cat(paste0(from,files))
   start_run(cfg=cfg,codeCheck = FALSE)
 }
@@ -82,13 +93,13 @@ cfg$gms$c09_gdp_scenario  <- "SSP2"    # def = SSP2
 
 for (i in crossvalid){
   cfg$title <- paste0("demand_ssp2_nocalib_",i)
-  from= paste0("crossvalidation/",i,"/")
-  to="modules/15_food/input/"
+  from <- paste0("crossvalidation/",i,"/")
+  to <- "modules/15_food/input/"
   files <- list.files(from, pattern="*.*")
-  file.copy(from =paste0(from,files),to = to, overwrite = TRUE)
+  file.copy(from=paste0(from,files),to = to, overwrite = TRUE)
   start_run(cfg=cfg,codeCheck = FALSE)
 }
 
-cfg$gms$s15_calibrate = 1
+cfg$gms$s15_calibrate <- 1
 
 cfg$gms$c_past <- "till_2010"

--- a/standalone/demand_model.gms
+++ b/standalone/demand_model.gms
@@ -13,6 +13,8 @@ $offsymlist
 $offlisting
 
 $setglobal c_timesteps  pastandfuture
+$setglobal c_past  till_1975
+
 
 *******************************MODULE SETUP*************************************
 $setglobal drivers  aug17
@@ -26,12 +28,12 @@ $include "./core/sets.gms"
 $batinclude "./modules/include.gms" sets
 
 sets
-   kap(kall)
+   kap(kall) animal products including fish
    /
    livst_rum,livst_pig,livst_chick, livst_egg, livst_milk, fish
    /
 
-   kli(kap)
+   kli(kap) livestock products
    /
    livst_rum,livst_pig,livst_chick, livst_egg, livst_milk
    /


### PR DESCRIPTION
This is the model code as it has been used for the Food Demand paper. It is based on MAgPIE 4.1 with updates in module "food". 

This version should be released as MAgPIE 4.1.1