### PR TITLE
Update input to rev4.67

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,15 +25,16 @@ cfg$model <- "main.gms"   #def = "main.gms"
 cfg$input <- c(regional    = "rev4.67_h12_magpie.tgz",
                cellular    = "rev4.67_h12_1998ea10_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.66_h12_validation.tgz",
-               additional  = "additional_data_rev4.08.tgz")
+               additional  = "additional_data_rev4.08.tgz",
+               calibration = "calibration_H12_sticky_feb18_free_18Jan22.tgz")
 
 # Options for calibration tgz files for different factor costs realizations, with default settings and rev4.64:
-# * (fixed_per_ton_mar18):       "calibration_H12_fixed_per_ton_mar18_30Nov21.tgz"
-# * (mixed_feb17):               "calibration_H12_mixed_feb17_30Nov21.tgz"
-# * (sticky_feb18)(free)         "calibration_H12_sticky_feb18_free_30Nov21.tgz"
-# * (sticky_feb18)(dynamic)      "calibration_H12_sticky_feb18_dynamic_30Nov21.tgz"
-# * (sticky_labor)(free)         "calibration_H12_sticky_feb18_free_30Nov21.tgz"
-# * (sticky_labor)(dynamic)      "calibration_H12_sticky_feb18_dynamic_30Nov21.tgz"
+# * (fixed_per_ton_mar18):       "calibration_H12_fixed_per_ton_mar18_18Jan22.tgz"
+# * (mixed_feb17):               "calibration_H12_mixed_feb17_18Jan22.tgz"
+# * (sticky_feb18)(free)         "calibration_H12_sticky_feb18_free_18Jan22.tgz"
+# * (sticky_feb18)(dynamic)      "calibration_H12_sticky_feb18_dynamic_18Jan22.tgz"
+# * (sticky_labor)(free)         "calibration_H12_sticky_feb18_free_18Jan22.tgz"
+# * (sticky_labor)(dynamic)      "calibration_H12_sticky_feb18_dynamic_18Jan22.tgz"
 
 #a list of repositories (please pay attention to the list format!) in which the
 #files should be searched for. Files will be searched in all repositories until

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -24,7 +24,7 @@ cfg$model <- "main.gms"   #def = "main.gms"
 # which input data sets should be used?
 cfg$input <- c(regional    = "rev4.67_h12_magpie.tgz",
                cellular    = "rev4.67_h12_1998ea10_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
-               validation  = "rev4.66_h12_validation.tgz",
+               validation  = "rev4.67_h12_validation.tgz",
                additional  = "additional_data_rev4.08.tgz",
                calibration = "calibration_H12_sticky_feb18_free_18Jan22.tgz")
 

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,11 +22,10 @@ cfg$model <- "main.gms"   #def = "main.gms"
 #### input settings ####
 
 # which input data sets should be used?
-cfg$input <- c(regional    = "rev4.66_h12_magpie.tgz",
-               cellular    = "rev4.66_h12_1998ea10_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
+cfg$input <- c(regional    = "rev4.67_h12_magpie.tgz",
+               cellular    = "rev4.67_h12_1998ea10_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.66_h12_validation.tgz",
-               additional  = "additional_data_rev4.07.tgz",
-               calibration = "calibration_H12_sticky_feb18_free_30Nov21.tgz")
+               additional  = "additional_data_rev4.08.tgz")
 
 # Options for calibration tgz files for different factor costs realizations, with default settings and rev4.64:
 # * (fixed_per_ton_mar18):       "calibration_H12_fixed_per_ton_mar18_30Nov21.tgz"


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

Update input data to rev4.67, additional data to 4.08 (India changes), and calibration files

## :wrench: Checklist for PR creator :wrench:

- [ ] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [ ] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch
  * Default run based on the current version of the fork from which PR is made

![Resources_Land_Cover_Pastures_and_Rangelands (1)](https://user-images.githubusercontent.com/37618991/150492068-cbebfc1e-1b4c-4898-9d53-ac039d9082b1.png)
![Productivity_Landuse_Intensity_Indicator_Tau (2)](https://user-images.githubusercontent.com/37618991/150492070-e8035688-753e-4966-aefe-5fa75592faf3.png)
![Resources_Land_Cover_Cropland (1)](https://user-images.githubusercontent.com/37618991/150492071-5c7c3bf5-72ae-441b-8811-1fe4a52db59d.png)
![Resources_Land_Cover_Forest (1)](https://user-images.githubusercontent.com/37618991/150492074-9f4beed7-e222-4930-8a3d-12ce0d6da8cd.png)
![Emissions_CO2_Land_Land_use_Change (1)](https://user-images.githubusercontent.com/37618991/150492075-abdc45b2-59e4-4e09-9d0b-482e5059013a.png)
![Emissions_CO2_Land](https://user-images.githubusercontent.com/37618991/150492079-399c35c2-f1ea-46d8-a9b1-320a74e3274d.png)


- [ ] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : 4.65: 0.51 mins, 4.66: 0.59
  * This PR's default :  0.59 mins

<img width="394" alt="image" src="https://user-images.githubusercontent.com/37618991/150491886-0159c635-ff62-42f3-b4b9-287a56a19f96.png">


- [ ] Added changes to `CHANGELOG.md`
- [ ] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] The new code doesn't contain declared but unused parameters or variables.
- [ ] Where relevant, In-code comments added including documentation comments.
- [ ] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [ ] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [ ] Self-review of my own code.
- [ ] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [x] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] Changes to the model are scientifically sound
- [x] In-code comments and documentation comments are satisfactory.
- [x] model behavior/performance is satisfactory.
- [x] Requested changes (if any) were applied correctly
