### PR TITLE
Update add. data rev. adding ecoSysProtAll_agMgmtOff scenario

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$model <- "main.gms"   #def = "main.gms"
 cfg$input <- c(regional    = "rev4.77_h12_magpie.tgz",
                cellular    = "rev4.77_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.77_h12_validation.tgz",
-               additional  = "additional_data_rev4.32.tgz",
+               additional  = "additional_data_rev4.33.tgz",
                calibration = "calibration_H12_per_ton_fao_may22_glo_23Nov22.tgz")
 
 # NOTE: It is recommended to recalibrate the model when changing cellular input data
@@ -1396,6 +1396,7 @@ cfg$gms$s56_limit_ch4_n2o_price <- 4000   # def = 4000
 # * ecoSysProtOff:               (All CH4 and N2O emis except peatland),
 # * ecoSysProtAll_agMgmtExclN2O: (Above ground CO2 emis from LUC in forest, forestry, natveg; All types of emis from peatland; All CH4 emis, no further N2O emis)
 # * ecoSysProtAll_agMgmtExclCH4: (Above ground CO2 emis from LUC in forest, forestry, natveg; All types of emis from peatland; All N2O emis, no further CH4 emis)
+# * ecoSysProtAll_agMgmtOff:     (Above ground CO2 emis from LUC in forest, forestry, natveg; All types of emis from peatland; No further CH4/N2O/other emis related to ag. management)
 cfg$gms$c56_emis_policy <- "redd+natveg_nosoil" 		# def = redd+natveg_nosoil
 
 # * CO2 emissions subject to carbon pricing

--- a/modules/56_ghg_policy/price_aug22/sets.gms
+++ b/modules/56_ghg_policy/price_aug22/sets.gms
@@ -104,7 +104,8 @@ sets
       ecoSysProtPrimForest,
       ecoSysProtOff,
       ecoSysProtAll_agMgmtExclN2O,
-      ecoSysProtAll_agMgmtExclCH4 /
+      ecoSysProtAll_agMgmtExclCH4,
+      ecoSysProtAll_agMgmtOff /
 
 ;
 *######################### R SECTION END (SETS) ################################


### PR DESCRIPTION
## :bird: Description of this PR :bird:

This PR updates the `additional_data` revision number to **4.33** adding the following new emission policy scenario option to `c56_emis_policy `
- `ecoSysProtAll_agMgmtOff`

and is an addition to [PR466](https://github.com/magpiemodel/magpie/pull/466).

In `ecoSysProtAll_agMgmtOff` all emissions related to ecosystem protection are covered by the GHG policy (involving all types of GHGs from peatlands). Emissions related to agricultural management (in particular N2O and CH4 emissions, but also other nitrogen-based pollutants and emissions from burning residues) are **exempted** from the GHG policy.


## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes  (NA, was already done in [PR466](https://github.com/magpiemodel/magpie/pull/466))
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `gams main.gms action=c`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Default run based on the current version of the fork from which PR is made
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : 0:22 mins (elapsed time from `full.log`)
  - This PR's default :  0:22 mins (elapsed time from `full.log`)

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
