### PR TITLE
bugfix: urban land

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -92,7 +92,7 @@ cfg$calib_accuracy_landconversion_cost <- 0.05         # def = 0.05
 # What is the maximum number of iterations if the precision goal is not reached?
 cfg$calib_maxiter_landconversion_cost <- 20           # def = 20
 # Restart from existing calibration factors (TRUE or FALSE)
-cfg$restart_landconversion_cost <- TRUE           # def = TRUE
+cfg$restart_landconversion_cost <- FALSE           # def = FALSE
 # factor determining how much the new calibration factor influences the result (0-1)
 cfg$damping_factor_landconversion_cost <- 0.98        # def= 0.98
 # set upper limit for cropland calibration factor

--- a/modules/34_urban/exo_nov21/presolve.gms
+++ b/modules/34_urban/exo_nov21/presolve.gms
@@ -9,7 +9,7 @@ vm_carbon_stock.fx(j,"urban",c_pools) = 0;
 *' Biodiversity value (BV)
 vm_bv.fx(j,"urban", potnatveg) = pcm_land(j,"urban") * fm_bii_coeff("urban",potnatveg) * fm_luh2_side_layers(j,potnatveg);
 
-if(m_year(t) <= sm_fix_SSP2,
+if(ord(t) = 1,
 	vm_land.fx(j,"urban") = i34_urban_area(t,j);
 else
 	vm_land.lo(j,"urban") = 0;


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

- bugfix: urban land only fixed in 1995, otherwise infeasible in 2000 at higher resolutions
- Change: Discard existing land conversion cost calibration factors by default in case recalibration is needed. This should make the land conversion cost calibration more robust under different model configurations
- No entry in changelog is needed because both changes affect unpublished developments

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [x] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current RC branch: RC_before
  * Default run based on the current version of the fork from which PR is made: RC_after

![Resources_Land_Cover_Cropland-53](https://user-images.githubusercontent.com/16921122/142160592-19fa05e8-c923-40d3-93f8-2a24feecdf05.png)
![Costs-7](https://user-images.githubusercontent.com/16921122/142160596-7ff9f834-c5b2-420b-88d1-25c3deba4c75.png)
![Resources_Land_Cover_Urban_Area-6](https://user-images.githubusercontent.com/16921122/142160645-04d1d9e2-ec57-47e5-b768-4ece34016970.png)


- [x] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current RC branch default : 0.82 h
  * This PR's default :  0.65 h

![Unknown-66](https://user-images.githubusercontent.com/16921122/142160402-076e622c-f6a6-4701-b7e5-93f838befa3c.png)


- [x] Added changes to `CHANGELOG.md`
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [x] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [x] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [x] Self-review of my own code.
- [x] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
