### PR TITLE
bugfix croparea correction

### DIFF
--- a/modules/14_yields/managementcalib_aug19/declarations.gms
+++ b/modules/14_yields/managementcalib_aug19/declarations.gms
@@ -9,7 +9,7 @@ parameters
  i14_yields_calib(t,j,kve,w)                             Calibrated biophysical input yields (excluding technological change) (tDM per ha per yr)
  p14_pyield_LPJ_reg(t_all,i)                             Regional average input yields aggregated from clusters with initial pasture area as weights (tDM per ha per yr)
  p14_pyield_corr(t,i)                                    Regional pasture management correction for historical time steps (1)
- i14_croparea_total(t_all,j)                             Cellular croparea (mio. ha)
+ i14_croparea_total(t_all,w,j)                           Cellular croparea (mio. ha)
  i14_modeled_yields_hist(t_all,i,kcr)                    Biophysical input yields average over region and water supply type at the historical reference year (tDM per ha per yr)
  i14_fao_yields_hist(t,i,kcr)                            FAO yields per region at the historical referende year (tDM per ha per yr)
  i14_lambda_yields(t,i,kcr)                              Scaling factor for non-linear management calibration (1)

--- a/modules/14_yields/managementcalib_aug19/preloop.gms
+++ b/modules/14_yields/managementcalib_aug19/preloop.gms
@@ -50,7 +50,7 @@ i14_yields_calib(t,j,"pasture",w) = i14_yields_calib(t,j,"pasture",w) * sum(cell
 *' to an additive term in case of a strongly underestimated baseline. The scalar
 * 's14_limit_calib' can be used to switch limited calibration on (1) and off (0).
 
-i14_croparea_total(t_all,j) = sum((kcr,w), fm_croparea(t_all,j,w,kcr));
+i14_croparea_total(t_all,w,j) = sum(kcr, fm_croparea(t_all,j,w,kcr));
 
 *' Historic crop area patterns ('fm_croprea') are used to calculate regional yields
 *' ('i14_modeled_yields_hist') from the given cellular input pattern. In rare cases where
@@ -60,8 +60,8 @@ i14_croparea_total(t_all,j) = sum((kcr,w), fm_croparea(t_all,j,w,kcr));
 i14_modeled_yields_hist(t_past,i,knbe14)
    = (sum((cell(i,j),w), fm_croparea(t_past,j,w,knbe14) * f14_yields(t_past,j,knbe14,w)) /
       sum((cell(i,j),w), fm_croparea(t_past,j,w,knbe14)))$(sum((cell(i,j),w), fm_croparea(t_past,j,w,knbe14))>0)
-   + (sum((cell(i,j),w), i14_croparea_total(t_past,j) * f14_yields(t_past,j,knbe14,w)) /
-      sum(cell(i,j), i14_croparea_total(t_past,j)))$(sum((cell(i,j),w), fm_croparea(t_past,j,w,knbe14))=0);
+   + (sum((cell(i,j),w), i14_croparea_total(t_past,w,j) * f14_yields(t_past,j,knbe14,w)) /
+      sum((cell(i,j),w), i14_croparea_total(t_past,w,j)))$(sum((cell(i,j),w), fm_croparea(t_past,j,w,knbe14))=0);
 
 
 *' The factor 'i14_lambda_yields' is calculated for the initial time step depending

--- a/modules/30_crop/endo_apr21/preloop.gms
+++ b/modules/30_crop/endo_apr21/preloop.gms
@@ -8,7 +8,7 @@
 *due to some rounding errors the input data currently may contain in some cases
 *very small, negative numbers. These numbers have to be set to 0 as area
 *cannot be smaller than 0!
-fm_croparea(t_past,j,w,kcr)$(fm_croparea(t_past,j,w,kcr)) = 0;
+fm_croparea(t_past,j,w,kcr)$(fm_croparea(t_past,j,w,kcr)<0) = 0;
 
 ****** Regional share of Set aside cropland policy in selective countries:
 * Country switch to determine countries for which a set aside cropland policy shall be applied.

--- a/modules/30_crop/endo_jun13/preloop.gms
+++ b/modules/30_crop/endo_jun13/preloop.gms
@@ -8,5 +8,5 @@
 *due to some rounding errors the input data currently may contain in some cases
 *very small, negative numbers. These numbers have to be set to 0 as area
 *cannot be smaller than 0!
-fm_croparea(t_past,j,w,kcr)$(fm_croparea(t_past,j,w,kcr)) = 0;
+fm_croparea(t_past,j,w,kcr)$(fm_croparea(t_past,j,w,kcr)<0) = 0;
 

--- a/scripts/start/extra/lpjml_addon.R
+++ b/scripts/start/extra/lpjml_addon.R
@@ -34,5 +34,6 @@ cfg$gms$processing                   <- "substitution_may21"
 cfg$gms$crop                         <- "endo_apr21"
 cfg$gms$factor_costs                 <- "sticky_feb18"
 cfg$gms$c41_initial_irrigation_area  <- "LUH2v2"
+cfg$gms$s80_optfile                  <- 1
 cfg                                  <- setScenario(cfg,"cc")
 


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

- This is a hotfix for the wrong fm_croparea replacement in the crop modules and wrong proxy yields for the management calib yield realization.
- For croparea:Since sticky realization is based on this values, the current version of sticky does not allocated capital shares correctly. 
- For yields: Proxy yields for regions without historical crop specific areas had wrong proxy yield calculation, that is now fixed.
- Run time has increase quite a lot, so switching on opt file by default is necessary to get a reasonable runtime.

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).
- [x] Providing additional information based on PR label
* Medium risk : Default run based on the current version of the fork from which PR is made

- [x] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : 1.11 h
  * This PR's default :  1.32-1.44 h
  
  Some additional info
  * Without opt_file + both fixes: runtime > 3h
  -> Opt_file is needed
  * Without opt_file + only one of the fixes: 2.18 rsply 2.28 h
  -> Runtime increase is due to general in crease of complexity and does not correspond to a single change. 
  * With initializing with fm_croprea + opt_file: 2.17 h
  -> initializing doesn't help and should (for now) not be included
  * With restricting sticky (stickyfix) + opt_file: 1.79 h
  -> restricting sticky to reduce solve space size does not help

- [x] Added changes to `CHANGELOG.md`
(no changes needed??)
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [ ] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [ ] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [x] Self-review of my own code.

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [x] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] No unnecessary increase in module interfaces
- [x] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [x] In-code comments and documentation comments are satisfactory.
- [x] model behavior/performance is satisfactory.
- [x] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
