### PR TITLE
Bugfix in HalfEarth Scenario: Synchronization until 2020 with WDPA protection scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### changed
 - **scripts** Updated AgMIP output scripts.
+- **35_natveg** Fader for HalfEarth protection policy
+- **12_interest_rate** Interest fader changed to csv
 
 ### removed
 

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -27,7 +27,7 @@ cfg$input <- c("isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev50_c200_690d3718e151be1b45
          "rev4.52_h12_magpie.tgz",
          "rev4.52_h12_validation.tgz",
          "calibration_H12_c200_26Feb20.tgz",
-         "additional_data_rev3.89.tgz")
+         "additional_data_rev3.92.tgz")
 
 #a list of repositories (please pay attention to the list format!) in which the
 #files should be searched for. Files will be searched in all repositories until

--- a/main.gms
+++ b/main.gms
@@ -146,9 +146,9 @@ $title magpie
 
 *##################### R SECTION START (VERSION INFO) ##########################
 * 
-* Used data set: isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev48_c200_690d3718e151be1b450b394c1064b1c5.tgz
+* Used data set: isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev50_c200_690d3718e151be1b450b394c1064b1c5.tgz
 * md5sum: NA
-* Repository: https://rse.pik-potsdam.de/data/magpie/public
+* Repository: scp://cluster.pik-potsdam.de/p/projects/landuse/data/input/archive
 * 
 * Used data set: rev4.52_h12_magpie.tgz
 * md5sum: NA
@@ -162,9 +162,9 @@ $title magpie
 * md5sum: NA
 * Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
-* Used data set: additional_data_rev3.88.tgz
-* md5sum: 5c43242889d06b94cbd8439bc1d8b166
-* Repository: /Users/flo/OneDrive/Dokumente/PIK/Development/input_data/
+* Used data set: additional_data_rev3.92.tgz
+* md5sum: NA
+* Repository: scp://cluster.pik-potsdam.de/p/projects/landuse/data/input/archive
 * 
 * Low resolution: c200
 * High resolution: 0.5
@@ -181,15 +181,15 @@ $title magpie
 * 
 * lpj2magpie settings:
 * * LPJmL data folder: /p/projects/landuse/data/input/lpj_input/isimip_rcp/IPSL_CM5A_LR/rcp2p6/co2
-* * Additional input folder: /p/projects/landuse/data/input/other/rev48
-* * Revision: 48
+* * Additional input folder: /p/projects/landuse/data/input/other/rev50
+* * Revision: 50
 * * Call: lpj2magpie(input_folder = path(cfg$lpj_input_folder, gsub("-",     "/", cfg$input)), input2_folder = path(cfg$additional_input_folder,     paste("rev", floor(cfg$revision), sep = "")), output_file = lpj2magpie_file,     rev = cfg$revision)
 * 
 * aggregation settings:
 * * Input resolution: 0.5
 * * Output resolution: c200
-* * Input file: /p/projects/landuse/data/input/archive/isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev48_0.5.tgz
-* * Output file: /p/projects/landuse/data/input/archive/isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev48_c200_690d3718e151be1b450b394c1064b1c5.tgz
+* * Input file: /p/projects/landuse/data/input/archive/isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev50_0.5.tgz
+* * Output file: /p/projects/landuse/data/input/archive/isimip_rcp-IPSL_CM5A_LR-rcp2p6-co2_rev50_c200_690d3718e151be1b450b394c1064b1c5.tgz
 * * Regionscode: 690d3718e151be1b450b394c1064b1c5
 * * (clustering) n-repeat: 5
 * * (clustering) n-redistribute: 0
@@ -197,7 +197,7 @@ $title magpie
 * 
 * 
 * 
-* Last modification (input data): Mon Nov 16 12:12:24 2020
+* Last modification (input data): Mon Jan 18 17:49:23 2021
 * 
 *###################### R SECTION END (VERSION INFO) ###########################
 

--- a/modules/12_interest_rate/input/files
+++ b/modules/12_interest_rate/input/files
@@ -1,2 +1,3 @@
 * list of files that are required here
 f12_interest_rate_coupling.csv
+f12_interest_fader.csv

--- a/modules/12_interest_rate/select_apr20/declarations.gms
+++ b/modules/12_interest_rate/select_apr20/declarations.gms
@@ -7,7 +7,6 @@
 
 parameters
  pm_interest(t_all,i)               Interest rate in each region and timestep (% per yr)
- i12_interest_fader(t_all)           Fader for interest rate policy (1)
 * country-specific region scenario switch
  p12_country_dummy(iso)              Dummy parameter indicating whether country is affected by interest rate scenario (1)
  p12_reg_shr(t_all,i)                Weighted share of region with regards to interest rate scenario of countries (1)

--- a/modules/12_interest_rate/select_apr20/input.gms
+++ b/modules/12_interest_rate/select_apr20/input.gms
@@ -49,7 +49,7 @@ sets
 parameter f12_interest_fader(t_all) Protection scenario fader (1)
 /
 $ondelim
-$include "./modules/15_food/input/f12_interest_fader.csv"
+$include "./modules/12_interest_rate/input/f12_interest_fader.csv"
 $offdelim
 /
 ;

--- a/modules/12_interest_rate/select_apr20/input.gms
+++ b/modules/12_interest_rate/select_apr20/input.gms
@@ -46,6 +46,14 @@ sets
                           VIR,VNM,VUT,WLF,WSM,YEM,ZAF,ZMB,ZWE /
 ;
 
+parameter f12_interest_fader(t_all) Protection scenario fader (1)
+/
+$ondelim
+$include "./modules/15_food/input/f12_interest_fader.csv"
+$offdelim
+/
+;
+
 $if "%c12_interest_rate%" == "coupling" parameter f12_interest_coupling(t_all) Interest rate (% per yr)
 $if "%c12_interest_rate%" == "coupling" /
 $if "%c12_interest_rate%" == "coupling" $ondelim

--- a/modules/12_interest_rate/select_apr20/preloop.gms
+++ b/modules/12_interest_rate/select_apr20/preloop.gms
@@ -5,15 +5,6 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
-* Interest rate policy fader:
-i12_interest_fader(t_all)$(m_year(t_all)<2025)=0;
-i12_interest_fader("y2025")=0.1;
-i12_interest_fader("y2030")=0.2;
-i12_interest_fader("y2035")=0.4;
-i12_interest_fader("y2040")=0.6;
-i12_interest_fader("y2045")=0.8;
-i12_interest_fader(t_all)$(m_year(t_all)>=2050)=1;
-
 * Country switch to determine countries for which chosen interest rate scenario
 * shall be applied.
 * In the default case, the interest rate scenario affects all countries when
@@ -29,8 +20,8 @@ p12_reg_shr(t_all,i) = sum(i_to_iso(i,iso), p12_country_dummy(iso) * im_pop_iso(
 $ifthen "%c12_interest_rate%" == "coupling"
   p12_interest_select(t_all,i) = f12_interest_coupling(t_all);
 $elseif "%c12_interest_rate%" == "gdp_dependent"
-  pm_interest(t_all,i) =  ( (s12_interest_lic - (s12_interest_lic-s12_interest_hic) * im_development_state(t_all,i)) * i12_interest_fader(t_all)
-                         +   (s12_hist_interest_lic - (s12_hist_interest_lic-s12_hist_interest_hic) * im_development_state(t_all,i)) * (1-i12_interest_fader(t_all)) ) * p12_reg_shr(t_all,i)
-                         + ( (s12_interest_lic_noselect - (s12_interest_lic_noselect-s12_interest_hic_noselect) * im_development_state(t_all,i)) * i12_interest_fader(t_all)
-                         +   (s12_hist_interest_lic_noselect - (s12_hist_interest_lic_noselect-s12_hist_interest_hic_noselect) * im_development_state(t_all,i) ) * (1-i12_interest_fader(t_all)) ) * (1-p12_reg_shr(t_all,i));
+  pm_interest(t_all,i) =  ( (s12_interest_lic - (s12_interest_lic-s12_interest_hic) * im_development_state(t_all,i)) * f12_interest_fader(t_all)
+                         +   (s12_hist_interest_lic - (s12_hist_interest_lic-s12_hist_interest_hic) * im_development_state(t_all,i)) * (1-f12_interest_fader(t_all)) ) * p12_reg_shr(t_all,i)
+                         + ( (s12_interest_lic_noselect - (s12_interest_lic_noselect-s12_interest_hic_noselect) * im_development_state(t_all,i)) * f12_interest_fader(t_all)
+                         +   (s12_hist_interest_lic_noselect - (s12_hist_interest_lic_noselect-s12_hist_interest_hic_noselect) * im_development_state(t_all,i) ) * (1-f12_interest_fader(t_all)) ) * (1-p12_reg_shr(t_all,i));
 $endif

--- a/modules/35_natveg/dynamic_may20/declarations.gms
+++ b/modules/35_natveg/dynamic_may20/declarations.gms
@@ -12,6 +12,7 @@ scalars
 parameters
  i35_secdforest(j,ac)							              Inital secdforest (mio. ha)
  i35_other(j,ac)								                Inital other land (mio. ha)
+ i35_protect_fader(t_all)                       Fader for half earth protection scenario (1)
  p35_secdforest(t,j,ac)  	                      Secdforest per age class (mio. ha)
  p35_other(t,j,ac)   	  	                      Other land per age class (mio. ha)
  pc35_secdforest(j,ac)    	                    Secdforest per age class in current time step (mio. ha)

--- a/modules/35_natveg/dynamic_may20/declarations.gms
+++ b/modules/35_natveg/dynamic_may20/declarations.gms
@@ -12,7 +12,6 @@ scalars
 parameters
  i35_secdforest(j,ac)							              Inital secdforest (mio. ha)
  i35_other(j,ac)								                Inital other land (mio. ha)
- i35_protect_fader(t_all)                       Fader for half earth protection scenario (1)
  p35_secdforest(t,j,ac)  	                      Secdforest per age class (mio. ha)
  p35_other(t,j,ac)   	  	                      Other land per age class (mio. ha)
  pc35_secdforest(j,ac)    	                    Secdforest per age class in current time step (mio. ha)

--- a/modules/35_natveg/dynamic_may20/input.gms
+++ b/modules/35_natveg/dynamic_may20/input.gms
@@ -17,7 +17,7 @@ s35_secdf_distribution Flag for secdf initialization (0=all secondary forest in 
 parameter f35_protection_fader(t_all) Protection scenario fader (1)
 /
 $ondelim
-$include "./modules/15_food/input/f35_protection_fader.csv"
+$include "./modules/35_natveg/input/f35_protection_fader.csv"
 $offdelim
 /
 ;

--- a/modules/35_natveg/dynamic_may20/input.gms
+++ b/modules/35_natveg/dynamic_may20/input.gms
@@ -14,6 +14,14 @@ s35_natveg_harvest_shr Constrains the allowed wood harvest from natural vegetati
 s35_secdf_distribution Flag for secdf initialization (0=all secondary forest in highest age class 1=Equal distribution among all age classes) (1) /0/
 ;
 
+parameter f35_protection_fader(t_all) Protection scenario fader (1)
+/
+$ondelim
+$include "./modules/15_food/input/f35_protection_fader.csv"
+$offdelim
+/
+;
+
 table f35_protect_area(j,prot_type) Conservation priority areas (mio. ha)
 $ondelim
 $include "./modules/35_natveg/input/protect_area.cs3"

--- a/modules/35_natveg/dynamic_may20/presolve.gms
+++ b/modules/35_natveg/dynamic_may20/presolve.gms
@@ -71,6 +71,10 @@ $elseif "%c35_protect_scenario%" == "WDPA"
   p35_save_secdforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"secdforest");
   p35_save_other(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"other");
 $elseif "%c35_protect_scenario%" == "HalfEarth"
+* Correction of Half Earth protection share
+* Note: Half Earth already contains WDPA protection
+p35_protect_shr(t,j,prot_type)$(p35_protect_shr(t,j,"HalfEarth") < p35_protect_shr(t,j,"WDPA")) = p35_protect_shr(t,j,"WDPA");
+
 * half earth scenario begins fading in after 2020:
 p35_save_primforest(t,j) = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader(t)*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"primforest");
 p35_save_secdforest(t,j) = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader(t)*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"secdforest");

--- a/modules/35_natveg/dynamic_may20/presolve.gms
+++ b/modules/35_natveg/dynamic_may20/presolve.gms
@@ -72,9 +72,9 @@ $elseif "%c35_protect_scenario%" == "WDPA"
   p35_save_other(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"other");
 $elseif "%c35_protect_scenario%" == "HalfEarth"
 * half earth scenario begins fading in after 2020:
-p35_save_primforest(t,j) = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"primforest");
-p35_save_secdforest(t,j) = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"secdforest");
-p35_save_other(t,j)      = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"other");
+p35_save_primforest(t,j) = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader(t)*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"primforest");
+p35_save_secdforest(t,j) = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader(t)*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"secdforest");
+p35_save_other(t,j)      = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader(t)*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"other");
 $else
 * conservation priority scenarios start in 2020, in addition to WDPA protection
   if (m_year(t) <= sm_fix_SSP2,

--- a/modules/35_natveg/dynamic_may20/presolve.gms
+++ b/modules/35_natveg/dynamic_may20/presolve.gms
@@ -73,7 +73,7 @@ $elseif "%c35_protect_scenario%" == "WDPA"
 $elseif "%c35_protect_scenario%" == "HalfEarth"
 * Correction of Half Earth protection share
 * Note: Half Earth already contains WDPA protection
-p35_protect_shr(t,j,prot_type)$(p35_protect_shr(t,j,"HalfEarth") < p35_protect_shr(t,j,"WDPA")) = p35_protect_shr(t,j,"WDPA");
+p35_protect_shr(t,j,"HalfEarth")$(p35_protect_shr(t,j,"HalfEarth") < p35_protect_shr(t,j,"WDPA")) = p35_protect_shr(t,j,"WDPA");
 
 * half earth scenario begins fading in after 2020:
 p35_save_primforest(t,j) = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader(t)*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"primforest");

--- a/modules/35_natveg/dynamic_may20/presolve.gms
+++ b/modules/35_natveg/dynamic_may20/presolve.gms
@@ -53,15 +53,6 @@ p35_protect_shr(t,j,prot_type)$(sum(land_natveg, pm_land_start(j,land_natveg)) >
 p35_protect_shr(t,j,prot_type)$(p35_protect_shr(t,j,prot_type) > 1) = 1;
 p35_protect_shr(t,j,prot_type)$(p35_protect_shr(t,j,prot_type) < 0) = 0;
 
-* Protection scenario fader:
-i35_protect_fader(t)$(m_year(t)<2025)=0;
-i35_protect_fader("y2025")=0.17;
-i35_protect_fader("y2030")=0.33;
-i35_protect_fader("y2035")=0.50;
-i35_protect_fader("y2040")=0.66;
-i35_protect_fader("y2045")=0.83;
-i35_protect_fader(t)$(m_year(t)>=2050)=1;
-
 * protection scenarios
 $ifthen "%c35_protect_scenario%" == "none"
   p35_save_primforest(t,j) = 0;
@@ -81,9 +72,9 @@ $elseif "%c35_protect_scenario%" == "WDPA"
   p35_save_other(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"other");
 $elseif "%c35_protect_scenario%" == "HalfEarth"
 * half earth scenario begins fading in after 2020:
-p35_save_primforest(t,j) = (p35_protect_shr(t,j,"WDPA")+i35_protect_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"primforest");
-p35_save_secdforest(t,j) = (p35_protect_shr(t,j,"WDPA")+i35_protect_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"secdforest");
-p35_save_other(t,j)      = (p35_protect_shr(t,j,"WDPA")+i35_protect_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"other");
+p35_save_primforest(t,j) = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"primforest");
+p35_save_secdforest(t,j) = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"secdforest");
+p35_save_other(t,j)      = (p35_protect_shr(t,j,"WDPA")+f35_protection_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"other");
 $else
 * conservation priority scenarios start in 2020, in addition to WDPA protection
   if (m_year(t) <= sm_fix_SSP2,

--- a/modules/35_natveg/dynamic_may20/presolve.gms
+++ b/modules/35_natveg/dynamic_may20/presolve.gms
@@ -71,9 +71,16 @@ $elseif "%c35_protect_scenario%" == "WDPA"
   p35_save_secdforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"secdforest");
   p35_save_other(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"other");
 $elseif "%c35_protect_scenario%" == "HalfEarth"
-  p35_save_primforest(t,j) = p35_protect_shr(t,j,"HalfEarth")*pm_land_start(j,"primforest");
-  p35_save_secdforest(t,j) = p35_protect_shr(t,j,"HalfEarth")*pm_land_start(j,"secdforest");
-  p35_save_other(t,j) = p35_protect_shr(t,j,"HalfEarth")*pm_land_start(j,"other");
+* half earth scenario starts in 2020
+if (m_year(t) <= sm_fix_SSP2,
+p35_save_primforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"primforest");
+p35_save_secdforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"secdforest");
+p35_save_other(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"other");
+else
+p35_save_primforest(t,j) = p35_protect_shr(t,j,"HalfEarth")*pm_land_start(j,"primforest");
+p35_save_secdforest(t,j) = p35_protect_shr(t,j,"HalfEarth")*pm_land_start(j,"secdforest");
+p35_save_other(t,j) = p35_protect_shr(t,j,"HalfEarth")*pm_land_start(j,"other");
+);
 $else
 * conservation priority scenarios start in 2020, in addition to WDPA protection
   if (m_year(t) <= sm_fix_SSP2,

--- a/modules/35_natveg/dynamic_may20/presolve.gms
+++ b/modules/35_natveg/dynamic_may20/presolve.gms
@@ -53,6 +53,15 @@ p35_protect_shr(t,j,prot_type)$(sum(land_natveg, pm_land_start(j,land_natveg)) >
 p35_protect_shr(t,j,prot_type)$(p35_protect_shr(t,j,prot_type) > 1) = 1;
 p35_protect_shr(t,j,prot_type)$(p35_protect_shr(t,j,prot_type) < 0) = 0;
 
+* Protection scenario fader:
+i35_protect_fader(t)$(m_year(t)<2025)=0;
+i35_protect_fader("y2025")=0.17;
+i35_protect_fader("y2030")=0.33;
+i35_protect_fader("y2035")=0.50;
+i35_protect_fader("y2040")=0.66;
+i35_protect_fader("y2045")=0.83;
+i35_protect_fader(t)$(m_year(t)>=2050)=1;
+
 * protection scenarios
 $ifthen "%c35_protect_scenario%" == "none"
   p35_save_primforest(t,j) = 0;
@@ -71,16 +80,10 @@ $elseif "%c35_protect_scenario%" == "WDPA"
   p35_save_secdforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"secdforest");
   p35_save_other(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"other");
 $elseif "%c35_protect_scenario%" == "HalfEarth"
-* half earth scenario starts in 2020
-if (m_year(t) <= sm_fix_SSP2,
-p35_save_primforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"primforest");
-p35_save_secdforest(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"secdforest");
-p35_save_other(t,j) = p35_protect_shr(t,j,"WDPA")*pm_land_start(j,"other");
-else
-p35_save_primforest(t,j) = p35_protect_shr(t,j,"HalfEarth")*pm_land_start(j,"primforest");
-p35_save_secdforest(t,j) = p35_protect_shr(t,j,"HalfEarth")*pm_land_start(j,"secdforest");
-p35_save_other(t,j) = p35_protect_shr(t,j,"HalfEarth")*pm_land_start(j,"other");
-);
+* half earth scenario begins fading in after 2020:
+p35_save_primforest(t,j) = (p35_protect_shr(t,j,"WDPA")+i35_protect_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"primforest");
+p35_save_secdforest(t,j) = (p35_protect_shr(t,j,"WDPA")+i35_protect_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"secdforest");
+p35_save_other(t,j)      = (p35_protect_shr(t,j,"WDPA")+i35_protect_fader*(p35_protect_shr(t,j,"HalfEarth")-p35_protect_shr(t,j,"WDPA")))*pm_land_start(j,"other");
 $else
 * conservation priority scenarios start in 2020, in addition to WDPA protection
   if (m_year(t) <= sm_fix_SSP2,

--- a/modules/35_natveg/input/files
+++ b/modules/35_natveg/input/files
@@ -1,3 +1,4 @@
 * list of files that are required here
 protect_area.cs3
 npi_ndc_ad_aolc_pol.cs3
+f35_protection_fader.csv


### PR DESCRIPTION
Please fill following information
(Add additional info if you think its important and not covered by this Pull Request (PR)):

## Purpose of this PR

- bugfix: synchronize HalfEarth scenario with WDPA until 2020, so that scenarios only diverge after 2020

## Performance loss/gain from current default behavior

![newplot](https://user-images.githubusercontent.com/39262100/104458624-eaae6b80-55ab-11eb-82fe-a7b246d5d54e.png)

- performance gain = 0.623352/0.6361311 = 0.9799
- like already noted when the HalfEarth Scenario was introduced the first time: runtime is even a bit faster compared to default (WDPA protection)

## Type of change

- [x] Bug fix (Change which fixes an issue).
- [ ] New feature (Change which adds functionality).
- [ ] Minor change (Change which does not modify core model code i.e., in /modules).
- [ ] Major change (fix or feature that would change current model behavior).

## How Has This Been Tested?

- [x] Runs using starting script which tests current defaults (using `test_runs.R`).
- [x] Runs using starting script which successfully runs the same scenarios as in `test_runs.R` but with the changes from PR.
- [ ] (If applicable) Runs using different scenarios/mappings which are not the default (12 regions/c200 clusters).

## *Additions* or *Changes* to default configuration (default.cfg):
no additions required 

Changes are deletion or updates to the existing model components in default config

- [ ] Realizations:
- [ ] Scenario switches:
- [ ] Scalars/Constants:
- [ ] Model interfaces:
- [x] Others: only change in presolve (synchronize data before 2020)

## Checklist:

- [x] Self-review of my own code.
- [x] Compilation check (model starts without compilation errors).
- [x] Added changes to `CHANGELOG.md` (I think this is not required, since it was only a bugfix, right?)
- [x] No hard coded numbers and cluster/country/region names.
- [x] The code doesn't contain declared but unused parameters or variables.
- [x] In-code comments added including documentation comments.
- [x] Compiled and checked resulting documentation with `goxygen::goxygen()` for the new/updated parts.
- [] Changes to `magpie4` R library for post processing of model output (ideally backward compatible).

## Special comments/warnings

- Notes: It was only an adjustment when the HalfEarth protection kicks in