### PR TITLE
Bugfix bracket bug in confinement equation

### DIFF
--- a/modules/55_awms/ipcc2006_aug16/equations.gms
+++ b/modules/55_awms/ipcc2006_aug16/equations.gms
@@ -29,7 +29,7 @@
          + sum(kap,vm_dem_feed(i2,kli,kap) * fm_attributes(npk,kap))
          + sum(ksd,vm_dem_feed(i2,kli,ksd) * fm_attributes(npk,ksd))
          + sum(kres,vm_dem_feed(i2,kli,kres) * fm_attributes(npk,kres)
-		 *(1-(1-sum(ct,im_development_state(ct,i2))))*0.25)
+		 *(1-(1-sum(ct,im_development_state(ct,i2)))*0.25))
          ;
 
 *' b) grazing animals on pastures where the manure stays on pastures


### PR DESCRIPTION
changed to:
"Crop residues in developed regions are fully assigned to house, while in developing regions we assume that 25% of the Nr in residues are consumed directly on croplands during stubble grazing."