### PR TITLE
Hf update lpjmladdon

### DIFF
--- a/scripts/start/extra/lpjml_addon.R
+++ b/scripts/start/extra/lpjml_addon.R
@@ -16,7 +16,7 @@ source("config/default.cfg")
 cfg$input <- c(cellular = "rev4.61_h12_42b44dcd_cellularmagpie_c200_GFDL-ESM4-ssp370_lpjml-ab83aee4.tgz",
                regional = "rev4.61_h12_magpie.tgz",
                validation = "rev4.61_h12_validation.tgz",
-               calibration = "calibration_H12_newlpjml_bestcalib_fc-sticky-dynamic_crop-endoApr21-allM_20May21.tgz",
+               calibration = "calibration_H12_newlpjml_bestcalib_fc-sticky-free_crop-endoApr21-allM_20May21.tgz",
                additional = cfg$input[grep("additional_data", cfg$input)])
 # see /p/projects/magpie/data/input/calibration for more available calibration factors
 
@@ -33,6 +33,7 @@ cfg$gms$s14_yld_past_switch          <- 0.25
 cfg$gms$processing                   <- "substitution_may21"
 cfg$gms$crop                         <- "endo_apr21"
 cfg$gms$factor_costs                 <- "sticky_feb18"
+cfg$gms$c38_sticky_mode              <- "free" 
 cfg$gms$c41_initial_irrigation_area  <- "LUH2v2"
 cfg$gms$s80_optfile                  <- 1
 cfg                                  <- setScenario(cfg,"cc")


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

- Update lpjml_addon.R settings for sticky from dynamic to free.

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [x] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch
  * Default run based on the current version of the fork from which PR is made

- [ ] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : ** mins
  * This PR's default :  ** mins

- [ ] Added changes to `CHANGELOG.md`
- [ ] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] The new code doesn't contain declared but unused parameters or variables.
- [ ] Where relevant, In-code comments added including documentation comments.
- [ ] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [ ] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [ ] Self-review of my own code.
- [ ] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
