### PR TITLE
Support for exogenous GHG pricing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### changed
 
+- **scripts** new optional parameter in start_run to read GHG prices from another report
 - **51_nitrogen** parameter change in rescaled_jan21, now including regionalized climate-dependent leaching factors
 - **config** Update default configuration to new input data (especially cellular inputs) including all module realization updates (14_yield, 22_processing, 30_crop, 38_factor_costs, 39_landconversion). Moreover, climate impatcs (cc options for biophysical inputs) are activiated as default. New best_calib calibration routine is activated as default.
 - **config** peatland module on by default (cfg$gms$peatland <- "on")

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -526,6 +526,13 @@ getReportData <- function(path_to_report,LU_pricing="y2010",path_magpie_ghgprice
     ghgrep <- read.report(path_magpie_ghgprice_report, as.list = FALSE)
     ghgrep <- collapseNames(ghgrep)
     ghgmag <- deletePlus(rep) #delete "+" and "++" from variable names
+    if(!("y1995" %in% getYears(ghgmag))){
+      empty95<-ghgmag[,1,];empty95[,,]<-0;dimnames(empty95)[[2]] <- "y1995"
+      ghgmag <- mbind(empty95,ghgmag)
+    }
+    years <- 1990+5*(1:32)
+    ghgmag <- time_interpolate(ghgmag,years)
+    
     .emission_prices(ghgmag)
   }
 }


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

This PR adds an optional argument `path_magpie_ghgprice_report` (default = NA) to the `start_run` function that allows a different report to be referenced from which to take GHG prices from. 

This is meant for coupling with REMIND, allowing REMIND and MAgPIE to have different GHG prices in a coupled run. The standard behavior is unaffected and only the start script changes, so this should be a Low risk one.
- If this argument is not provided it defaults to NA which causes `.emission_prices` in `getReportData` to be called with the report in `path_report` like it used to be, ignoring GHG pricing before the year in `LU_pricing`
- If a path to a report is provided in this argument, it reads that report and calls `.emission_prices` with it instead

## :wrench: Checklist for PR creator :wrench:

- [ ] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [x] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch
  * Default run based on the current version of the fork from which PR is made

- [ ] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : ** mins
  * This PR's default :  ** mins

- [x] Added changes to `CHANGELOG.md`
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [x] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [ ] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [x] Self-review of my own code.
- [x] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
