### PR TITLE
Bugfixes in 32_forestry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ pandoc: false
 r_packages:
   - gms
 install:
-  - Rscript -e "if(!requireNamespace('devtools')) install.packages('devtools')"
-  - Rscript -e "if(!requireNamespace('gms')) devtools::install_github('pik-piam/gms')"
+  - Rscript -e "if(!requireNamespace('gms')) install.packages('gms')"
 script:
   - Rscript -e "null <- gms::codeCheck(strict=TRUE)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### removed
 
 ### fixed
+- **32_forestry** Bugfixes for "ac_est" and carbon treshold afforestation; removed plantations from "vm_cdr_aff".
 
 ## [4.3.1] - 2020-11-03
 

--- a/modules/32_forestry/dynamic_may20/declarations.gms
+++ b/modules/32_forestry/dynamic_may20/declarations.gms
@@ -22,7 +22,6 @@ parameters
  p32_rotation_cellular_estb(t_all,j)                Establishment rotation length translated to age classes on cellular level (1)
  p32_rotation_cellular_harvesting(t_all,j)          Harvesting rotation length of plantations translated to age class equivalent for future (1)
  p32_cdr_ac(t,j,ac)                                 Non-cumulative CDR from afforestation plantations for each age-class depending on planning horizon (tC per ha)
- p32_cdr_ac_plant(t,j,ac)                           Non-cumulative CDR from timber plantations for each age-class depending on planning horizon (tC per ha)
  p32_rotation_offset                                Offset calc in age class equivalents (1)
  p32_land_start_ac(j,type32,ac)                     Saving first value of starting land (mio. ha)
  p32_land_before(t,j,type32,ac)                     Saving time value of starting land (mio. ha)

--- a/modules/32_forestry/dynamic_may20/equations.gms
+++ b/modules/32_forestry/dynamic_may20/equations.gms
@@ -30,18 +30,18 @@ q32_cost_total(i2) .. vm_cost_fore(i2) =e=
 *-----------------------------------------------
 ****** Carbon price induced afforestation ******
 *-----------------------------------------------
-*' The interface `vm_cdr_aff` provides the projected bgc (CDR) and local bph effects of an afforestation
-*' activity for a planning horizon of 30 years `s32_planing_horizon` to the [56_ghg_policy] module.
+*' The interface `vm_cdr_aff` provides the projected biogeochemical (bgc) carbon sequestration
+*' and the local biophysical (bph) warming/cooling effects of an afforestation
+*' activity for a planning horizon of 50 years `s32_planing_horizon` to the [56_ghg_policy] module.
 
 q32_cdr_aff(j2,ac) ..
 vm_cdr_aff(j2,ac,"bgc") =e=
 sum(ac_est, v32_land(j2,"aff",ac_est)) * sum(ct, p32_cdr_ac(ct,j2,ac))
-+ sum(ac_est, v32_land(j2,"plant",ac_est)) * sum(ct, p32_cdr_ac_plant(ct,j2,ac))
 ;
 
 q32_bgp_aff(j2,ac) ..
 vm_cdr_aff(j2,ac,"bph") =e=
-v32_land(j2,"aff","ac0") * p32_aff_bgp(j2,ac);
+sum(ac_est, v32_land(j2,"aff",ac_est)) * p32_aff_bgp(j2,ac);
 
 *' ac_est can only increase if total afforested land increases
 q32_aff_est(j2) ..
@@ -110,7 +110,7 @@ sum(ac_est, v32_land(j2,"aff",ac_est)) =l= sum(ac, v32_land(j2,"aff",ac)) - sum(
 q32_cost_establishment(i2)..
 						v32_cost_establishment(i2)
 						=e=
-            (sum((cell(i2,j2),type32), v32_land(j2,type32,"ac0") * s32_reESTBcost)
+            (sum((cell(i2,j2),type32,ac_est), v32_land(j2,type32,ac_est) * s32_reESTBcost)
 *            +sum(cell(i2,j2), v32_land(j2,"plant","ac0") * s32_harvesting_cost)
 *              /((1+sum(ct,pm_interest(ct,i2)))**sum(ct,(p32_rotation_regional(ct,i2))))
               )

--- a/modules/32_forestry/dynamic_may20/input.gms
+++ b/modules/32_forestry/dynamic_may20/input.gms
@@ -26,7 +26,6 @@ scalars
   s32_max_aff_area                Maximum total global afforestation (mio. ha)    / Inf /
   s32_aff_plantation              Switch for using growth curves for afforestation 0=natveg 1=plantations (1) / 0 /
   s32_timber_plantation           Switch for using growth curves for timber plantations 0=natveg 1=plantations (1) / 1 /
-  s32_plant_carbon_foresight      Switch to allow plantations to be used as incentives for CDR (1) / 1 /
   s32_tcre_local                  Switch for local (1) or global (0) TRCE factors (1) / 1 /
   s32_fix_plant                   Fixing plantation area after sm_fix_SSP2 0=Not fixed 1=Fixed (1) / 0 /
   s32_plant_share                 Constant percentage of production which can come from plantations (1) / 0.25 /

--- a/modules/32_forestry/dynamic_may20/preloop.gms
+++ b/modules/32_forestry/dynamic_may20/preloop.gms
@@ -144,7 +144,6 @@ p32_aff_togo(t) = sum(j, smax(t2, p32_aff_pol(t2,j)) - p32_aff_pol(t,j));
 s32_max_aff_area = max(s32_max_aff_area, sum(j, smax(t2, p32_aff_pol(t2,j))) );
 
 p32_cdr_ac(t,j,ac) = 0;
-p32_cdr_ac_plant(t,j,ac) = 0;
 
 ** Initialize parameter
 p32_land(t,j,type32,ac) = 0;

--- a/modules/32_forestry/dynamic_may20/presolve.gms
+++ b/modules/32_forestry/dynamic_may20/presolve.gms
@@ -58,10 +58,6 @@ p32_carbon_density_ac(t,j,"ndc",ac,ag_pools) = pm_carbon_density_ac(t,j,ac,ag_po
 p32_cdr_ac(t,j,ac)$(ord(ac) > 1 AND (ord(ac)-1) <= s32_planing_horizon/5)
 = p32_carbon_density_ac(t,j,"aff",ac,"vegc") - p32_carbon_density_ac(t,j,"aff",ac-1,"vegc");
 
-*' CDR from timber plantations for each unharvested age-class.
-p32_cdr_ac_plant(t,j,ac)$(ord(ac) > 1 AND ord(ac) < p32_rotation_cellular_harvesting(t,j))
-= (p32_carbon_density_ac(t,j,"plant",ac,"vegc") - p32_carbon_density_ac(t,j,"plant",ac-1,"vegc")) * s32_plant_carbon_foresight;
-
 *' Regrowth of natural vegetation (natural succession) is modelled by shifting
 *' age-classes according to time step length. For first year of simulation, the
 *' shift is just 1. Division by 5 happends because the age-classes exist in 5 year steps

--- a/modules/32_forestry/dynamic_may20/presolve.gms
+++ b/modules/32_forestry/dynamic_may20/presolve.gms
@@ -34,16 +34,6 @@ else
 ** END ndc **
 
 *' @code
-*' Certain areas (e.g. the boreal zone) are excluded from endogenous afforestation.
-** DON'T USE TYPE32 SET HERE
-if(m_year(t) <= sm_fix_SSP2,
-	v32_land.fx(j,"aff","ac0") = 0;
-else
-	v32_land.lo(j,"aff","ac0") = 0;
-	v32_land.up(j,"aff","ac0") = f32_aff_mask(j) * sum(land, pcm_land(j,land));
-);
-*' No afforestation is allowed if carbon density <= 20 tc/ha
-v32_land.fx(j,"aff","ac0")$(fm_carbon_density(t,j,"forestry","vegc") <= 20) = 0;
 
 *' Afforestation switch:
 *' 0 = Use natveg carbon densities for afforestation,
@@ -114,16 +104,27 @@ v32_land.up(j,"plant",ac_est) = Inf;
 ** need to be held at constant 1995 levels.
 v32_land.fx(j,"plant",ac)$(s32_initial_distribution=0) = p32_land_start_ac(j,"plant",ac);
 
-** fix ndc afforestation forever, all age-classes are fixed except ac0
+** fix ndc afforestation forever, all age-classes are fixed except ac_est
 v32_land.fx(j,"ndc",ac_sub) = pc32_land(j,"ndc",ac_sub);
 v32_land.lo(j,"ndc",ac_est) = 0;
 v32_land.up(j,"ndc",ac_est) = Inf;
 
-** fix c price induced afforestation based on s32_planing_horizon, fixed only until end of s32_planing_horizon, ac0 is free
+** fix c price induced afforestation based on s32_planing_horizon, fixed only until end of s32_planing_horizon, ac_est is free
 v32_land.fx(j,"aff",ac)$(ac.off <= s32_planing_horizon/5) = pc32_land(j,"aff",ac);
 v32_land.up(j,"aff",ac)$(ac.off > s32_planing_horizon/5) = pc32_land(j,"aff",ac);
 v32_land.lo(j,"aff",ac_est) = 0;
 v32_land.up(j,"aff",ac_est) = Inf;
+
+** Certain areas (e.g. the boreal zone) are excluded from endogenous afforestation.
+** DON'T USE TYPE32 SET HERE
+if(m_year(t) <= sm_fix_SSP2,
+	v32_land.fx(j,"aff",ac_est) = 0;
+else
+	v32_land.lo(j,"aff",ac_est) = 0;
+	v32_land.up(j,"aff",ac_est) = f32_aff_mask(j) * sum(land, pcm_land(j,land));
+);
+*' No afforestation is allowed if carbon density <= 20 tc/ha
+v32_land.fx(j,"aff",ac_est)$(fm_carbon_density(t,j,"forestry","vegc") <= 20) = 0;
 
 m_boundfix(v32_land,(j,type32,ac_sub),l,10e-5);
 

--- a/modules/32_forestry/input/files
+++ b/modules/32_forestry/input/files
@@ -4,6 +4,5 @@ aff_noboreal.cs2
 aff_onlytropical.cs2
 npi_ndc_aff_pol.cs3
 f32_plant_prod_share.csv
-f32_bph_effect.cs3
 f32_bph_effect_noTCRE.cs3
 f32_localTCRE.cs3

--- a/scripts/start/projects/forestry.R
+++ b/scripts/start/projects/forestry.R
@@ -91,8 +91,6 @@ for(s73_foresight in c(0)){
         for(emis_policy in c("redd+_nosoil")){
 
           for(ssp in c("SSP1","SSP2","SSP3")){
-            if(emis_policy == "redd+_nosoil") cfg$gms$s32_plant_carbon_foresight = 1
-            if(emis_policy == "ssp_nosoil")   cfg$gms$s32_plant_carbon_foresight = 0
 
             cfg                           = setScenario(cfg,c(ssp,"NPI"))
             cfg$gms$c56_emis_policy       = emis_policy


### PR DESCRIPTION
Please fill following information
(Add additional info if you think its important and not covered by this Pull Request (PR)):

## Purpose of this PR

- ac0 was used instead of ac_est in some case
- minimum carbon treshold for afforesation was overwritten (code moved to end of presolve.gms)
- Removed plantations from vm_cdr_aff because p32_cdr_ac can be changed to plantations with s32_aff_plantation.

## Performance loss/gain from current default behavior

- no test runs. No expected impact on performance. Just bugfixes

## Type of change

- [x] Bug fix (Change which fixes an issue).
- [ ] New feature (Change which adds functionality).
- [x] Minor change (Change which does not modify core model code i.e., in /modules).
- [ ] Major change (fix or feature that would change current model behavior).

## How Has This Been Tested?

- GAMS Compilation works fine "gams main.gms action=C"

## *Additions* or *Changes* to default configuration (default.cfg):
Additions are the introduction of new model components in default config

Changes are deletion or updates to the existing model components in default config

- [ ] Realizations:
- [ ] Scenario switches:
- [ ] Scalars/Constants:
- [ ] Model interfaces:
- [ ] Others:

## Checklist:

- [x] Self-review of my own code.
- [x] Compilation check (model starts without compilation errors).
- [x] Added changes to `CHANGELOG.md`
- [x] No hard coded numbers and cluster/country/region names.
- [x] The code doesn't contain declared but unused parameters or variables.
- [x] In-code comments added including documentation comments.
- [x] Compiled and checked resulting documentation with `goxygen::goxygen()` for the new/updated parts.
- [x] Changes to `magpie4` R library for post processing of model output (ideally backward compatible).

## Special comments/warnings

- Notes
