### PR TITLE
bugfix s56_limit_ch4_n2o_price default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### fixed
 - **scripts** rewrite of land conversion cost calibration script `landconversion_cost.R`
-
+- **config** changed default value for s56_limit_ch4_n2o_price from 1000 to 4000 for consistency with c57_macc_version = "PBL_2022"
 
 ## [4.6.0] - 2022-11-09
 

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -1364,11 +1364,15 @@ cfg$gms$s56_buffer_aff <- 0.2 	# def = 0.2
 
 # * Upper limit for CH4 and N2O GHG price (USD05MER per tC)
 # * Limits GHG prices selected in c56_pollutant_prices to the chosen value.
-# * CH4 and N2O GHG prices are limited by default to 1000 USD05MER per tC equivalent,
-# * which induces the maximum abatement possible in the 57_maccs module.
-# * Beyond 1000 USD05MER per tC equivalent no further technical mitigation is possible
-# * but would increase food prices.
-cfg$gms$s56_limit_ch4_n2o_price <- 1000   # def = 1000
+# * CH4 and N2O GHG prices are limited by default to 4000 USD05MER per tC equivalent,
+# * which induces the maximum abatement possible with c57_macc_version = "PBL_2022"
+# * Beyond 4000 USD05MER per tC equivalent no further technical mitigation is possible
+# * but would increase agricultural prices.
+# * Suggested limits for different c57_macc_version settings
+# * PBL_2007: 1000 (200 steps, 5 USD each)
+# * PBL_2019: 4000 (200 steps, 20 USD each)
+# * PBL_2022: 4000 (200 steps, 20 USD each)
+cfg$gms$s56_limit_ch4_n2o_price <- 4000   # def = 4000
 
 # * NOTE: The following 2 options for emission pricing have strong interactions in runs with CO2 prices and should only be changed by experienced users.
 # * 	  The main purpose of these options is to regulate the pricing of positive emissions. Note that re/afforestation is covered by a separate mechanism.


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- changed default value for s56_limit_ch4_n2o_price from 1000 to 4000 for consistency with c57_macc_version = "PBL_2022"
- FSDP runs are feasible

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

Default run is unchanged.

![Productivity_Landuse_Intensity_Indicator_Tau-67](https://user-images.githubusercontent.com/16921122/204257530-b69aa226-2c3e-4f7a-9e92-5ee4ef009a7a.png)
![Resources_Land_Cover_Cropland-77](https://user-images.githubusercontent.com/16921122/204257547-3c68f287-4a1b-40d2-9e01-ab7bfbebd07b.png)

As expected, there is slightly more non-CO2 emission reduction in climate policy runs the updated version.
 
![Emissions_CH4_Land_Agriculture-4](https://user-images.githubusercontent.com/16921122/204257779-f2e15f8a-6c18-4ac4-8a12-d3bec908e80d.png)
![Emissions_N2O_Land_Agriculture-2](https://user-images.githubusercontent.com/16921122/204257792-ec58f00f-7b58-4d4f-a3cc-cea606af6257.png)


- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `gams main.gms action=c`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Default run based on the current version of the fork from which PR is made
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : 0.39 h
  - This PR's default :  0.42 h

![newplot-12](https://user-images.githubusercontent.com/16921122/204258301-b2908422-1469-4ab5-99ab-2bccf8d35f05.png)

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
