### PR TITLE
Update the lpjml version in addon script

### DIFF
--- a/scripts/start/extra/lpjml_addon.R
+++ b/scripts/start/extra/lpjml_addon.R
@@ -13,18 +13,21 @@ library(gms)
 source("scripts/start_functions.R")
 source("config/default.cfg")
 
-cfg$input <- c(cellular = "rev4.61_h12_42b44dcd_cellularmagpie_c200_GFDL-ESM4-ssp370_lpjml-ab83aee4.tgz",
-               regional = "rev4.61_h12_magpie.tgz",
-               validation = "rev4.61_h12_validation.tgz",
+cfg$input <- c(cellular    = "rev4.62_h12_1b31a144_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-ab83aee4.tgz",
+               regional    = "rev4.62_h12_magpie.tgz",
+               validation  = "rev4.62_h12_validation.tgz",
                calibration = "calibration_H12_newlpjml_bestcalib_fc-sticky-dynamic_crop-endoApr21-allM_20May21.tgz",
-               additional = cfg$input[grep("additional_data", cfg$input)])
+               additional  = cfg$input[grep("additional_data", cfg$input)])
 # see /p/projects/magpie/data/input/calibration for more available calibration factors
 
 cfg$title                            <- "default_lpjml5"
 
 # in case of recalibration, following settings should be applied
+### cfg$recalibrate    <- TRUE
+### cfg$force_download <- TRUE
 cfg$crop_calib_max                   <- 1.5
 cfg$best_calib                       <- TRUE
+
 
 # preliminary test settings for new default 
 # (including new yield, crop, factor cost realizations)


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

- Update LPjmL and input data version in the lpjml_addon.R script (basically just update default GCM from GFDL to MRI). Since the historical baseline is not different only minor changes in the future trajectories are expected. The change should improve at least a bit the carbon sink estimates (smaller jump) and also enable us to run the baseline GCM for all RCPs.

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

- [x] Providing additional information based on PR label

- [ ] Added changes to `CHANGELOG.md`
-> not needed
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [ ] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [ ] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [x] Self-review of my own code.
- [ ] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
