### PR TITLE
Bugfix FSDP_collect.R

### DIFF
--- a/scripts/output/projects/FSDP_collect.R
+++ b/scripts/output/projects/FSDP_collect.R
@@ -195,16 +195,20 @@ for (i in 1:length(outputdir)) {
     } else missing <- c(missing, outputdir[i])
 
     #add dimensions
-    y <- add_dimension(y, dim = 3.1, add = "scenario", nm = gsub(".", "_", cfg$title, fixed = TRUE))
-    y <- add_dimension(y, dim = 3.1, add = "model", nm = "MAgPIE")
-    getSets(y, fulldim = FALSE)[2] <- "period"
 
-    #save as data.frame with xy coordinates
-    y <- as.data.table(as.data.frame(y, rev = 3))
+    if (is.null(y)) {
+      message("Scenario: ", cfg$title, " contained none of the cellular output data.")
+    } else {
+      y <- add_dimension(y, dim = 3.1, add = "scenario", nm = gsub(".", "_", cfg$title, fixed = TRUE))
+      y <- add_dimension(y, dim = 3.1, add = "model", nm = "MAgPIE")
+      getSets(y, fulldim = FALSE)[2] <- "period"
 
-    #bind together
-    grid <- rbind(grid, y)
+      #save as data.frame with xy coordinates
+      y <- as.data.table(as.data.frame(y, rev = 3))
 
+      #bind together
+      grid <- rbind(grid, y)
+    }
   }
 }
 


### PR DESCRIPTION
## :bird: Purpose of this PR :bird:

This PR fixes a commonly occurring error that, when one of the scenario's output scripts breaks due to lazy-load errors, the entire FSDP_collect function breaks.

## :wrench: Checklist for PR creator :wrench:

- [ ] Labeling pull request correctly [from the label list](https://github.com/magpiemodel/magpie/labels).

* Low risk : Simple bugfixes (missing files, updated documentation, typos) or Start/output scripts
* Medium risk : New realization / Changes to existing realization / Other changes which don't modify default.cfg
* High risk : New input files (if cfg$input is changed in default.cfg) / Modification to core model (eg. changes in equations, calculations, introduction of new sets etc.) / Other changes in default.cfg

- [ ] Providing additional information based on PR label

* Low risk : No new model run needed.
* Medium risk : Default run based on the current version of the fork from which PR is made
* High risk
  * Default run from the current develop branch
  * Default run based on the current version of the fork from which PR is made

- [ ] :chart_with_downwards_trend: Performance loss/gain from current default behavior :chart_with_upwards_trend:
  * Current develop branch default : ** mins
  * This PR's default :  ** mins

- [ ] Added changes to `CHANGELOG.md`
- [ ] Compilation check (model starts without compilation errors - use `gams main.gms action=c` in model folder for testing).
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] The new code doesn't contain declared but unused parameters or variables.
- [ ] Where relevant, In-code comments added including documentation comments.
- [ ] Made sure that documentation created with [`goxygen`](https://github.com/pik-piam/goxygen) is okay (use `goxygen::goxygen()` for testing).
- [ ] Changes to [`magpie4`](https://github.com/pik-piam/magpie4) R library for post processing of model output (ideally backward compatible).
- [ ] Self-review of my own code.
- [ ] In case of updated cellular input tgz file in default.cfg: scenario_config.csv has been updated accordingly (rcp1p9, rcp2p6 etc)
- [ ] For high risk runs: validation of major model indicators - Land-use, emissions, food prices, Tau.  %Delete this line in case it is not a high risk run%

## :warning: Additional notes or warnings :warning:
NA

## :rotating_light: Checklist for RSE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] No unnecessary increase in module interfaces
- [ ] All required updates in interfaces (if any) have been properly adressed in the module contracts
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly

## :rotating_light: Checklist for MAgPIE reviewer :rotating_light:

- [ ] PR is labeled correctly.
- [ ] `CHANGELOG` is updated correctly
- [ ] No hard coded numbers and cluster/country/region names.
- [ ] Changes to the model are scientifically sound
- [ ] In-code comments and documentation comments are satisfactory.
- [ ] model behavior/performance is satisfactory.
- [ ] Requested changes (if any) were applied correctly
