### PR TITLE
include fallow into som calculations

### DIFF
--- a/modules/59_som/cellpool_aug16/declarations.gms
+++ b/modules/59_som/cellpool_aug16/declarations.gms
@@ -11,6 +11,7 @@ parameters
           i59_tillage_share(i,tillage59)       Share of land under tillage class (1)
           i59_input_share(i,inputs59)          Share of land under input class (1)
           i59_cratio(j,kcr,w)                  Ratio of carbon density of land relative to natural vegetaion (1)
+          i59_cratio_fallow(j)                 Ratio of carbon density of fallow land relative to natural vegetation (1)
           p59_som_pool(j,pools59)              Actual C pool (mio. tC)
           i59_subsoilc_density(t_all,j)        Subsoil carbon density of a hectare of land (tC per ha)
 ;

--- a/modules/59_som/cellpool_aug16/equations.gms
+++ b/modules/59_som/cellpool_aug16/equations.gms
@@ -13,6 +13,7 @@
 q59_som_target_cropland(j2) ..
               v59_som_target(j2,"crop")
               =e= sum((kcr,w), vm_area(j2,kcr,w) * i59_cratio(j2,kcr,w)) * sum(ct,f59_topsoilc_density(ct,j2))
+              + vm_fallow(j2) * i59_cratio_fallow(j2)) * sum(ct,f59_topsoilc_density(ct,j2))
               ;
 *' as well as for all non cropland given by
 

--- a/modules/59_som/cellpool_aug16/preloop.gms
+++ b/modules/59_som/cellpool_aug16/preloop.gms
@@ -68,6 +68,16 @@ i59_cratio(j,kcr,w) = sum((cell(i,j),tillage59,inputs59,climate59),
                  * i59_input_share(i,inputs59)
                  * f59_cratio_inputs(climate59,inputs59)
                  * f59_cratio_irrigation(climate59,w,kcr));
+
+*' For fallow we assume annual crops with bare fallow - therefor low input -
+*' and reduced tillage
+
+i59_cratio_fallow(j) = sum(climate59,
+                sum(clcl_climate59(clcl,climate59),pm_climate_class(j,clcl))
+                * f59_cratio_landuse(climate59,"maiz")
+                * f59_cratio_tillage(climate59,"reduced_tillage")
+                * f59_cratio_inputs(climate59,"low_input")
+                * 1;
 *' @stop
 
 p59_carbon_density(t,j,pools59)=0;

--- a/modules/59_som/cellpool_aug16/preloop.gms
+++ b/modules/59_som/cellpool_aug16/preloop.gms
@@ -70,14 +70,15 @@ i59_cratio(j,kcr,w) = sum((cell(i,j),tillage59,inputs59,climate59),
                  * f59_cratio_irrigation(climate59,w,kcr));
 
 *' For fallow we assume annual crops with bare fallow - therefor low input -
-*' and reduced tillage
+*' and reduced tillage. Assumed to have no irrigation, so irrigation multiplier
+*' is 1.
 
 i59_cratio_fallow(j) = sum(climate59,
                 sum(clcl_climate59(clcl,climate59),pm_climate_class(j,clcl))
                 * f59_cratio_landuse(climate59,"maiz")
                 * f59_cratio_tillage(climate59,"reduced_tillage")
                 * f59_cratio_inputs(climate59,"low_input")
-                * 1;
+                * 1);
 *' @stop
 
 p59_carbon_density(t,j,pools59)=0;

--- a/modules/59_som/cellpool_aug16/realization.gms
+++ b/modules/59_som/cellpool_aug16/realization.gms
@@ -13,13 +13,13 @@
 *' This approach also accounts for the temporal dimension of soil organic carbon change,
 *' since it assumes a gradual step of 15% in the direction of the new equilibrium soil
 *' organic carbon pool each year. Stock change factors tracks crop types as well as
-*' management (e.g. irrigation) and input differences on cropland. 
+*' management (e.g. irrigation) and input differences on cropland.
 
 *' @limitations It is assumed that pastures and rangelandes as well as managed forests
 *' do not change in soil carbon compared to the natural reference state.
 
 
-*' @authors Benjamin Leon Bodirsky, Kristine Karstens
+*' @authors Kristine Karstens, Benjamin Leon Bodirsky
 
 
 

--- a/modules/59_som/static_jan19/not_used.txt
+++ b/modules/59_som/static_jan19/not_used.txt
@@ -12,3 +12,4 @@ vm_landexpansion,input,questionnaire
 vm_croplandexpansion,input,questionnaire
 vm_croplandreduction,input,questionnaire
 pm_climate_class,input,questionnaire
+vm_fallow,input,questionnaire

--- a/scripts/start/projects/test_rotations.R
+++ b/scripts/start/projects/test_rotations.R
@@ -27,7 +27,7 @@ cfg$gms$s13_max_gdp_shr <- 0.01
 
 cfg$results_folder <- "output/:title:"
 #cfg$output <- c("rds_report","extra/disaggregation")#"extra/highres"
-prefix <- "rota_penalty17"
+prefix <- "rota_penalty18"
 
 cfg$title <- paste(prefix,"olddefault",sep="_")
 start_run(cfg,codeCheck=FALSE)
@@ -44,16 +44,15 @@ start_run(cfg,codeCheck=FALSE)
 
 cfg$title <- paste(prefix,"newdefault",sep="_")
 cfg$gms$crop    <- "penalty_apr22"
+cfg$gms$som    <- "cellpool_aug16"
 cfg$gms$c30_rotation_scenario = "default"
 
 
 #cfg$qos <- "priority"
 cfg$recalibrate <- TRUE
 cfg$recalibrate_landconversion_cost <- TRUE
-cfg$recalibrate <- FALSE
-cfg$recalibrate_landconversion_cost <- FALSE
 start_run(cfg,codeCheck=FALSE)
-magpie4::submitCalibration("H12_sticky_feb18_dynamic_rotation")
+magpie4::submitCalibration("H12_sticky_feb18_dynamic_rotation2")
 cfg$recalibrate <- FALSE
 cfg$recalibrate_landconversion_cost <- FALSE
 


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

- Fallow land was so far not considered in the SOM calculations. This is even a bug if the two non-default realizations "som_cellpool_aug16" of the SOM module and the "rotation_apr22" realization of the 30_crop module are jointly activated.

## :wrench: Checklist for PR creator :wrench:

- [X ] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg

- [X ] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch
  * Default run based on the current version of the fork from which PR is made

- [ ] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : ** mins
  * This PR's default :  ** mins

- [ X] Added changes to `CHANGELOG.md`
- [ X] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [ X] No hard coded numbers and cluster/country/region names.
- [ X] The new code doesn't contain declared but unused parameters or variables.
- [ X] Where relevant, In-code comments added including documentation comments.
- [ X] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [ ] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
--> not needed
- [ X] Self-review of my own code.
- [ ] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
