### PR TITLE
bugfix m_fillmissingyears macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### fixed
 - **32_forestry** Bugfixes for "ac_est" and carbon treshold afforestation; removed plantations from "vm_cdr_aff".
+- **core** bugfix m_fillmissingyears macro; was running over t before; now running over t_all_
 
 ## [4.3.1] - 2020-11-03
 

--- a/core/macros.gms
+++ b/core/macros.gms
@@ -64,11 +64,11 @@ $macro m_annuity_costs_update(past_costs, cost_annuity, invest_horizon) past_cos
 * fill empty years with values from previous time step
 * input = name of input parameter
 * sets = all sets except of t_all written in quotes (e.g. "kve,w")
-$macro m_fillmissingyears(input,sets) loop(t, \
-          ct(t) = yes;     \
-          if(sum((ct,&&sets),input(ct,&&sets))=0,    \
-            input(t,&&sets) = input(t-1,&&sets);    \
-            display "Data gap in input filled with data from previous time step for the following year: ",ct;    \
+$macro m_fillmissingyears(input,sets) loop(t_all, \
+          ct_all(t_all) = yes;     \
+          if(sum((ct_all,&&sets),input(ct_all,&&sets))=0,    \
+            input(t_all,&&sets) = input(t_all-1,&&sets);    \
+            display "Data gap in input filled with data from previous time step for the following year: ",ct_all;    \
           ); \
-          ct(t) = no;    \
+          ct_all(t_all) = no;    \
        );

--- a/core/sets.gms
+++ b/core/sets.gms
@@ -184,6 +184,7 @@ $If "%c_timesteps%"== "5year" /y1995,y2000,y2005,y2010,y2015,y2020,y2025,y2030,y
 $If "%c_timesteps%"== "5year2050" /y1995,y2000,y2005,y2010,y2015,y2020,y2025,y2030,y2035,y2040,y2045,y2050/;
 $If "%c_timesteps%"== "5year2070" /y1995,y2000,y2005,y2010,y2015,y2020,y2025,y2030,y2035,y2040,y2045,y2050,y2055,y2060,y2065,y2070/;
 $If "%c_timesteps%"== "quicktest" /y1995,y2010,y2025/;
+$If "%c_timesteps%"== "quicktest2" /y1995,y2020,y2050,y2100/;
 $If "%c_timesteps%"== "1" /y1995/;
 $If "%c_timesteps%"== "2" /y1995,y2000/;
 $If "%c_timesteps%"== "3" /y1995,y2000,y2010/;
@@ -204,6 +205,7 @@ $If "%c_timesteps%"=="17" /y1995,y2000,y2010,y2020,y2030,y2040,y2050,y2060,y2070
 $If "%c_timesteps%"=="past" /y1965,y1970,y1975,y1980,y1985,y1990,y1995,y2000,y2005,y2010/;
 $If "%c_timesteps%"=="pastandfuture" /y1965,y1970,y1975,y1980,y1985,y1990,y1995,y2000,y2005,y2010,y2015,y2020,y2025,y2030,y2035,y2040,y2045,y2050,y2055,y2060,y2065,y2070,y2075,y2080,y2085,y2090,y2095,y2100/;
 set ct(t) Current time period;
+set ct_all(t_all) Current time period for loops over t_all;
 
 alias(t,t2);
 


### PR DESCRIPTION
Please fill following information
(Add additional info if you think its important and not covered by this Pull Request (PR)):

## Purpose of this PR

- bugfix m_fillmissingyears macro. The macro was running over "t" not "t_all". This error-prone. For instance, if t is 2050 and 2100, but data is only availabe until 2095, the macro would use data from 2050 for 2100. Now, the macro runs over t_all, which makes sure that the data from 2095 is used for 2100. 

## Performance loss/gain from current default behavior

- No test runs performed

## Type of change

- [x] Bug fix (Change which fixes an issue).
- [ ] New feature (Change which adds functionality).
- [ ] Minor change (Change which does not modify core model code i.e., in /modules).
- [x] Major change (fix or feature that would change current model behavior).

## How Has This Been Tested?

- [x] gams compilation OK "gams main.gms action=C"
- [x] local test run OK "gams main.gms"

## *Additions* or *Changes* to default configuration (default.cfg):
Additions are the introduction of new model components in default config

Changes are deletion or updates to the existing model components in default config

- [ ] Realizations:
- [ ] Scenario switches:
- [ ] Scalars/Constants:
- [ ] Model interfaces:
- [ ] Others:

## Checklist:

- [x] Self-review of my own code.
- [x] Compilation check (model starts without compilation errors).
- [x] Added changes to `CHANGELOG.md`
- [x] No hard coded numbers and cluster/country/region names.
- [x] The code doesn't contain declared but unused parameters or variables.
- [x] In-code comments added including documentation comments.
- [x] Compiled and checked resulting documentation with `goxygen::goxygen()` for the new/updated parts.
- [x] Changes to `magpie4` R library for post processing of model output (ideally backward compatible).

## Special comments/warnings

- Notes
