### PR TITLE
add urban area to soil C tracking (with natural soil C as proxy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **scripts** update of rds_report to allow gridded intermediate outputs
 - **config** non-food system emission MAGICC switch
 - **scripts** output/extra/disaggregation_BII.R adjusted BII output for primary and secondary other land
-- **59_som** Now calculates soil C for fallow
+- **59_som** Now calculates soil C for fallow and urban areas
 - **inputs** updated non-food initial prices, MACCs curves, and removed suitability threshold of 0.1 in all_marginal setting
 - **documentation** added literature
 - **scripts/start** cleanup of old start scripts
 - **scripts** log files are now written in a subfolder "logs"
 - **config** adjusted PR template
 - **scripts** added single time step run to test runs
+- **52_carbon** Soil C of urban areas set to soil C of natural other land
 
 ### added
 - **scripts** added output script creating a set of outputs for Alessandro Passaro in the FSEC context

--- a/modules/14_yields/managementcalib_aug19/input.gms
+++ b/modules/14_yields/managementcalib_aug19/input.gms
@@ -12,7 +12,7 @@ $setglobal c14_yields_scenario  cc
 
 scalar s14_limit_calib   Relative managament calibration switch (1=limited 0=pure relative) / 1 /;
 
-scalar s14_calib_ir2rf   Switch to calibrate rainfed to irrigated yield ratios (1=calib 0=not calib) / 0 /;
+scalar s14_calib_ir2rf   Switch to calibrate rainfed to irrigated yield ratios (1=calib 0=not calib) / 1 /;
 
 scalars
   s14_yld_past_switch  Spillover parameter for translating technological change in the crop sector into pasture yield increases  (1)     / 0.25 /

--- a/modules/18_residues/off/realization.gms
+++ b/modules/18_residues/off/realization.gms
@@ -17,6 +17,7 @@
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "sets" $include "./modules/18_residues/off/sets.gms"
 $Ifi "%phase%" == "declarations" $include "./modules/18_residues/off/declarations.gms"
+$Ifi "%phase%" == "input" $include "./modules/18_residues/off/input.gms"
 $Ifi "%phase%" == "preloop" $include "./modules/18_residues/off/preloop.gms"
 $Ifi "%phase%" == "postsolve" $include "./modules/18_residues/off/postsolve.gms"
 *######################## R SECTION END (PHASES) ###############################

--- a/modules/34_urban/exo_nov21/presolve.gms
+++ b/modules/34_urban/exo_nov21/presolve.gms
@@ -5,7 +5,7 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
-vm_carbon_stock.fx(j,"urban",c_pools,stockType) = 0;
+vm_carbon_stock.fx(j,"urban",ag_pools,stockType) = 0;
 
 if(ord(t) = 1,
 	vm_land.fx(j,"urban") = i34_urban_area(t,j);

--- a/modules/34_urban/static/presolve.gms
+++ b/modules/34_urban/static/presolve.gms
@@ -7,7 +7,7 @@
 
 
 vm_land.fx(j,"urban") = pcm_land(j,"urban");
-vm_carbon_stock.fx(j,"urban",c_pools) = 0;
+vm_carbon_stock.fx(j,"urban",ag_pools) = 0;
 *' Biodiveristy value (BV)
 vm_bv.fx(j,"urban", potnatveg) = pcm_land(j,"urban") * fm_bii_coeff("urban",potnatveg) * fm_luh2_side_layers(j,potnatveg);
 

--- a/modules/52_carbon/normal_dec17/input.gms
+++ b/modules/52_carbon/normal_dec17/input.gms
@@ -23,6 +23,8 @@ $if "%c52_carbon_scenario%" == "nocc" fm_carbon_density(t_all,j,land,c_pools) = 
 $if "%c52_carbon_scenario%" == "nocc_hist" fm_carbon_density(t_all,j,land,c_pools)$(m_year(t_all) > sm_fix_cc) = fm_carbon_density(t_all,j,land,c_pools)$(m_year(t_all) = sm_fix_cc);
 m_fillmissingyears(fm_carbon_density,"j,land,c_pools");
 
+fm_carbon_density(t_all,j,"urban","soilc") = fm_carbon_density(t_all,j,"other","soilc")
+
 parameter f52_growth_par(clcl,chap_par,forest_type) Parameters for chapman-richards equation (1)
 /
 $ondelim

--- a/modules/52_carbon/normal_dec17/input.gms
+++ b/modules/52_carbon/normal_dec17/input.gms
@@ -23,6 +23,8 @@ $if "%c52_carbon_scenario%" == "nocc" fm_carbon_density(t_all,j,land,c_pools) = 
 $if "%c52_carbon_scenario%" == "nocc_hist" fm_carbon_density(t_all,j,land,c_pools)$(m_year(t_all) > sm_fix_cc) = fm_carbon_density(t_all,j,land,c_pools)$(m_year(t_all) = sm_fix_cc);
 m_fillmissingyears(fm_carbon_density,"j,land,c_pools");
 
+* Fix urban area soilc to natural land soilc as long as preprocessed 
+* fm_carbon_density does not provide meaningful numbers for urban.
 fm_carbon_density(t_all,j,"urban","soilc") = fm_carbon_density(t_all,j,"other","soilc")
 
 parameter f52_growth_par(clcl,chap_par,forest_type) Parameters for chapman-richards equation (1)

--- a/modules/59_som/cellpool_aug16/sets.gms
+++ b/modules/59_som/cellpool_aug16/sets.gms
@@ -8,10 +8,10 @@
 sets
 
 pools59(land) Carbon differentiating landuse types
-/crop, past, forestry, primforest, secdforest, other/
+/crop, past, forestry, primforest, secdforest, other, urban/
 
 noncropland59(pools59) Soil carbon conserving landuse types
-/past, forestry, primforest, secdforest, other/
+/past, forestry, primforest, secdforest, other, urban/
 
 tillage59 Tillage categories of IPCC
 /full_tillage,reduced_tillage,no_tillage/

--- a/modules/59_som/static_jan19/sets.gms
+++ b/modules/59_som/static_jan19/sets.gms
@@ -7,7 +7,7 @@
 
 sets
 noncropland59(land) Soil carbon conserving landuse types
-/past, forestry, primforest, secdforest, other/
+/past, forestry, primforest, secdforest, other, urban/
 
 exo_scen59 exogenous scenarios for soil organic matter loss
 /constant, fadeout_2050/


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

This PR will fix the small soil C mismatches we get from not tracking urban areas within the som module. It will only let ag carbon pools (vegc and litc) be 0 for urban areas, but will use the "other" land soilc values for urban areas. All 59_som realizations will from now on track urban areas (as a noncropland pool together with all other land use types).
For now we manually set fm_carbon_density for soilc in urban within the input.gms file, which will be faded out by end of this year, when all preprocessing will contain meaningful numbers for fm_carbon_density for soilc in urban.  Changes to mrmagpie where already pushed.

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).
- [x] Providing additional information based on PR label

* Medium risk : Default run based on the current version of the fork from which PR is made
-> Made a test run. It run though.

- [x] Added changes to `CHANGELOG.md`
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [ ] Where relevant, In-code comments added including documentation comments.
- [ ] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [x] Self-review of my own code.

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [x] PR is labeled correctly.
- [x] `CHANGELOG` is updated correctly
- [x] No hard coded numbers and cluster/country/region names.
- [x] Changes to the model are scientifically sound
- [x] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
