### PR TITLE
FSEC start script and output scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### added
 - **scripts** output/projects/FSEC_dietaryIndicators.R to create output datasets for the FSEC project
 - **scripts** output/projects/FSEC_environmentalPollutants.R to create output datasets of pollutants for the FSEC project
+- **scripts** start/projects/project_FSEC_SWF.R runs simulations which will be the basis for the FSEC Social Welfare Function calculation.
 
 ### removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### added
 - **scripts** output/projects/FSEC_dietaryIndicators.R to create output datasets for the FSEC project
+- **scripts** output/projects/FSEC_environmentalPollutants.R to create output datasets of pollutants for the FSEC project
 
 ### removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **80_optimization** nlp_par realization; bugfix i2 in submission loop
 - **scripts** calibration; set NA values to 1
 - **scripts** fixed misleading warning in check_config
+- **scripts** fixed configuration error in FSEC output scripts, FSEC_dietaryIndicators.R and FSEC_environmentalPollutants.R
 
 ## [4.4.0] - 2021-12-13
 

--- a/scripts/output/projects/FSEC_dietaryIndicators.R
+++ b/scripts/output/projects/FSEC_dietaryIndicators.R
@@ -13,26 +13,26 @@
 # Version 1.00 - Michael Crawford
 # 1.00: first working version
 
-library(lucode2)
+library(gms)
 library(magpie4)
 
 message("Starting FSEC_DietaryIndicators output runscript")
 
 ############################# BASIC CONFIGURATION #######################################
 if (!exists("source_include")) {
-    
+
     title       <- NULL
     outputdir   <- NULL
 
     # Define arguments that can be read from command line
     readArgs("outputdir", "title")
-    
+
 }
 #########################################################################################
 
 baseDir <- getwd()
 message("Script started for output directory: ", outputdir)
-load(file.path(outputdir, "config.Rdata"))
+cfg <- gms::loadConfig(file.path(outputdir, "config.yml"))
 title <- cfg$title
 
 message("Generating DietaryIndicators output for the run: ", title)
@@ -41,7 +41,7 @@ report <- getReportDietaryIndicators(gdx, scenario = title)
 
 dietaryIndicatorsOutputDir <- file.path(baseDir, "output", "DietaryIndicators")
 if (!dir.exists(dietaryIndicatorsOutputDir)) {
-    dir.create(dietaryIndicatorsOutputDir)    
+    dir.create(dietaryIndicatorsOutputDir)
 }
 
 Map(f = function(x, i) write.csv(x, file = file.path(dietaryIndicatorsOutputDir, paste0(title, "_", i, ".csv")),

--- a/scripts/output/projects/FSEC_environmentalPollution_grid.R
+++ b/scripts/output/projects/FSEC_environmentalPollution_grid.R
@@ -13,7 +13,7 @@
 # Version 1.00 - Michael Crawford
 # 1.00: first working version
 
-library(lucode2)
+library(gms)
 library(magpie4)
 
 message("Starting FSEC environmental pollutants output runscript")
@@ -31,7 +31,7 @@ if (!exists("source_include")) {
 #########################################################################################
 
 message("Script started for output directory: ", outputdir)
-load(file.path(outputdir, "config.Rdata"))
+cfg <- gms::loadConfig(file.path(outputdir, "config.yml"))
 title <- cfg$title
 
 message("Generating environmental pollutants output for the run: ", title)

--- a/scripts/output/projects/FSEC_environmentalPollution_grid.R
+++ b/scripts/output/projects/FSEC_environmentalPollution_grid.R
@@ -1,0 +1,46 @@
+# |  (C) 2008-2022 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+# |  Contact: magpie@pik-potsdam.de
+
+# --------------------------------------------------------------
+# description: Create FSEC environmental pollutants output dataset
+# comparison script: FALSE
+# ---------------------------------------------------------------
+
+# Version 1.00 - Michael Crawford
+# 1.00: first working version
+
+library(lucode2)
+library(magpie4)
+
+message("Starting FSEC environmental pollutants output runscript")
+
+############################# BASIC CONFIGURATION #######################################
+if (!exists("source_include")) {
+
+    title       <- NULL
+    outputdir   <- NULL
+
+    # Define arguments that can be read from command line
+    readArgs("outputdir", "title")
+
+}
+#########################################################################################
+
+message("Script started for output directory: ", outputdir)
+load(file.path(outputdir, "config.Rdata"))
+title <- cfg$title
+
+message("Generating environmental pollutants output for the run: ", title)
+gdx <- file.path(outputdir, "fulldata.gdx")
+
+baseDir <- getwd()
+pollutantsOutputDir <- file.path(baseDir, "output", "pollutants")
+if (!dir.exists(pollutantsOutputDir)) {
+    dir.create(pollutantsOutputDir)
+}
+
+out <- getReportGridPollutants(gdx = gdx, reportOutputDir = pollutantsOutputDir, magpieOutputDir = outputdir, scenario = title)

--- a/scripts/start/projects/project_FSEC_SWF.R
+++ b/scripts/start/projects/project_FSEC_SWF.R
@@ -1,0 +1,56 @@
+# |  (C) 2008-2021 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+# |  Contact: magpie@pik-potsdam.de
+
+# ----------------------------------------------------------
+# description: FSEC Social Welfare Function indicators start script
+# ----------------------------------------------------------
+
+library(gms)
+source("scripts/start_functions.R")
+source("scripts/performance_test.R")
+source("config/default.cfg")
+
+# Set defaults
+codeCheck <- TRUE
+
+input <- c(regional    = "rev4.67_h12_magpie.tgz",
+           cellular    = "rev4.67_h12_1998ea10_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
+           validation  = "rev4.67_h12_validation.tgz",
+           additional  = "additional_data_rev4.08.tgz",
+           calibration = "calibration_H12_sticky_feb18_free_18Jan22.tgz")
+
+# General settings
+general_settings <- function(title) {
+  source("config/default.cfg")
+  cfg$input <- input
+  cfg <- lucode::setScenario(cfg, "nocc")
+  cfg$recalibrate <- FALSE
+  return(cfg)
+}
+
+
+# -----------------------------------------------------------------------------------------------------------------
+# Scenario runs
+
+### Business-as-usual
+cfg <- general_settings(title = "FSEC_SSP2")
+cfg <- lucode::setScenario(cfg, "SSP2")
+
+start_run(cfg = cfg, codeCheck = codeCheck)
+
+
+### SSP1
+cfg <- general_settings(title = "FSEC_SSP1")
+cfg <- lucode::setScenario(cfg, "SSP1")
+
+start_run(cfg = cfg, codeCheck = codeCheck)
+
+
+# -----------------------------------------------------------------------------------------------------------------
+# Output generation
+
+cfg$output <- c(cfg$output, "disaggregation_BII", "FSEC_dietaryIndicators", "FSEC_environmentalPollution_grid")

--- a/scripts/start/projects/project_FSEC_SWF.R
+++ b/scripts/start/projects/project_FSEC_SWF.R
@@ -26,10 +26,11 @@ input <- c(regional    = "rev4.67_h12_magpie.tgz",
 # General settings
 general_settings <- function(title) {
   source("config/default.cfg")
-  cfg$input <- input
-  cfg <- gms::setScenario(cfg, "nocc")
+  cfg$input       <- input
+  cfg             <- gms::setScenario(cfg, "nocc")
+  cfg$title       <- title
   cfg$recalibrate <- FALSE
-  cfg$output <- c(cfg$output,
+  cfg$output      <- c(cfg$output,
                   "extra/disaggregation_BII", "projects/FSEC_dietaryIndicators", "projects/FSEC_environmentalPollution_grid")
   return(cfg)
 }

--- a/scripts/start/projects/project_FSEC_SWF.R
+++ b/scripts/start/projects/project_FSEC_SWF.R
@@ -53,4 +53,5 @@ start_run(cfg = cfg, codeCheck = codeCheck)
 # -----------------------------------------------------------------------------------------------------------------
 # Output generation
 
-cfg$output <- c(cfg$output, "disaggregation_BII", "FSEC_dietaryIndicators", "FSEC_environmentalPollution_grid")
+cfg$output <- c(cfg$output,
+                "extra/disaggregation_BII", "projects/FSEC_dietaryIndicators", "projects/FSEC_environmentalPollution_grid")

--- a/scripts/start/projects/project_FSEC_SWF.R
+++ b/scripts/start/projects/project_FSEC_SWF.R
@@ -29,6 +29,9 @@ general_settings <- function(title) {
   cfg$input <- input
   cfg <- lucode::setScenario(cfg, "nocc")
   cfg$recalibrate <- FALSE
+  cfg$output <- c(cfg$output,
+                  "extra/disaggregation_BII", "projects/FSEC_dietaryIndicators", "projects/FSEC_environmentalPollution_grid")
+
   return(cfg)
 }
 
@@ -48,10 +51,3 @@ cfg <- general_settings(title = "FSEC_SSP1")
 cfg <- lucode::setScenario(cfg, "SSP1")
 
 start_run(cfg = cfg, codeCheck = codeCheck)
-
-
-# -----------------------------------------------------------------------------------------------------------------
-# Output generation
-
-cfg$output <- c(cfg$output,
-                "extra/disaggregation_BII", "projects/FSEC_dietaryIndicators", "projects/FSEC_environmentalPollution_grid")

--- a/scripts/start/projects/project_FSEC_SWF.R
+++ b/scripts/start/projects/project_FSEC_SWF.R
@@ -15,7 +15,7 @@ source("scripts/performance_test.R")
 source("config/default.cfg")
 
 # Set defaults
-codeCheck <- TRUE
+codeCheck <- FALSE
 
 input <- c(regional    = "rev4.67_h12_magpie.tgz",
            cellular    = "rev4.67_h12_1998ea10_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
@@ -27,11 +27,10 @@ input <- c(regional    = "rev4.67_h12_magpie.tgz",
 general_settings <- function(title) {
   source("config/default.cfg")
   cfg$input <- input
-  cfg <- lucode::setScenario(cfg, "nocc")
+  cfg <- gms::setScenario(cfg, "nocc")
   cfg$recalibrate <- FALSE
   cfg$output <- c(cfg$output,
                   "extra/disaggregation_BII", "projects/FSEC_dietaryIndicators", "projects/FSEC_environmentalPollution_grid")
-
   return(cfg)
 }
 
@@ -41,13 +40,13 @@ general_settings <- function(title) {
 
 ### Business-as-usual
 cfg <- general_settings(title = "FSEC_SSP2")
-cfg <- lucode::setScenario(cfg, "SSP2")
+cfg <- gms::setScenario(cfg, "SSP2")
 
 start_run(cfg = cfg, codeCheck = codeCheck)
 
 
 ### SSP1
 cfg <- general_settings(title = "FSEC_SSP1")
-cfg <- lucode::setScenario(cfg, "SSP1")
+cfg <- gms::setScenario(cfg, "SSP1")
 
 start_run(cfg = cfg, codeCheck = codeCheck)

--- a/scripts/start/projects/project_FSEC_SWF.R
+++ b/scripts/start/projects/project_FSEC_SWF.R
@@ -30,6 +30,7 @@ general_settings <- function(title) {
   cfg             <- gms::setScenario(cfg, "nocc")
   cfg$title       <- title
   cfg$recalibrate <- FALSE
+  cfg$qos         <- "priority_maxMem"
   cfg$output      <- c(cfg$output,
                   "extra/disaggregation_BII", "projects/FSEC_dietaryIndicators", "projects/FSEC_environmentalPollution_grid")
   return(cfg)


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

- Addition of a start script (project_FSEC_SWF.R) and an output script (FSEC_environmentalPollutants_grid.R), with modifications to a third output script (FSEC_dietaryIndicators.R). These scripts are all used in the FSEC project.

## :wrench: Checklist for PR creator :wrench:

- [X] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).
- [X] Added changes to `CHANGELOG.md`
- [X] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [X] No hard coded numbers and cluster/country/region names.
- [X] The new code doesn't contain declared but unused parameters or variables.
- [X] Where relevant, In-code comments added including documentation comments.
- [X] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [X] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [X] Self-review of my own code.

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [x] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] No unnecessary increase in module interfaces
- [x] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [x] In-code comments and documentation comments are satisfactory.
- [x] model behavior/performance is satisfactory.
- [x] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [x] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] Changes to the model are scientifically sound
- [x] In-code comments and documentation comments are satisfactory.
- [x] model behavior/performance is satisfactory.
- [x] Requested changes (if any) were applied correctly
