### PR TITLE
bugfix in start.R (avoiding illegal log file names)

### DIFF
--- a/start.R
+++ b/start.R
@@ -76,14 +76,15 @@ runOutputs <- function(runscripts=NULL, submit=NULL) {
       }
 
       cat("Executing",name,"\n")
-      sbatch_command <- paste0("sbatch --job-name=",rout," --output=",rout,"-%j.out --mail-type=END --wrap=\"Rscript ",name,"\"")
+      rout_name <- sub("\\.R$","",sub("/","_",rout))
+      sbatch_command <- paste0("sbatch --job-name=",rout_name," --output=",rout_name,"-%j.out --mail-type=END --wrap=\"Rscript ",name,"\"")
       if(submit=="direct") {
         tmp.env <- new.env()
         tmp.error <- try(sys.source(name,envir=tmp.env))
         if(!is.null(tmp.error)) warning("Script ",name," was stopped by an error and not executed properly!")
         rm(tmp.env)
       } else if(submit=="background") {
-        log <- format(Sys.time(), paste0(rout,"-%Y-%H-%M-%S-%OS3.log"))
+        log <- format(Sys.time(), paste0(rout_name,"-%Y-%H-%M-%S-%OS3.log"))
         system2("Rscript",name, stderr = log, stdout = log, wait=FALSE)
       } else if(submit=="slurmpriority") {
         system(paste(sbatch_command,"--qos=priority"))


### PR DESCRIPTION
Bugfix in start.R preventing start.R from trying to use illegal file names for its log files