### PR TITLE
Add GDP share constraint for tech cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### changed
- - **config** added s13_tech_cost_gdp_share setting for tech cost upper bound as share of GDP PPP
-- **13_tc** changed vm_tech_cost upper bound to share of regional GDP PPP (s13_tech_cost_gdp_share)
+ - **config** added s13_max_gdp_shr setting for tech cost upper bound as share of GDP PPP
+- **13_tc** changed vm_tech_cost upper bound to share of regional GDP PPP (s13_max_gdp_shr)
  - **scripts**The disaggregation_LUH2.R was extended to include the changes used to generate ISIMIP3b maps for LUH harmonization. The largest changes are: 1) The convertLUH function now breaks the grid level magpie objects by groups of years, then creates the raster for the groups and aggregates them to create the final map at a quarter of a degree resolution (this speeds up the process). 2) The mapping between LUH and MAgPIE is now defined by country and magpie-LUH types (not 1 to 1 anymore). 3) The split of MAgPIE's pasture land type between pasture and rangeland changed. Rangeland is assumed to stay constant after 2015, and changes in MAgPIE's pasture are due to pasture. 4) IFs were added so if a certain map already exists in the output folder, it will not generate it once again. 5) Flooded land now corresponds to a share of rice cropland, based on historical values. 6) To speed calculations, yields are read at the cell level, the crops are aggregated based on the new MAgPIE-LUH mapping, and then disaggregated to grid level.
  - **56_ghg_policy** additional scenarios for c56_emis_policy
  - **09_drivers** separation of GDP and population scenarios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### changed
- - **config** Add new tech cost limit switch (c13_tech_cost_GDP) and GDP share limit setting (s13_tech_cost_gdp_share)
-- **13_tc** Changed vm_tech_cost.up to be switchable (c13_tech_cost_GDP) between default fixed upper bound and GDP share upper bound (s13_tech_cost_gdp_share)
+ - **config** added s13_tech_cost_gdp_share setting for tech cost upper bound as share of GDP PPP
+- **13_tc** changed vm_tech_cost upper bound to share of regional GDP PPP (s13_tech_cost_gdp_share)
  - **scripts**The disaggregation_LUH2.R was extended to include the changes used to generate ISIMIP3b maps for LUH harmonization. The largest changes are: 1) The convertLUH function now breaks the grid level magpie objects by groups of years, then creates the raster for the groups and aggregates them to create the final map at a quarter of a degree resolution (this speeds up the process). 2) The mapping between LUH and MAgPIE is now defined by country and magpie-LUH types (not 1 to 1 anymore). 3) The split of MAgPIE's pasture land type between pasture and rangeland changed. Rangeland is assumed to stay constant after 2015, and changes in MAgPIE's pasture are due to pasture. 4) IFs were added so if a certain map already exists in the output folder, it will not generate it once again. 5) Flooded land now corresponds to a share of rice cropland, based on historical values. 6) To speed calculations, yields are read at the cell level, the crops are aggregated based on the new MAgPIE-LUH mapping, and then disaggregated to grid level.
  - **56_ghg_policy** additional scenarios for c56_emis_policy
  - **09_drivers** separation of GDP and population scenarios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### changed
+ - **config** Add new tech cost limit switch (c13_tech_cost_GDP) and GDP share limit setting (s13_tech_cost_gdp_share)
+- **13_tc** Changed vm_tech_cost.up to be switchable (c13_tech_cost_GDP) between default fixed upper bound and GDP share upper bound (s13_tech_cost_gdp_share)
  - **scripts**The disaggregation_LUH2.R was extended to include the changes used to generate ISIMIP3b maps for LUH harmonization. The largest changes are: 1) The convertLUH function now breaks the grid level magpie objects by groups of years, then creates the raster for the groups and aggregates them to create the final map at a quarter of a degree resolution (this speeds up the process). 2) The mapping between LUH and MAgPIE is now defined by country and magpie-LUH types (not 1 to 1 anymore). 3) The split of MAgPIE's pasture land type between pasture and rangeland changed. Rangeland is assumed to stay constant after 2015, and changes in MAgPIE's pasture are due to pasture. 4) IFs were added so if a certain map already exists in the output folder, it will not generate it once again. 5) Flooded land now corresponds to a share of rice cropland, based on historical values. 6) To speed calculations, yields are read at the cell level, the crops are aggregated based on the new MAgPIE-LUH mapping, and then disaggregated to grid level.
  - **56_ghg_policy** additional scenarios for c56_emis_policy
  - **09_drivers** separation of GDP and population scenarios

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -275,7 +275,7 @@ cfg$gms$c13_tccost <- "medium"		# def = medium
 cfg$gms$s13_ignore_tau_historical <- 1		# def = 1
 
 # * Maximum regional tech cost expressed as share of reginal GDP
-cfg$gms$s13_tech_cost_gdp_share <- 0.002 # def = 0.002
+cfg$gms$s13_max_gdp_shr <- 0.002 # def = 0.002
 
 
 # ***---------------------    14_yield    --------------------------------------

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -271,8 +271,17 @@ cfg$gms$tc <- "endo_jan22"              # def = endo_jan22
 # * tc cost scenario crops: low, medium or high
 cfg$gms$c13_tccost <- "medium"		# def = medium
 
-# * ignore historial tau (1) or use it as lower bound (0)
+# * ignore historical tau (1) or use it as lower bound (0)
 cfg$gms$s13_ignore_tau_historical <- 1		# def = 1
+
+# * Use fixed upper bound (0) or GDP-relative upper bound  (1) for
+# * regional tech cost per year
+cfg$gms$c13_tech_cost_GDP <- 0 # def = 0
+
+# * Maximum regional tech cost expressed as share of reginal GDP applied when
+# * cfg$gms$c13_tech_cost_GDP <- 1
+cfg$gms$s13_tech_cost_gdp_share <- 0.002 # def = 0.002
+
 
 # ***---------------------    14_yield    --------------------------------------
 # * (managementcalib_aug19): calibrate potential LPJmL-yields to FAO regional numbers,

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -274,12 +274,7 @@ cfg$gms$c13_tccost <- "medium"		# def = medium
 # * ignore historical tau (1) or use it as lower bound (0)
 cfg$gms$s13_ignore_tau_historical <- 1		# def = 1
 
-# * Use fixed upper bound (0) or GDP-relative upper bound  (1) for
-# * regional tech cost per year
-cfg$gms$c13_tech_cost_GDP <- 0 # def = 0
-
-# * Maximum regional tech cost expressed as share of reginal GDP applied when
-# * cfg$gms$c13_tech_cost_GDP <- 1
+# * Maximum regional tech cost expressed as share of reginal GDP
 cfg$gms$s13_tech_cost_gdp_share <- 0.002 # def = 0.002
 
 

--- a/modules/13_tc/endo_jan22/input.gms
+++ b/modules/13_tc/endo_jan22/input.gms
@@ -8,7 +8,7 @@
 
 scalars
  s13_ignore_tau_historical	ignore historical tau (1) or use it as lower bound (0) (binary) / 1 /
- s13_tech_cost_gdp_share Maximum tech cost as share of regional GDP / 0.002 /
+ s13_max_gdp_shr Maximum tech cost as share of regional GDP / 1 /
 ;
 
 parameter fm_tau1995(h) Agricultural land use intensity tau in 1995 (1)

--- a/modules/13_tc/endo_jan22/input.gms
+++ b/modules/13_tc/endo_jan22/input.gms
@@ -7,7 +7,9 @@
 
 
 scalars
- s13_ignore_tau_historical	ignore historial tau (1) or use it as lower bound (0) (binary) / 1 /
+ s13_ignore_tau_historical	ignore historical tau (1) or use it as lower bound (0) (binary) / 1 /
+ c13_tech_cost_GDP Use fixed upper bound (0) or GDP-relative upper bound  (1) for regional tech cost per year / 0 /
+ s13_tech_cost_gdp_share Maximum tech cost as share of regional GDP / 0.002 /
 ;
 
 parameter fm_tau1995(h) Agricultural land use intensity tau in 1995 (1)

--- a/modules/13_tc/endo_jan22/input.gms
+++ b/modules/13_tc/endo_jan22/input.gms
@@ -8,7 +8,6 @@
 
 scalars
  s13_ignore_tau_historical	ignore historical tau (1) or use it as lower bound (0) (binary) / 1 /
- c13_tech_cost_GDP Use fixed upper bound (0) or GDP-relative upper bound  (1) for regional tech cost per year / 0 /
  s13_tech_cost_gdp_share Maximum tech cost as share of regional GDP / 0.002 /
 ;
 

--- a/modules/13_tc/endo_jan22/presolve.gms
+++ b/modules/13_tc/endo_jan22/presolve.gms
@@ -26,4 +26,9 @@ else
 );
 
 vm_tau.up(h,tautype) = 2*pcm_tau(h,tautype);
-vm_tech_cost.up(i) = 10e9;
+
+* constrain tech cost either to 10e9 mio. USD05PPP per yr per region or to a
+* share of regional GDP
+vm_tech_cost.up(i) =
+  (1 - c13_tech_cost_GDP) * 10e9 +
+  c13_tech_cost_GDP * sum((i_to_iso(i,iso),ct), im_gdp_pc_ppp_iso(ct,iso) * im_pop_iso(ct,iso)) * s13_tech_cost_gdp_share;

--- a/modules/13_tc/endo_jan22/presolve.gms
+++ b/modules/13_tc/endo_jan22/presolve.gms
@@ -27,9 +27,12 @@ else
 
 vm_tau.up(h,tautype) = 2*pcm_tau(h,tautype);
 
-* constrain tech cost either to 10e9 mio. USD05PPP per yr per region or to a
-* share of regional GDP
+* We constrain tech cost to a defined share of regional GDP to avoid unrealistically
+* high endogenous tech investments
 vm_tech_cost.up(i) =
 	sum((i_to_iso(i,iso),ct), im_gdp_pc_ppp_iso(ct,iso) * im_pop_iso(ct,iso)) * s13_max_gdp_shr;
 
-vm_tech_cost.L(i) = vm_tech_cost.up(i);
+* We set the initial solving basis for the tech cost to its upper bound to support the solver in finding
+* a proper solution. Without such initial values, the model leave tech cost at 0 and as such ignore tau
+* as an efficient part of the optimal solution.
+vm_tech_cost.l(i) = vm_tech_cost.up(i);

--- a/modules/13_tc/endo_jan22/presolve.gms
+++ b/modules/13_tc/endo_jan22/presolve.gms
@@ -30,6 +30,6 @@ vm_tau.up(h,tautype) = 2*pcm_tau(h,tautype);
 * constrain tech cost either to 10e9 mio. USD05PPP per yr per region or to a
 * share of regional GDP
 vm_tech_cost.up(i) =
-	sum((i_to_iso(i,iso),ct), im_gdp_pc_ppp_iso(ct,iso) * im_pop_iso(ct,iso)) * s13_tech_cost_gdp_share;
+	sum((i_to_iso(i,iso),ct), im_gdp_pc_ppp_iso(ct,iso) * im_pop_iso(ct,iso)) * s13_max_gdp_shr;
 
 vm_tech_cost.L(i) = vm_tech_cost.up(i);

--- a/modules/13_tc/endo_jan22/presolve.gms
+++ b/modules/13_tc/endo_jan22/presolve.gms
@@ -30,5 +30,6 @@ vm_tau.up(h,tautype) = 2*pcm_tau(h,tautype);
 * constrain tech cost either to 10e9 mio. USD05PPP per yr per region or to a
 * share of regional GDP
 vm_tech_cost.up(i) =
-  (1 - c13_tech_cost_GDP) * 10e9 +
-  c13_tech_cost_GDP * sum((i_to_iso(i,iso),ct), im_gdp_pc_ppp_iso(ct,iso) * im_pop_iso(ct,iso)) * s13_tech_cost_gdp_share;
+	sum((i_to_iso(i,iso),ct), im_gdp_pc_ppp_iso(ct,iso) * im_pop_iso(ct,iso)) * s13_tech_cost_gdp_share;
+
+vm_tech_cost.L(i) = vm_tech_cost.up(i);

--- a/modules/13_tc/exo/not_used.txt
+++ b/modules/13_tc/exo/not_used.txt
@@ -1,0 +1,3 @@
+name,type,reason
+im_pop_iso,input,questionnaire
+im_gdp_pc_ppp_iso,input,questionnaire


### PR DESCRIPTION
Change tech cost upper bound to a config-set GDP share

## :bird: Purpose of this PR :bird:

- This PR changes the tech cost upper bound in the endo TC realization to a permille share ofthe regional GDP (PPP). As the current default is purely technical, this is a necessary constraint for price-driven runs that may push TC and TC cost to extreme heights.

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* **Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg**
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [x] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch
  * Default run based on the current version of the fork from which PR is made

![Costs_TC](https://user-images.githubusercontent.com/72768733/165549261-5372ab71-0890-4f77-98e2-7983a1865a50.png)

![Productivity_Landuse_Intensity_Indicator_Tau_cropland](https://user-images.githubusercontent.com/72768733/165549285-397fc095-80ce-4107-b96f-1f0cebbcff8f.png)

- [x] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : 33 mins
  * This PR's default :  37 mins

- [x] Added changes to `CHANGELOG.md`
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [x] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [x] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [x] Self-review of my own code.
- [x] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [x] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] Changes to the model are scientifically sound
- [x] In-code comments and documentation comments are satisfactory.
- [x] model behavior/performance is satisfactory.
- [x] Requested changes (if any) were applied correctly
