### PR TITLE
removed time dimension from regional maximum afforestation input

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -555,7 +555,7 @@ cfg$gms$s32_max_aff_area <- Inf              # def = Inf
 # Type of afforestation constraint 
 cfg$gms$c32_max_aff_area <- "global"              # def = global
 # * ("global"): global sets a global limit according to s32_max_aff_area
-# * ("regional"): regional sets a regional limit, based on an input file.
+# * ("regional"): regional sets a regional limit, based on the input file "f32_max_aff_area.cs4"
 
 # Switch to determine whether afforestation should be limited to
 # certain latitudinal zones

--- a/modules/32_forestry/dynamic_feb21/input.gms
+++ b/modules/32_forestry/dynamic_feb21/input.gms
@@ -56,15 +56,13 @@ $offdelim
 /;
 
 $onEmpty
-table f32_max_aff_area(t,i) Maximum regional afforestation area (mio. ha)
-$ifthen "%c32_max_aff_area%" == "regional" 
+parameter f32_max_aff_area(i) Maximum regional afforestation area (mio. ha)
+/
 $ondelim
-$if exist "./modules/32_forestry/input/f32_max_aff_area.csv" $include "./modules/32_forestry/input/f32_max_aff_area.csv"
+$if exist "./modules/32_forestry/input/f32_max_aff_area.cs4" $include "./modules/32_forestry/input/f32_max_aff_area.cs4"
 $offdelim
-$endif
-;
+/;
 $offEmpty
-
 
 table f32_aff_pol(t_all,j,pol32) npi+ndc afforestation policy (Mha new forest wrt to 2010)
 $ondelim

--- a/modules/32_forestry/dynamic_feb21/preloop.gms
+++ b/modules/32_forestry/dynamic_feb21/preloop.gms
@@ -240,7 +240,7 @@ if(c32_max_aff_area_glo = 1,
 	i32_max_aff_area_reg(i) = 0;
 elseif c32_max_aff_area_glo = 0,
 	i32_max_aff_area_glo = 0;
-	i32_max_aff_area_reg(i) = max(smax(t2,f32_max_aff_area(t2,i)), smax(t2, sum(cell(i,j), p32_aff_pol(t2,j)))) + sum((cell(i,j),ac), p32_land_start_ac(j,"ndc",ac));
+	i32_max_aff_area_reg(i) = max(f32_max_aff_area(i), smax(t2, sum(cell(i,j), p32_aff_pol(t2,j)))) + sum((cell(i,j),ac), p32_land_start_ac(j,"ndc",ac));
 );
 
 *** NPI/NDC policies END

--- a/scripts/output/extra/highres.R
+++ b/scripts/output/extra/highres.R
@@ -88,14 +88,16 @@ highres <- function(cfg) {
   aff <- dimSums(landForestry(gdx)[,,c("aff","ndc")],dim=3)
   #Take away initial NDC area for consistency with global afforestation limit
   aff <- aff-setYears(aff[,1,],NULL)
-  write.magpie(aff,"modules/32_forestry/input/f32_max_aff_area.csv")
+  #calculate maximum regional afforestation over time
+  aff_max <- setYears(aff[,1,],NULL)
+  for (r in getRegions(aff)) {
+    aff_max[r,,] <- max(aff[r,,])
+  }
+  aff_max[aff_max<0] <- 0
+  write.magpie(aff_max,"modules/32_forestry/input/f32_max_aff_area.cs4")
   cfg$gms$c32_max_aff_area <- "regional"
   #check
   if(cfg$gms$s32_max_aff_area < Inf) {
-    aff_max <- setYears(aff[,1,],NULL)
-    for (r in getRegions(aff)) {
-      aff_max[r,,] <- max(aff[r,,])
-    }
     indicator <- abs(sum(aff_max)-cfg$gms$s32_max_aff_area)
     if(indicator > 1e-06) warning(paste("Global and regional afforestation limit differ by",indicator,"Mha"))
   }


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

- Removed time dimension from regional maximum afforestation input, which allows users to specify regional afforestation limits.
- This PR is related to this fix in the pik-piam gms R library https://github.com/pik-piam/gms/commit/5fdf9da62d98d41358ed0d75274976048e6fb294
- Without the change in the pik-piam gms R library the construct "$if exist file $include file" was not working in the full.gms file (singleGAMSFile)

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [x] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch
  * Default run based on the current version of the fork from which PR is made

- [x] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : ** mins
  * This PR's default :  ** mins

- [x] Added changes to `CHANGELOG.md`
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [x] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [x] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [x] Self-review of my own code.
- [x] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [x] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] No unnecessary increase in module interfaces
- [x] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [x] In-code comments and documentation comments are satisfactory.
- [x] model behavior/performance is satisfactory.
- [x] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
