### PR TITLE
 Added new scenario in f56_emis_policy (maccs_excl_cropland_n2o) and updated additional data revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### added
 - **15_food** Added the option to fade out livestock demand towards a target level in kcal/cap/day.
 - **35_natveg** Added HalfEarth scenario to protection scenarios
+- **56_ghg_policy** Added new scenario to emission policy
 
 ### changed
 - **scripts** Updated AgMIP output scripts.

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,7 +27,7 @@ cfg$input <- c("isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev50_c200_690d3718e151be1b45
          "rev4.52_h12_magpie.tgz",
          "rev4.52_h12_validation.tgz",
          "calibration_H12_c200_26Feb20.tgz",
-         "additional_data_rev3.88.tgz")
+         "additional_data_rev3.89.tgz")
 
 #a list of repositories (please pay attention to the list format!) in which the
 #files should be searched for. Files will be searched in all repositories until
@@ -807,6 +807,7 @@ cfg$gms$s56_limit_ch4_n2o_price <- 1000   # def = 1000
 # * redd+_nosoil: Above ground CO2 emis from LUC in natveg and forestry; all CH4 and N2O emissions
 # * all_nosoil: Above ground CO2 emis from LUC for all LUs; all CH4 and N2O emissions
 # * all:        CO2 emis from LUC in all LUs; all CH4 and N2O emissions
+# * maccs_excl_cropland_n2o: Above ground CO2 emis from LUC in natveg and forestry; all CH4 emissions and animal-sourced N2O
 cfg$gms$c56_emis_policy <- "redd+_nosoil" 		# def = redd+_nosoil
 
 # * Treatment of negative costs originating from negative co2 emissions

--- a/modules/56_ghg_policy/price_jan20/sets.gms
+++ b/modules/56_ghg_policy/price_jan20/sets.gms
@@ -70,7 +70,7 @@ sets
    	SSPDB-SSP5-Ref-REMIND-MAGPIE/
 
   scen56 emission policy scenarios
-  / none, all, ssp, ssp_nosoil, redd+_nosoil, all_nosoil /
+  / none, all, ssp, ssp_nosoil, redd+_nosoil, all_nosoil, maccs_excl_cropland_n2o /
 
    emis_cell_one56(emis_source_cell) cellular oneoff emission sources
    /crop_vegc, crop_litc, crop_soilc, past_vegc, past_litc, past_soilc, forestry_vegc,


### PR DESCRIPTION
## Purpose of this PR

- Added new scenario in f56_emis_policy (maccs_excl_cropland_n2o) that can be chosen when combining climate policy (ghg prices) and fertilizer use efficiency. It avoids double accounting because the MACCS are switched off for all nitrogen-related emissions that are related to cropland (pasture and animal waste management are kept)

## Performance loss/gain from current default behavior

<img width="620" alt="Capture" src="https://user-images.githubusercontent.com/39262100/101915643-2ed1d900-3bc6-11eb-8b49-3c948c33dc24.PNG">

- Add an image using plot from `shinyresults::appResults()` and annotate accordingly.

- 1.102 = 0.789/0.716  (loss in performance)

## Type of change

- [ ] Bug fix (Change which fixes an issue).
- [ ] New feature (Change which adds functionality).
- [x] Minor change (Change which does not modify core model code i.e., in /modules).
- [ ] Major change (fix or feature that would change current model behavior).

## How Has This Been Tested?

- [x] Runs using starting script which tests current defaults (using `test_runs.R`).
- [x] Runs using starting script which successfully runs the same scenarios as in `test_runs.R` but with the changes from PR.
- [ ] (If applicable) Runs using different scenarios/mappings which are not the default (12 regions/c200 clusters).

## *Additions* or *Changes* to default configuration (default.cfg):
- added new scenario description in default.cfg

Changes are deletion or updates to the existing model components in default config

- [ ] Realizations:
- [ ] Scenario switches:
- [ ] Scalars/Constants:
- [ ] Model interfaces:
- [x] Others: only new scenario added in f56_emis_policy 

## Checklist:

- [x] Self-review of my own code.
- [x] Compilation check (model starts without compilation errors).
- [x] Added changes to `CHANGELOG.md`
- [x] No hard coded numbers and cluster/country/region names.
- [x] The code doesn't contain declared but unused parameters or variables.
- [x] In-code comments added including documentation comments.
- [ ] Compiled and checked resulting documentation with `goxygen::goxygen()` for the new/updated parts.
- [ ] Changes to `magpie4` R library for post processing of model output (ideally backward compatible).

## Special comments/warnings

- Notes
