### PR TITLE
use gams status as exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### changed
+- **scripts** quit with exit code = gams status at the end of submit.R
 - **scripts** fix in start_functions for the calibration setting `ifneeded`
 - **config** best_calib set to FALSE in default
 - **42_water_demand** account for multiple cropping in water requirements

--- a/scripts/run_submit/submit.R
+++ b/scripts/run_submit/submit.R
@@ -124,3 +124,14 @@ lucode2::runstatistics(file           = paste0(cfg$results_folder, "/runstatisti
                       timeOutputEnd   = timeOutputEnd)
 
 print(warnings())
+
+# quit with gams status as exit code unless model completed locally optimal everywhere
+gamsCode <- Find(function(code) !code %in% c(2, 7), ms_all)
+if (is.null(gamsCode) && 7 %in% ms_all) {
+  gamsCode <- 7
+}
+if (!is.null(gamsCode)) {
+  exitCode <- gamsCode + 200 # low numbered exit codes are used by R, add 200 to avoid confusion
+  message("gams status was ", gamsCode, ", exiting with code ", exitCode)
+  quit(status = exitCode)
+}


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

As explained [here](https://github.com/pik-piam/discussions/discussions/47) magpie runs would complete with exit code 0, even though gams status was not always 2 (locally optimal).
With this PR the first gams status not equal to 2 or 7 is used as exit code. Otherwise if gams status is 7 we use 7 as exit code. In order to avoid confusion with predefined exit codes we add 200 to the exit code, so gams status 6 will result in exit code 206. The exit code is reported in slurm mails, allowing for a quick way to see the gams status of a run.

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts

- [x] Providing additional information based on PR label

* Low risk : No new model run needed.

- [x] Added changes to `CHANGELOG.md`
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [x] Self-review of my own code.

## :warning: Additional notes or warnings :warning:
Sourcing the submit.R script will now quit the R session in order to set the exit code (if there is a problematic gams status). 

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
