### PR TITLE
Update additional data revision number adding ecoSysProt scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **52_carbon** Soil C of urban areas set to soil C of natural other land
 
 ### added
+- **56_ghg_policy** added new ecosystem protection scenarios
 - **scripts** added output script creating a set of outputs for Alessandro Passaro in the FSEC context
 - **50_nr_soil_budget** new module realization for more consistent MACCs implementation. change of interface from vm_btm_reg to vm_emissions_reg
 - **53_methane** moved maccs into emission modules. change of interface from vm_btm_reg to vm_emissions_reg

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$model <- "main.gms"   #def = "main.gms"
 cfg$input <- c(regional    = "rev4.77_h12_magpie.tgz",
                cellular    = "rev4.77_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.77_h12_validation.tgz",
-               additional  = "additional_data_rev4.31.tgz",
+               additional  = "additional_data_rev4.32.tgz",
                calibration = "calibration_H12+ir2rf_05Oct22.tgz")
 
 # NOTE: It is recommended to recalibrate the model when changing cellular input data
@@ -1384,6 +1384,12 @@ cfg$gms$s56_limit_ch4_n2o_price <- 1000   # def = 1000
 # * sdp_redd_soil_peat (only co2 from vegc, litc, soilc and co2, ch4 and n2o from peatland), sdp_all (all individual sdp scenarios combined)
 # * gcs_lbs (land-based mitigation: above-ground CO2 emis from LUC in forest, forestry and natveg; co2, ch4 and n2o from peatland),
 # * gcs_res (mitigation in production systems: all agricultural non-CO2 emissions)
+# * ecoSysProtAll:               (Above ground CO2 emis from LUC in forest, forestry, natveg; All types of emis from peatland; All CH4 and N2O emis),
+# * ecoSysProtForest:            (Above ground CO2 emis from LUC in forest, forestry; All CH4 and N2O emis except peatland),
+# * ecoSysProtPrimForest:        (Above ground CO2 emis from LUC in primary forest; All CH4 and N2O emis except peatland),
+# * ecoSysProtOff:               (All CH4 and N2O emis except peatland),
+# * ecoSysProtAll_agMgmtExclN2O: (Above ground CO2 emis from LUC in forest, forestry, natveg; All types of emis from peatland; All CH4 emis, no further N2O emis)
+# * ecoSysProtAll_agMgmtExclCH4: (Above ground CO2 emis from LUC in forest, forestry, natveg; All types of emis from peatland; All N2O emis, no further CH4 emis)
 cfg$gms$c56_emis_policy <- "redd+natveg_nosoil" 		# def = redd+natveg_nosoil
 
 # * CO2 emissions subject to carbon pricing

--- a/modules/56_ghg_policy/price_aug22/sets.gms
+++ b/modules/56_ghg_policy/price_aug22/sets.gms
@@ -98,7 +98,13 @@ sets
       sdp_redd_soil_peat,
       sdp_all,
       gcs_lbs,
-      gcs_res /
+      gcs_res,
+      ecoSysProtAll,
+      ecoSysProtForest,
+      ecoSysProtPrimForest,
+      ecoSysProtOff,
+      ecoSysProtAll_agMgmtExclN2O,
+      ecoSysProtAll_agMgmtExclCH4 /
 
 ;
 *######################### R SECTION END (SETS) ################################


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

This PR updates the `additional_data` revision number to **4.32** adding the following new emission policy scenario options to `c56_emis_policy `:
- `ecoSysProtAll`
- `ecoSysProtForest` 
- `ecoSysProtPrimForest` 
- `ecoSysProtOff`
- `ecoSysProtAll_agMgmtExclN2O`
- `ecoSysProtAll_agMgmtExclCH4`

In the first 4 scenarios GHG emission policies related to ecosystem protection are gradually switched off, which in particular also involves exempting all types of GHG emissions from peatlands from the policy in `ecoSysProtForest`, `ecoSysProtPrimForest` and `ecoSysProtOff`. Other N2O and CH4 emissions, i.e those related to agricultural management, are still covered by the policy.

In `ecoSysProtAll_agMgmtExclN2O` all emission related to ecosystem protection are covered by the GHG policy (involving all types of GHGs from peatlands). Other CH4 emissions are also covered but further **N2O emissions** and other nitrogen-based pollutants are **exempted** from the GHG policy.

In `ecoSysProtAll_agMgmtExclCH4` all emission related to ecosystem protection are covered by the GHG policy (involving all types of GHGs from peatlands). Other N2O emissions and other nitrogen-based pollutants are also covered but further **CH4 emissions** are **exempted** from the GHG policy.

## :wrench: Checklist for PR creator :wrench:

- [x] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [x] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch
  * Default run based on the current version of the fork from which PR is made

- [x] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : 62.06568 mins
  * This PR's default :  64.74054 mins

- [x] Added changes to `CHANGELOG.md`
- [x] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [x] No hard coded numbers and cluster/country/region names.
- [x] The new code doesn't contain declared but unused parameters or variables.
- [x] Where relevant, In-code comments added including documentation comments.
- [x] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [x] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible). (**Not applicable**)
- [x] Self-review of my own code.
- [x] In case of updated cellular input tgz file in default.cfg: scenario_config.csv has been updated accordingly (rcp1p9, rcp2p6 etc) (**Not applicable**)

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
