### PR TITLE
Fixed misleading warning in config check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **62_material** exo_flexreg_apr16 realization; avoid division by zero
 - **80_optimization** nlp_par realization; bugfix i2 in submission loop
 - **scripts** calibration; set NA values to 1
+- **scripts** fixed misleading warning in check_config
 
 ## [4.4.0] - 2021-12-13
 

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -238,11 +238,11 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
     lock_id <- gms::model_lock(timeout1=1)
     on.exit(gms::model_unlock(lock_id), add=TRUE)
   }
-  
+
   # Apply scenario settings ans check configuration file for consistency
   if(!is.null(scenario)) cfg <- gms::setScenario(cfg,scenario)
-  cfg <- gms::check_config(cfg, extras = "info")
-  
+  cfg <- gms::check_config(cfg, extras = c("info", "repositories"))
+
   # save model version
   cfg$info$version <- citation::read_cff("CITATION.cff")$version
 
@@ -265,8 +265,8 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
     stop(paste0("Results folder ",cfg$results_folder,
                 " could not be created because is already exists."))
   }
-  
-  # If reports for both bioenergy and GHG prices are available convert them 
+
+  # If reports for both bioenergy and GHG prices are available convert them
   # to MAgPIE input, save to the respective input folders, and use it as input
   if (!is.na(cfg$path_to_report_bioenergy) & !is.na(cfg$path_to_report_ghgprices)) {
     getReportData(cfg$path_to_report_bioenergy, cfg$mute_ghgprices_until, cfg$path_to_report_ghgprices)
@@ -405,7 +405,7 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
     file.copy("calibration_results.pdf", cfg$results_folder, overwrite=TRUE)
     cat("Yield calibration factor calculated!\n")
   }
-  
+
   land_calib_file <- "modules/39_landconversion/input/f39_calib.csv"
   if(cfg$recalibrate_landconversion_cost=="ifneeded") {
     # recalibrate if file does not exist
@@ -428,7 +428,7 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
                      best_calib = cfg$best_calib_landconversion_cost)
     cat("Land conversion cost calibration factor calculated!\n")
   }
-  
+
   # copy important files into output_folder (before MAgPIE execution)
   for(file in cfg$files2export$start) {
     try(file.copy(Sys.glob(file), cfg$results_folder, overwrite=TRUE))
@@ -543,7 +543,7 @@ getReportData <- function(path_to_report_bioenergy, mute_ghgprices_until = "y201
   mag <- time_interpolate(mag,years)
 
   .bioenergy_demand(mag)
-  
+
   # write emission files, if specified use path_to_report_ghgprices instead of the bioenergy report
   if (is.na(path_to_report_ghgprices)) {
     message("Reading ghg prices from ",path_to_report_bioenergy)


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

This PR removes a misleading warning triggered by check_config when the model is started with an additional repository in place.

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [x] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch
  * Default run based on the current version of the fork from which PR is made

- [x] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : ** mins
  * This PR's default :  ** mins

- [x] Added changes to `CHANGELOG.md`
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [x] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [x] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [x] Self-review of my own code.
- [ ] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [x] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] Changes to the model are scientifically sound
- [x] In-code comments and documentation comments are satisfactory.
- [x] model behavior/performance is satisfactory.
- [x] Requested changes (if any) were applied correctly
