### PR TITLE
Small update in 44_biodiversity

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -999,9 +999,9 @@ cfg$gms$s44_bii_lower_bound <- 0	#def = 0
 
 # * Indicative outcomes for `s44_bii_lower_bound` based on c44_bii_decrease = 1, s44_start_year = 2025 and s44_target_year = 2100.
 # *		< 0.7:  continued decrease of global BII
-# *		0.72: no further decrease of global BII
-# *		0.75: moderate increase of global BII
-# *		>= 0.8: very strong increase of global BII accomplished by high conversion of pasture to non-forest natural land
+# *		0.74: no further decrease of global BII
+# *		0.76: moderate increase of global BII
+# *		>= 0.78: (very) strong increase of global BII accomplished by high conversion of pasture to non-forest natural land
 
 # * BII lower bound implementation (binary)
 # *   options:   0 (no decrease allowed) or 1 (decrease allowed)

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -1005,7 +1005,7 @@ cfg$gms$s44_bii_lower_bound <- 0	#def = 0
 
 # * BII lower bound implementation (binary)
 # *   options:   0 (no decrease allowed) or 1 (decrease allowed)
-# * 0 (no decrease allowed): If the biome-level BII in the start year exceeds the lower bound defined in `s44_bii_lower_bound, the BII value in the start year is used as lower bound for BII in all future time steps.
+# * 0 (no decrease allowed): If the biome-level BII in `s44_start_year` exceeds the lower bound defined in `s44_bii_lower_bound, the BII value in the start year is used as lower bound for BII in all future time steps.
 # * 1 (decrease allowed): The lower bound for BII can decrease over time, depending on the biome-level BII in the start year and the lower bound defined in `s44_bii_lower_bound.
 # * Note: The BII constraint is defined as a minium constraint. Therefore, the actual BII can be higher than the lower bound. 
 cfg$gms$c44_bii_decrease <- 1		#def = 1

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -971,7 +971,7 @@ cfg$gms$c43_watavail_scenario  <- "cc"   # def = "cc"
 
 
 # ***-------------------------    44_biodiversity ------------------------------
-# * (bii_target): Biodiversity Intactness Index (BII) calculation at the level of 71 biomes with the option to define a target for BII increase
+# * (bii_target): Biodiversity Intactness Index (BII) for 71 biomes with the option to define a lower bound for BII at biome level
 # * (bv_btc_mar21): Global optimization of range-rarity weighted biodiversity stocks based on a price for losses and gains
 cfg$gms$biodiversity <- "bii_target"    # def = bii_target
 
@@ -982,8 +982,9 @@ cfg$gms$s44_start_year <- 2025		#def = 2025
 cfg$gms$s44_target_year <- 2100		#def = 2100
 
 # ** Options for realization `bii_target`
-# * This realisation allows to define a target value and year for the Biodiversity Intactness Index (BII)
-# * that is applied in each biome type of each biogeographic realm or at the global level. 
+# * This realisation allows to define a lower bound for the Biodiversity Intactness Index (BII) 
+# * that is applied in each biome type of each biogeographic realm. 
+# * The lower bound increases in each biome linearly from the BII level in the start year (s44_start_year) to the value defined in `s44_bii_lower_bound` in the target year (s44_target_year).
 # * The BII has been proposed as a control variable for changes in ecosystem functioning at the global scale
 # * and has shown to capture increasing levels of ecosystem degradation. Steffen et al. (2015, 10.1126/science.1259855) have proposed 
 # * a premliminary boundary of 0.9 at the biome level (safe space) but with an uncertainty range of 0.9-0.3,
@@ -993,22 +994,22 @@ cfg$gms$s44_target_year <- 2100		#def = 2100
 # * in 2000. https://www.nhm.ac.uk/our-science/data/biodiversity-indicators/biodiversity-intactness-index-data
 # * In MAgPIE, the global BII value is about 0.8 in 1995 and declines to 0.795 by 2020. 
 
-# * BII target mode (binary)
-# *   options:   0 (global) or 1 (biome)
-# * In case of 0 (global), the BII target `s44_bii_target` is converted into increasing lower bounds for the BII in each of the 71 biomes with to goal to meet the BII target at global level in the target year.
-# * In case of 1 (biome), the BII target `s44_bii_target` is set as lower bound in each of the 71 biomes.
-cfg$gms$c44_bii_target_mode <- 1	#def = 1
+# * Lower bound for BII in target year; plausible range: 0-1
+cfg$gms$s44_bii_lower_bound <- 0	#def = 0
 
-# * Target value for BII in target year; plausible range: 0-1
-# * In case a biome has a higher BII value than the calculated lower bound, the current BII value is set as lower bound.
-cfg$gms$s44_bii_target <- 0		#def = 0
+# * Indicative outcomes for `s44_bii_lower_bound` based on c44_bii_decrease = 1, s44_start_year = 2025 and s44_target_year = 2100.
+# *		< 0.7:  continued decrease of global BII
+# *		0.72: no further decrease of global BII
+# *		0.75: moderate increase of global BII
+# *		>= 0.8: very strong increase of global BII accomplished by high conversion of pasture to non-forest natural land
 
-# * Indicative outcomes for `s44_bii_target` based on c44_bii_target_mode = 0, s44_start_year = 2025 and s44_target_year = 2100.
-# *		0: continued decrease of global BII
-# *		0.79: no further decrease of global BII
-# *		0.80: moderate increase of global BII
-# *		0.81: stronger increase of global BII
-# *		>= 0.82: very strong increase of global BII accomplished by high conversion of pasture to non-forest natural land
+# * BII lower bound implementation (binary)
+# *   options:   0 (no decrease allowed) or 1 (decrease allowed)
+# * 0 (no decrease allowed): If the biome-level BII in the start year exceeds the lower bound defined in `s44_bii_lower_bound, the BII value in the start year is used as lower bound for BII in all future time steps.
+# * 1 (decrease allowed): The lower bound for BII can decrease over time, depending on the biome-level BII in the start year and the lower bound defined in `s44_bii_lower_bound.
+# * Note: The BII constraint is defined as a minium constraint. Therefore, the actual BII can be higher than the lower bound. 
+cfg$gms$c44_bii_decrease <- 1		#def = 1
+
 
 # ** Options for realization `bv_btc_mar21`
 

--- a/modules/44_biodiversity/bii_target/declarations.gms
+++ b/modules/44_biodiversity/bii_target/declarations.gms
@@ -14,7 +14,7 @@ positive variables
 ;
 
 parameters
- p44_bii_target(t,biome44)				Interpolated target values for BII over time (1)
+ p44_bii_lower_bound(t,biome44)				Interpolated target values for BII over time (1)
  p44_start_value(biome44)				Start value for BII (1)
  p44_target_value(biome44)				Target value for BII (1)
 ;

--- a/modules/44_biodiversity/bii_target/declarations.gms
+++ b/modules/44_biodiversity/bii_target/declarations.gms
@@ -14,9 +14,9 @@ positive variables
 ;
 
 parameters
- p44_bii_lower_bound(t,biome44)				Interpolated target values for BII over time (1)
- p44_start_value(biome44)				Start value for BII (1)
- p44_target_value(biome44)				Target value for BII (1)
+ p44_bii_lower_bound(t,biome44)			Interpolated lower bound for BII over time (1)
+ p44_start_value(biome44)				Start value for BII lower bound (1)
+ p44_target_value(biome44)				Target value for BII lower bound (1)
 ;
 
 equations

--- a/modules/44_biodiversity/bii_target/equations.gms
+++ b/modules/44_biodiversity/bii_target/equations.gms
@@ -13,14 +13,14 @@
  					=e=
  					(sum((j2,potnatveg,landcover44), vm_bv(j2,landcover44,potnatveg) * f44_biome(j2,biome44)) / sum((j2,land), pcm_land(j2,land) * f44_biome(j2,biome44)));
 
-*' For each of the 71 biomes, the BII has to meet a minium level based on `s44_bii_target`.
+*' For each of the 71 biomes, the BII has to meet a minium level based on `s44_bii_lower_bound`.
 *' `v44_bii_missing` is a technical variable to maintain feasibility in case `v44_bii` cannot be increased.
  					
  q44_bii_target(biome44)$(sum(j2, f44_biome(j2,biome44)) > 0) .. 					
- 					v44_bii(biome44) + v44_bii_missing(biome44) =g= sum(ct, p44_bii_target(ct,biome44));
+ 					v44_bii(biome44) + v44_bii_missing(biome44) =g= sum(ct, p44_bii_lower_bound(ct,biome44));
 
 *' Costs accrue only for `v44_bii_missing`. In the best case costs should be zero or close to zero.
-*' Costs strongly depend on the choice of `s44_bii_target`.
+*' Costs strongly depend on the choice of `s44_bii_lower_bound`.
 
  q44_cost ..	sum(j2, vm_cost_bv_loss(j2)) =e= 
 					sum(biome44, v44_bii_missing(biome44)) * s44_cost_bii_missing;

--- a/modules/44_biodiversity/bii_target/input.gms
+++ b/modules/44_biodiversity/bii_target/input.gms
@@ -6,10 +6,10 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 scalars 
- s44_bii_lower_bound					Target value for global BII (1)									/ 0 /
- c44_bii_nodecrease			BII target mode (binary)										/ 1 /
- s44_target_year				Year in which the BII target value is reached  (1)				/ 2100 /
- s44_start_year					Start year for interpolation towards BII target value (1) 		/ 2025 /
+ s44_bii_lower_bound			Lower bound for BII (1)											/ 0 /
+ c44_bii_decrease				Implementation of lower bound for BII (binary)					/ 1 /
+ s44_target_year				Year in which the BII lower bound is reached  (1)				/ 2100 /
+ s44_start_year					Start year for interpolation towards BII lower bound (1) 		/ 2025 /
  s44_cost_bii_missing			Technical costs for missing BII increase (USD per unit of BII)	/ 1000000 /
 ;
 

--- a/modules/44_biodiversity/bii_target/input.gms
+++ b/modules/44_biodiversity/bii_target/input.gms
@@ -6,8 +6,8 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 scalars 
- s44_bii_target					Target value for global BII (1)									/ 0 /
- c44_bii_target_mode			BII target mode (binary)										/ 1 /
+ s44_bii_lower_bound					Target value for global BII (1)									/ 0 /
+ c44_bii_nodecrease			BII target mode (binary)										/ 1 /
  s44_target_year				Year in which the BII target value is reached  (1)				/ 2100 /
  s44_start_year					Start year for interpolation towards BII target value (1) 		/ 2025 /
  s44_cost_bii_missing			Technical costs for missing BII increase (USD per unit of BII)	/ 1000000 /

--- a/modules/44_biodiversity/bii_target/preloop.gms
+++ b/modules/44_biodiversity/bii_target/preloop.gms
@@ -9,6 +9,6 @@ v44_bii.l(biome44) = 0.75;
 
 v44_bii.fx(biome44)$(sum(j, f44_biome(j,biome44)) = 0) = 0;
 v44_bii_missing.fx(biome44)$(sum(j, f44_biome(j,biome44)) = 0) = 0;
-p44_bii_target(t,biome44) = 0;
+p44_bii_lower_bound(t,biome44) = 0;
 
 vm_bv.l(j,landcover44,potnatveg) = 0;

--- a/modules/44_biodiversity/bii_target/presolve.gms
+++ b/modules/44_biodiversity/bii_target/presolve.gms
@@ -14,9 +14,9 @@ if(m_year(t) = s44_start_year AND s44_bii_lower_bound > 0,
 * Linear increase of BII target values at biome level from start year to target year, and constant values thereafter.
 	p44_bii_lower_bound(t2,biome44) = p44_start_value(biome44) + ((m_year(t2) - s44_start_year) / (s44_target_year - s44_start_year)) * (p44_target_value(biome44) - p44_start_value(biome44));
 	p44_bii_lower_bound(t2,biome44)$(m_year(t2) > s44_target_year) = p44_target_value(biome44);
-	if(c44_bii_nodecrease = 1,
+	if(c44_bii_decrease = 0,
 		p44_bii_lower_bound(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = v44_bii.l(biome44);		
-	elseif c44_bii_nodecrease = 0,
+	elseif c44_bii_decrease = 1,
 		p44_bii_lower_bound(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = p44_target_value(biome44);
 	);
 	p44_bii_lower_bound(t2,biome44)$(p44_bii_lower_bound(t2,biome44) >= 1) = 1;

--- a/modules/44_biodiversity/bii_target/presolve.gms
+++ b/modules/44_biodiversity/bii_target/presolve.gms
@@ -19,6 +19,7 @@ if(m_year(t) = s44_start_year AND s44_bii_target > 0,
 	p44_bii_target(t2,biome44) = p44_start_value(biome44) + ((m_year(t2) - s44_start_year) / (s44_target_year - s44_start_year)) * (p44_target_value(biome44) - p44_start_value(biome44));
 	p44_bii_target(t2,biome44)$(m_year(t2) > s44_target_year) = p44_target_value(biome44);
 *	p44_bii_target(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = v44_bii.l(biome44);
+	p44_bii_target(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = p44_target_value(biome44);
 	p44_bii_target(t2,biome44)$(p44_bii_target(t2,biome44) >= 1) = 1;
 	p44_bii_target(t2,biome44)$(m_year(t2) < s44_start_year) = 0;
 	p44_bii_target(t2,biome44)$(sum(j, f44_biome(j,biome44)) = 0) = 0;

--- a/modules/44_biodiversity/bii_target/presolve.gms
+++ b/modules/44_biodiversity/bii_target/presolve.gms
@@ -18,12 +18,13 @@ if(m_year(t) = s44_start_year AND s44_bii_target > 0,
 * Linear increase of BII target values at biome level from start year to target year, and constant values thereafter.
 	p44_bii_target(t2,biome44) = p44_start_value(biome44) + ((m_year(t2) - s44_start_year) / (s44_target_year - s44_start_year)) * (p44_target_value(biome44) - p44_start_value(biome44));
 	p44_bii_target(t2,biome44)$(m_year(t2) > s44_target_year) = p44_target_value(biome44);
-	p44_bii_target(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = v44_bii.l(biome44);
+*	p44_bii_target(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = v44_bii.l(biome44);
 	p44_bii_target(t2,biome44)$(p44_bii_target(t2,biome44) >= 1) = 1;
 	p44_bii_target(t2,biome44)$(m_year(t2) < s44_start_year) = 0;
 	p44_bii_target(t2,biome44)$(sum(j, f44_biome(j,biome44)) = 0) = 0;
 * The lower bound of `v44_bii` is set to the current level if the current level of a biome is above the target to avoid a reduction of BII in combination with `v44_bii_missing`.
-	v44_bii.lo(biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = v44_bii.l(biome44);
+*	v44_bii.lo(biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = v44_bii.l(biome44);
+	v44_bii.lo(biome44) = p44_bii_target(t,biome44);
 	display p44_bii_target;
 );
 

--- a/modules/44_biodiversity/bii_target/presolve.gms
+++ b/modules/44_biodiversity/bii_target/presolve.gms
@@ -5,27 +5,25 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
-if(m_year(t) = s44_start_year AND s44_bii_target > 0,
+if(m_year(t) = s44_start_year AND s44_bii_lower_bound > 0,
 * The start value for the linear interpolation is the BII at biome level in the start year.
 	p44_start_value(biome44) = v44_bii.l(biome44);
-* In the global case (s44_bii_target_mode = 0), the target value is the start value scaled with the ratio of the global BII target `s44_bii_target` and global BII level in the start year
-	if(c44_bii_target_mode = 0,
-		p44_target_value(biome44) = (s44_bii_target / (sum((j,potnatveg,landcover44), vm_bv.l(j,landcover44,potnatveg)) / sum((j,land), pcm_land(j,land)))) * v44_bii.l(biome44);
-	elseif c44_bii_target_mode = 1,
-		p44_target_value(biome44) = s44_bii_target;
-	);
+* The target value for the linear interpolation is the lower bound defined in `s44_bii_lower_bound`.
+	p44_target_value(biome44) = s44_bii_lower_bound;
 	
 * Linear increase of BII target values at biome level from start year to target year, and constant values thereafter.
-	p44_bii_target(t2,biome44) = p44_start_value(biome44) + ((m_year(t2) - s44_start_year) / (s44_target_year - s44_start_year)) * (p44_target_value(biome44) - p44_start_value(biome44));
-	p44_bii_target(t2,biome44)$(m_year(t2) > s44_target_year) = p44_target_value(biome44);
-*	p44_bii_target(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = v44_bii.l(biome44);
-	p44_bii_target(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = p44_target_value(biome44);
-	p44_bii_target(t2,biome44)$(p44_bii_target(t2,biome44) >= 1) = 1;
-	p44_bii_target(t2,biome44)$(m_year(t2) < s44_start_year) = 0;
-	p44_bii_target(t2,biome44)$(sum(j, f44_biome(j,biome44)) = 0) = 0;
-* The lower bound of `v44_bii` is set to the current level if the current level of a biome is above the target to avoid a reduction of BII in combination with `v44_bii_missing`.
-*	v44_bii.lo(biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = v44_bii.l(biome44);
-	v44_bii.lo(biome44) = p44_bii_target(t,biome44);
-	display p44_bii_target;
+	p44_bii_lower_bound(t2,biome44) = p44_start_value(biome44) + ((m_year(t2) - s44_start_year) / (s44_target_year - s44_start_year)) * (p44_target_value(biome44) - p44_start_value(biome44));
+	p44_bii_lower_bound(t2,biome44)$(m_year(t2) > s44_target_year) = p44_target_value(biome44);
+	if(c44_bii_nodecrease = 1,
+		p44_bii_lower_bound(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = v44_bii.l(biome44);		
+	elseif c44_bii_nodecrease = 0,
+		p44_bii_lower_bound(t2,biome44)$(v44_bii.l(biome44) >= p44_target_value(biome44)) = p44_target_value(biome44);
+	);
+	p44_bii_lower_bound(t2,biome44)$(p44_bii_lower_bound(t2,biome44) >= 1) = 1;
+	p44_bii_lower_bound(t2,biome44)$(m_year(t2) < s44_start_year) = 0;
+	p44_bii_lower_bound(t2,biome44)$(sum(j, f44_biome(j,biome44)) = 0) = 0;
+* The lower bound of `v44_bii` is set to `p44_bii_lower_bound` to avoid a reduction of BII in combination with `v44_bii_missing`.
+	v44_bii.lo(biome44) = p44_bii_lower_bound(t,biome44);
+	display p44_bii_lower_bound;
 );
 

--- a/modules/44_biodiversity/bii_target/presolve.gms
+++ b/modules/44_biodiversity/bii_target/presolve.gms
@@ -5,7 +5,7 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
-if(m_year(t) = s44_start_year AND s44_bii_lower_bound > 0,
+if(m_year(t) = s44_start_year,
 * The start value for the linear interpolation is the BII at biome level in the start year.
 	p44_start_value(biome44) = v44_bii.l(biome44);
 * The target value for the linear interpolation is the lower bound defined in `s44_bii_lower_bound`.


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

- Improvment and simplification for setting a lower bound for the BII

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [x] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch: MAgPIE PR399_SSP2−Ref_updated3
  * Default run based on the current version of the fork from which PR is made: MAgPIE PR400_2_SSP2−BII0−Mode1

- [x] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * run time of the default of this PR is very simliar to the current develop.

![Unknown-74](https://user-images.githubusercontent.com/16921122/172809380-b6bc6c9a-f6ed-4405-b19d-d3849cbb4f74.png)

Results of the default are unchanged:
![Resources_Land_Cover_Cropland-69](https://user-images.githubusercontent.com/16921122/172810633-e6fd7191-9f62-4592-8a06-60354e55f97d.png)


Results for different lower bounds for the BII
cfg$gms$c44_bii_decrease <- 1: decrease of lower bound for BII is allowed in case the BII in the start year is above the provided lower bound.
![Biodiversity_BII_decrease_allowed](https://user-images.githubusercontent.com/16921122/172808286-94659278-2e4e-458b-a325-7633adf1005d.png)

![Resources_Land_Cover_Change_Other_Land-9](https://user-images.githubusercontent.com/16921122/172811202-0d654cd4-b21b-449a-8f96-55d93994fdbc.png)

cfg$gms$c44_bii_decrease <- 0: stricter implementation. No decrease of BII below the lower bound is allowed after the start year.
![Biodiversity_BII_nodecrease_allowed](https://user-images.githubusercontent.com/16921122/172808316-d7c0a915-544d-47c1-b2ff-e28366e3e6f6.png)

![Resources_Land_Cover_Change_Other_Land-10](https://user-images.githubusercontent.com/16921122/172811401-dd9d71c4-2daa-406e-bdd8-d2ba6919c086.png)


- [x] Added changes to `CHANGELOG.md`
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [x] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [x] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [x] Self-review of my own code.
- [ ] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [x] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] No unnecessary increase in module interfaces
- [x] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [x] In-code comments and documentation comments are satisfactory.
- [x] model behavior/performance is satisfactory.
- [x] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] Changes to the model are scientifically sound
- [x] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
