### PR TITLE
semi-natural vegetation in cropland areas rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### added
 - **10_land** added `vm_lu_transitions` as interface
 - **39_landconversion** scalar `s39_reward_crop_reduction` provides a cropland reduction reward
-- **10_land** added interface `fm_land_iso` realization for consistency
+- **10_land** added interface `fm_land_iso` for consistency
 
 ### removed
 - **10_land** removed `feb15` realization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **30_crop** replaced `f30_scenario_fader` with macro
 - **30_crop/config** changed switch `c30_rotation_scenario_speed` to `s30_rotation_scenario_target`
 - **30_crop/config** changed switch `c30_snv_target` to `s30_snv_scenario_target`
-- **30_crop/config** added switch `s30_snv_natveg_only`for including only natveg in semi-natural vegetation in cropland scenarios
 - **config** changed default value for `c30_marginal_land` from `'all_marginal'` to `'q33_marginal'` for better spatial cropland patterns
 
 ### added
 - **10_land** added `vm_lu_transitions` as interface
 - **39_landconversion** scalar `s39_reward_crop_reduction` provides a cropland reduction reward
 - **10_land** added interface `fm_land_iso` for consistency
+- **30_crop/config** added switch `s30_snv_natveg_only`for including only natveg in semi-natural vegetation in cropland scenarios
+- **30_crop/config** added switch `s30_rotation_scenario_start`
+- **30_crop/config** added switch `s30_snv_scenario_start`
 
 ### removed
 - **10_land** removed `feb15` realization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **10_land** added `vm_lu_transitions` as interface
 - **39_landconversion** scalar `s39_reward_crop_reduction` provides a cropland reduction reward
 - **10_land** added interface `fm_land_iso` for consistency
-- **30_crop/config** added switch `s30_snv_natveg_only`for including only natveg in semi-natural vegetation in cropland scenarios
+- **30_crop/config** added switch for set `land_snv`for defining which land cover types are allowed in the semi-natural vegetation policy in cropland scenarios
 - **30_crop/config** added switch `s30_rotation_scenario_start`
 - **30_crop/config** added switch `s30_snv_scenario_start`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### changed
--
+- **30_crop** replaced `f30_scenario_fader` with macro
+- **30_crop/config** changed switch `c30_rotation_scenario_speed` to `s30_rotation_scenario_target`
+- **30_crop/config** changed switch `c30_snv_target` to `s30_snv_scenario_target`
+- **30_crop/config** added switch `s30_snv_natveg_only`for including only natveg in semi-natural vegetation in cropland scenarios
+- **config** changed default value for `c30_marginal_land` from `'all_marginal'` to `'q33_marginal'` for better spatial cropland patterns
 
 ### added
-- **10_land** added `vm_lu_transitions` as interface 
+- **10_land** added `vm_lu_transitions` as interface
 - **39_landconversion** scalar `s39_reward_crop_reduction` provides a cropland reduction reward
+- **10_land** added interface `fm_land_iso` realization for consistency
 
 ### removed
 - **10_land** removed `feb15` realization
 - **10_land** removed the interfaces `vm_croplandexpansion` and `vm_croplandreduction`
 - **39_landconversion** removed `s39_reward_shr`
 - **scripts** removed remind2::deletePlus in coupling interface of start_function
+- **30_crop** removed `f30_scenario_fader.csv`input
 
 ### fixed
 - **59_som** fixed land use change tracking for non-cropland pools in the `cellpool_aug16` realization

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$model <- "main.gms"   #def = "main.gms"
 cfg$input <- c(regional    = "rev4.77_h12_magpie.tgz",
                cellular    = "rev4.77_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.77_h12_validation.tgz",
-               additional  = "additional_data_rev4.33.tgz",
+               additional  = "additional_data_rev4.34.tgz",
                calibration = "calibration_H12_per_ton_fao_may22_glo_23Nov22.tgz")
 
 # NOTE: It is recommended to recalibrate the model when changing cellular input data
@@ -613,8 +613,11 @@ cfg$gms$c30_rotation_constraints <- "on"       # def = "on"
 # * legumes (increased incentives for legumes), agroforestry (increased incentives for perennials), agroecology (mix)
 # * In realization endo_apr21: no scenarios exist.
 cfg$gms$c30_rotation_scenario <- "default"     # def = "default"
-# * (c30_rotation_scenario_speed): time by which scenario is fully implemented: "by2030", "by2050"
-cfg$gms$c30_rotation_scenario_speed <- "by2050"       # def ="by2050"
+# * Year by which rotation scenario is fully implemented:
+# * Start year:
+cfg$gms$s30_rotation_scenario_start <- 2020       # def = 2020
+# * Target year (year when full protection is reached):
+cfg$gms$s30_rotation_scenario_target <- 2050       # def = 2050
 
 
 # * Switch to determine whether marginal land (suitability index below 0.33) should be included
@@ -624,7 +627,7 @@ cfg$gms$c30_rotation_scenario_speed <- "by2050"       # def ="by2050"
 # * ("no_marginal"): Marginal land is completely excluded from crop cultivation
 # * Note: Option "q33_marginal" produces the highest spatial correlation
 # * with observed cropland patterns and is recommended for productive runs.
-cfg$gms$c30_marginal_land <- "q33_marginal"   # def = "all_marginal"
+cfg$gms$c30_marginal_land <- "q33_marginal"   # def = "q33_marginal"
 
 # * Share of available cropland that is withheld for maintaining semi-natural vegetation (SNV)
 # * in cropland areas, including grassland, forest and other land. For example,
@@ -634,11 +637,11 @@ cfg$gms$c30_marginal_land <- "q33_marginal"   # def = "all_marginal"
 # s30_snv_shr_noselect applies to all other countries.
 cfg$gms$s30_snv_shr <- 0                # def = 0
 cfg$gms$s30_snv_shr_noselect <- 0       # def = 0
-# * Target year for SNV policy ('s30_snv_shr'). Options are:
-# * ("none"): No SNV policy
-# * ("by2030"): The target is reached by 2030
-# * ("by2050"): The target is reached by 2050
-cfg$gms$c30_snv_target <- "none"        # def = "none"
+# * Year by which SNV policy ('s30_snv_shr') is fully implemented.
+# * Start year:
+cfg$gms$s30_rotation_scenario_start <- 2020       # def = 2020
+# * Target year (year when full protection is reached):
+cfg$gms$s30_rotation_scenario_target <- 2030       # def = 2030
 # * Switch and specification of countries for which SNV policy in
 # * s30_snv_shr apply.
 # * Options: list of iso-codes of countries where SNV policy should be applied

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -645,6 +645,10 @@ cfg$gms$c30_snv_target <- "none"        # def = "none"
 # * Note: must be written in the format: "IND, BRA, DEU"
 # * Default: all iso countries
 cfg$gms$policy_countries30  <- all_iso_countries
+# * Switch for vegetation cover of SNV
+# * options: 1 (SNV only includes natural forest and other land)
+# *          0 (SNV includes grassland, forest, forestry & other land)
+cfg$gms$s30_snv_natveg_only <- 0   # def = 0
 
 
 # ***---------------------    31_past    ---------------------------------------

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -26,7 +26,7 @@ cfg$input <- c(regional    = "rev4.77_h12_magpie.tgz",
                cellular    = "rev4.77_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.77_h12_validation.tgz",
                additional  = "additional_data_rev4.34.tgz",
-               calibration = "calibration_H12_per_ton_fao_may22_glo_23Nov22.tgz")
+               calibration = "calibration_H12_per_ton_fao_may22_glo_07Dec22.tgz")
 
 # NOTE: It is recommended to recalibrate the model when changing cellular input data
 #       as well as for any other setting that would affect initial values in the model,

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -648,11 +648,11 @@ cfg$gms$s30_snv_scenario_target <- 2030       # def = 2030
 # * Note: must be written in the format: "IND, BRA, DEU"
 # * Default: all iso countries
 cfg$gms$policy_countries30  <- all_iso_countries
-# * Switch for vegetation cover of SNV
-# * options: 1 (SNV only includes natural forest and other land)
-# *          0 (SNV includes grassland, forest, forestry & other land)
-cfg$gms$s30_snv_natveg_only <- 0   # def = 0
-
+# * Land types included in the SNV policy. This option allows for sensitivity analyses.
+# *	plausible options:  "secdforest, forestry, past, other",
+# *                     "secdforest, other",
+# *                     "secdforest, past, other" etc.
+cfg$gms$land_snv <- "secdforest, forestry, past, other"    #def = "secdforest, forestry, past, other"
 
 # ***---------------------    31_past    ---------------------------------------
 # * (static):     static pasture

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -616,7 +616,7 @@ cfg$gms$c30_rotation_scenario <- "default"     # def = "default"
 # * Year by which rotation scenario is fully implemented:
 # * Start year:
 cfg$gms$s30_rotation_scenario_start <- 2020       # def = 2020
-# * Target year (year when full protection is reached):
+# * Target year (year when full implementation is reached):
 cfg$gms$s30_rotation_scenario_target <- 2050       # def = 2050
 
 
@@ -639,9 +639,9 @@ cfg$gms$s30_snv_shr <- 0                # def = 0
 cfg$gms$s30_snv_shr_noselect <- 0       # def = 0
 # * Year by which SNV policy ('s30_snv_shr') is fully implemented.
 # * Start year:
-cfg$gms$s30_rotation_scenario_start <- 2020       # def = 2020
-# * Target year (year when full protection is reached):
-cfg$gms$s30_rotation_scenario_target <- 2030       # def = 2030
+cfg$gms$s30_snv_scenario_start <- 2020       # def = 2020
+# * Target year (year when full implementation is reached):
+cfg$gms$s30_snv_scenario_target <- 2030       # def = 2030
 # * Switch and specification of countries for which SNV policy in
 # * s30_snv_shr apply.
 # * Options: list of iso-codes of countries where SNV policy should be applied

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -624,7 +624,7 @@ cfg$gms$c30_rotation_scenario_speed <- "by2050"       # def ="by2050"
 # * ("no_marginal"): Marginal land is completely excluded from crop cultivation
 # * Note: Option "q33_marginal" produces the highest spatial correlation
 # * with observed cropland patterns and is recommended for productive runs.
-cfg$gms$c30_marginal_land <- "all_marginal"   # def = "all_marginal"
+cfg$gms$c30_marginal_land <- "q33_marginal"   # def = "all_marginal"
 
 # * Share of available cropland that is withheld for maintaining semi-natural vegetation (SNV)
 # * in cropland areas, including grassland, forest and other land. For example,

--- a/config/scenario_config.csv
+++ b/config/scenario_config.csv
@@ -29,7 +29,7 @@ gms$c22_protect_scenario_noselect;;;;;;;;;;;;;;;;;;;;;none;none;BH_IFL;none;BH_I
 gms$c30_bioen_water;;;;rainfed;rainfed;rainfed;rainfed;rainfed;rainfed;all;rainfed;rainfed;;;;;;;rainfed;;;;;;;;;;;;;;;;;;;;;;;;
 gms$s30_snv_shr;;;;0;0;0;0;0;0;0;0;0.2;;;;;;;0;;0.2;0.2;0.2;0.2;0.2;;;;;;;;;;;;;;;;;;
 gms$s30_snv_shr_noselect;;;;;;;;;;;;;;;;;;;;;0;0;0.2;0;0.2;;;;;;;;;;;;;;;;;;
-gms$c30_snv_target;;;;none;none;none;none;none;none;none;none;by2030;;;;;;;none;;by2030;by2030;by2030;by2030;by2030;;;;;;;;;;;;;;;;;;
+gms$s30_snv_scenario_target;;;;;;;;;;;;2030;;;;;;;;;2030;2030;2030;2030;2030;;;;;;;;;;;;;;;;;;
 gms$c31_past_suit_scen;;;;ssp126;ssp245;ssp370;ssp460;ssp585;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;ssp126;ssp126;ssp245;ssp460;ssp370;ssp585
 gms$s32_aff_plantation;;;;0;0;0;0;0;0;1;0;0;;;;;;;0;;;;;;;;;;;;;;;;;;;;;;;;
 gms$s32_aff_bii_coeff;;;;0;0;0;0;0;0;1;0;0;;;;;;;0;;;;;;;;;;;;;;;;;;;;;;;;

--- a/config/scenario_config.csv
+++ b/config/scenario_config.csv
@@ -27,7 +27,7 @@ gms$c21_trade_liberalization;;;;l908080r807070;l909090r808080;l909595r809090;l90
 gms$c22_protect_scenario;;;;none;none;none;none;none;BH;none;BH_IFL;BH;;;;;;;BH;;BH_IFL;BH_IFL;BH_IFL;BH_IFL;BH_IFL;;;;;;;;;;;;;;;;;;
 gms$c22_protect_scenario_noselect;;;;;;;;;;;;;;;;;;;;;none;none;BH_IFL;none;BH_IFL;;;;;;;;;;;;;;;;;;
 gms$c30_bioen_water;;;;rainfed;rainfed;rainfed;rainfed;rainfed;rainfed;all;rainfed;rainfed;;;;;;;rainfed;;;;;;;;;;;;;;;;;;;;;;;;
-gms$s30_snv_shr;;;;;;;;;;;;0.2;;;;;;;;;0.2;0.2;0.2;0.2;0.2;;;;;;;;;;;;;;;;;;
+gms$s30_snv_shr;;;;0;0;0;0;0;0;0;0;0.2;;;;;;;0;;0.2;0.2;0.2;0.2;0.2;;;;;;;;;;;;;;;;;;
 gms$s30_snv_shr_noselect;;;;;;;;;;;;;;;;;;;;;0;0;0.2;0;0.2;;;;;;;;;;;;;;;;;;
 gms$s30_snv_scenario_target;;;;;;;;;;;;2030;;;;;;;;;2030;2030;2030;2030;2030;;;;;;;;;;;;;;;;;;
 gms$c31_past_suit_scen;;;;ssp126;ssp245;ssp370;ssp460;ssp585;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;ssp126;ssp126;ssp245;ssp460;ssp370;ssp585

--- a/config/scenario_config.csv
+++ b/config/scenario_config.csv
@@ -27,7 +27,7 @@ gms$c21_trade_liberalization;;;;l908080r807070;l909090r808080;l909595r809090;l90
 gms$c22_protect_scenario;;;;none;none;none;none;none;BH;none;BH_IFL;BH;;;;;;;BH;;BH_IFL;BH_IFL;BH_IFL;BH_IFL;BH_IFL;;;;;;;;;;;;;;;;;;
 gms$c22_protect_scenario_noselect;;;;;;;;;;;;;;;;;;;;;none;none;BH_IFL;none;BH_IFL;;;;;;;;;;;;;;;;;;
 gms$c30_bioen_water;;;;rainfed;rainfed;rainfed;rainfed;rainfed;rainfed;all;rainfed;rainfed;;;;;;;rainfed;;;;;;;;;;;;;;;;;;;;;;;;
-gms$s30_snv_shr;;;;0;0;0;0;0;0;0;0;0.2;;;;;;;0;;0.2;0.2;0.2;0.2;0.2;;;;;;;;;;;;;;;;;;
+gms$s30_snv_shr;;;;;;;;;;;;0.2;;;;;;;;;0.2;0.2;0.2;0.2;0.2;;;;;;;;;;;;;;;;;;
 gms$s30_snv_shr_noselect;;;;;;;;;;;;;;;;;;;;;0;0;0.2;0;0.2;;;;;;;;;;;;;;;;;;
 gms$s30_snv_scenario_target;;;;;;;;;;;;2030;;;;;;;;;2030;2030;2030;2030;2030;;;;;;;;;;;;;;;;;;
 gms$c31_past_suit_scen;;;;ssp126;ssp245;ssp370;ssp460;ssp585;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;ssp126;ssp126;ssp245;ssp460;ssp370;ssp585

--- a/config/scenario_fsec.csv
+++ b/config/scenario_fsec.csv
@@ -23,7 +23,7 @@ gms$c21_trade_liberalization;;;;;;;;;;;;;;;;;;;;;;l908080r807070;;;;;;;;;;;;;;;;
 gms$c22_protect_scenario;;;;;;;;;;;;;;;;;;;;;;;;;;;HalfEarth;;;;;;;;;;;;;
 gms$crop;penalty_apr22;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 gms$c30_rotation_scenario;default;;;;;;;;;;;;;;;;;;;;;;;;;agroecology;;;;;;;;;;;;;;
-gms$c30_rotation_scenario_speed;by2050;;;;;;;;;;;;;;;;;;;;;;;;;by2050;;;;;;;;;;;;;;
+gms$s30_rotation_scenario_target;2050;;;;;;;;;;;;;;;;;;;;;;;;;2050;;;;;;;;;;;;;;
 gms$c30_marginal_land;q33_marginal;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 gms$c30_bioen_water;;;;;;;;;;;;;;;;;;;;;;;;;;;;rainfed;;;;;;;;;;;;
 gms$past;endo_jun13;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/modules/10_land/input/files
+++ b/modules/10_land/input/files
@@ -2,3 +2,4 @@
 avl_land_t.cs3
 avl_land_t_0.5.mz
 luh2_side_layers.cs3
+avl_land_t_iso.cs3

--- a/modules/10_land/landmatrix_dec18/input.gms
+++ b/modules/10_land/landmatrix_dec18/input.gms
@@ -20,3 +20,9 @@ $ondelim
 $include "./modules/10_land/input/luh2_side_layers.cs3"
 $offdelim
 ;
+
+table fm_land_iso(t_ini10,iso,land) Land area for different land pools at ISO level (mio. ha)
+$ondelim
+$include "./modules/10_land/input/avl_land_t_iso.cs3"
+$offdelim
+;

--- a/modules/22_land_conservation/area_based_apr22/input.gms
+++ b/modules/22_land_conservation/area_based_apr22/input.gms
@@ -10,7 +10,7 @@ $setglobal c22_protect_scenario_noselect  none
 
 scalars
 s22_restore_land  If land restoration is allowed (0=no 1=yes) / 1 /
-s22_conservation_start		Land conservation target year				/ 2020 /
+s22_conservation_start		Land conservation start year				/ 2020 /
 s22_conservation_target		Land conservation target year				/ 2030 /
 ;
 

--- a/modules/22_land_conservation/area_based_apr22/input.gms
+++ b/modules/22_land_conservation/area_based_apr22/input.gms
@@ -59,8 +59,3 @@ $include "./modules/22_land_conservation/input/consv_prio_areas.cs3"
 $offdelim
 ;
 
-table f22_land_iso(t_ini10,iso,land) Land area for different land pools at ISO level (mio. ha)
-$ondelim
-$include "./modules/22_land_conservation/input/avl_land_t_iso.cs3"
-$offdelim;
-

--- a/modules/22_land_conservation/area_based_apr22/preloop.gms
+++ b/modules/22_land_conservation/area_based_apr22/preloop.gms
@@ -17,7 +17,7 @@ p22_country_dummy(policy_countries22) = 1;
 * Because MAgPIE is not run at country-level, but at region level, a region
 * share is calculated that translates the countries' influence to regional level.
 * Countries are weighted by total land area.
-i22_land_iso(iso) = sum(land, f22_land_iso("y1995",iso,land));
+i22_land_iso(iso) = sum(land, fm_land_iso("y1995",iso,land));
 p22_country_weight(i) = sum(i_to_iso(i,iso), p22_country_dummy(iso) * i22_land_iso(iso)) / sum(i_to_iso(i,iso), i22_land_iso(iso));
 
 * ---------------------------------------------------------------------

--- a/modules/30_crop/endo_apr21/declarations.gms
+++ b/modules/30_crop/endo_apr21/declarations.gms
@@ -17,9 +17,9 @@ parameters
 
 positive variables
 * Fallow land is cropland which is temporarily fallow. Croparea+fallow=cropland
- vm_fallow(j)                   Fallow land (mio. ha)
- vm_area(j,kcr,w)                Agricultural production area (mio. ha)
- vm_rotation_penalty(i)                  Penalty for violating rotational constraints (USD05MER)
+ vm_fallow(j)                       Fallow land (mio. ha)
+ vm_area(j,kcr,w)                   Agricultural production area (mio. ha)
+ vm_rotation_penalty(i)             Penalty for violating rotational constraints (USD05MER)
 ;
 
 equations

--- a/modules/30_crop/endo_apr21/declarations.gms
+++ b/modules/30_crop/endo_apr21/declarations.gms
@@ -31,7 +31,7 @@ equations
  q30_carbon(j,ag_pools,stockType)   Cropland above ground carbon content calculation (mio. tC)
  q30_bv_ann(j,potnatveg)            Biodiversity value of annual cropland (mio. ha)
  q30_bv_per(j,potnatveg)            Biodiversity value of perennial cropland (mio. ha)
- q30_natveg_snv(j)                  Natural vegetation cover in cropland areas (mio. ha)
+ q30_land_snv(j)                    Land constraint for the SNV policy in cropland areas (mio. ha)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################
@@ -47,7 +47,7 @@ parameters
  oq30_carbon(t,j,ag_pools,stockType,type) Cropland above ground carbon content calculation (mio. tC)
  oq30_bv_ann(t,j,potnatveg,type)          Biodiversity value of annual cropland (mio. ha)
  oq30_bv_per(t,j,potnatveg,type)          Biodiversity value of perennial cropland (mio. ha)
- oq30_natveg_snv(t,j,type)                Natural vegetation cover in cropland areas (mio. ha)
+ oq30_land_snv(t,j,type)                  Land constraint for the SNV policy in cropland areas (mio. ha)
 ;
 *##################### R SECTION END (OUTPUT DECLARATIONS) #####################
 

--- a/modules/30_crop/endo_apr21/declarations.gms
+++ b/modules/30_crop/endo_apr21/declarations.gms
@@ -7,7 +7,8 @@
 
 parameters
  p30_avl_cropland(t,j)             	Total available land for crop cultivation (mio. ha)
- p30_region_snv_shr(i)			    SNV share of the region (1)
+ p30_country_snv_weight(i)			SNV policy country weight per region (1)
+ p30_snv_shr(t,j)                   Share of semi-natural vegetation in cropland areas (1)
  p30_country_dummy(iso)		        Dummy parameter indicating whether country is affected by selected SNV policy (1)
  i30_avl_cropland_iso(iso)			Available land area for cropland at ISO level (mio. ha)
 ;
@@ -26,8 +27,9 @@ equations
  q30_rotation_min(j,crp30,w)     Local minimum rotational constraints (mio. ha)
  q30_prod(j,kcr)                 Production of cropped products (mio. tDM)
  q30_carbon(j,ag_pools,stockType) Cropland above ground carbon content calculation (mio. tC)
- q30_bv_ann(j,potnatveg)         Biodiversity value of annual cropland (Mha)
- q30_bv_per(j,potnatveg)         Biodiversity value of perennial cropland (Mha)
+ q30_bv_ann(j,potnatveg)         Biodiversity value of annual cropland (mio. ha)
+ q30_bv_per(j,potnatveg)         Biodiversity value of perennial cropland (mio. ha)
+ q30_natveg_snv(j)               Natural vegetation cover in cropland areas (mio. ha)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################
@@ -41,8 +43,9 @@ parameters
  oq30_rotation_min(t,j,crp30,w,type)      Local minimum rotational constraints (mio. ha)
  oq30_prod(t,j,kcr,type)                  Production of cropped products (mio. tDM)
  oq30_carbon(t,j,ag_pools,stockType,type) Cropland above ground carbon content calculation (mio. tC)
- oq30_bv_ann(t,j,potnatveg,type)          Biodiversity value of annual cropland (Mha)
- oq30_bv_per(t,j,potnatveg,type)          Biodiversity value of perennial cropland (Mha)
+ oq30_bv_ann(t,j,potnatveg,type)          Biodiversity value of annual cropland (mio. ha)
+ oq30_bv_per(t,j,potnatveg,type)          Biodiversity value of perennial cropland (mio ha)
+ oq30_natveg_snv(t,j,type)                Natural vegetation cover in cropland areas (mio. ha)
 ;
 *##################### R SECTION END (OUTPUT DECLARATIONS) #####################
 

--- a/modules/30_crop/endo_apr21/declarations.gms
+++ b/modules/30_crop/endo_apr21/declarations.gms
@@ -6,11 +6,11 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 parameters
- p30_avl_cropland(t,j)             	Total available land for crop cultivation (mio. ha)
- p30_country_snv_weight(i)			SNV policy country weight per region (1)
+ p30_avl_cropland(t,j)              Total available land for crop cultivation (mio. ha)
+ p30_country_snv_weight(i)          SNV policy country weight per region (1)
  p30_snv_shr(t,j)                   Share of semi-natural vegetation in cropland areas (1)
- p30_country_dummy(iso)		        Dummy parameter indicating whether country is affected by selected SNV policy (1)
- i30_avl_cropland_iso(iso)			Available land area for cropland at ISO level (mio. ha)
+ p30_country_dummy(iso)             Dummy parameter indicating whether country is affected by selected SNV policy (1)
+ i30_avl_cropland_iso(iso)          Available land area for cropland at ISO level (mio. ha)
  p30_snv_scenario_fader(t_all)      SNV scenario fader (1)
  p30_rotation_scenario_fader(t_all) Crop rotation scenario fader (1)
 ;
@@ -23,15 +23,15 @@ positive variables
 ;
 
 equations
- q30_cropland(j)                 Total cropland calculation (mio. ha)
- q30_avl_cropland(j)             Available cropland constraint (mio. ha)
- q30_rotation_max(j,crp30,w)     Local maximum rotational constraints (mio. ha)
- q30_rotation_min(j,crp30,w)     Local minimum rotational constraints (mio. ha)
- q30_prod(j,kcr)                 Production of cropped products (mio. tDM)
- q30_carbon(j,ag_pools,stockType) Cropland above ground carbon content calculation (mio. tC)
- q30_bv_ann(j,potnatveg)         Biodiversity value of annual cropland (mio. ha)
- q30_bv_per(j,potnatveg)         Biodiversity value of perennial cropland (mio. ha)
- q30_natveg_snv(j)               Natural vegetation cover in cropland areas (mio. ha)
+ q30_cropland(j)                    Total cropland calculation (mio. ha)
+ q30_avl_cropland(j)                Available cropland constraint (mio. ha)
+ q30_rotation_max(j,crp30,w)        Local maximum rotational constraints (mio. ha)
+ q30_rotation_min(j,crp30,w)        Local minimum rotational constraints (mio. ha)
+ q30_prod(j,kcr)                    Production of cropped products (mio. tDM)
+ q30_carbon(j,ag_pools,stockType)   Cropland above ground carbon content calculation (mio. tC)
+ q30_bv_ann(j,potnatveg)            Biodiversity value of annual cropland (mio. ha)
+ q30_bv_per(j,potnatveg)            Biodiversity value of perennial cropland (mio. ha)
+ q30_natveg_snv(j)                  Natural vegetation cover in cropland areas (mio. ha)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################

--- a/modules/30_crop/endo_apr21/declarations.gms
+++ b/modules/30_crop/endo_apr21/declarations.gms
@@ -44,7 +44,7 @@ parameters
  oq30_prod(t,j,kcr,type)                  Production of cropped products (mio. tDM)
  oq30_carbon(t,j,ag_pools,stockType,type) Cropland above ground carbon content calculation (mio. tC)
  oq30_bv_ann(t,j,potnatveg,type)          Biodiversity value of annual cropland (mio. ha)
- oq30_bv_per(t,j,potnatveg,type)          Biodiversity value of perennial cropland (mio ha)
+ oq30_bv_per(t,j,potnatveg,type)          Biodiversity value of perennial cropland (mio. ha)
  oq30_natveg_snv(t,j,type)                Natural vegetation cover in cropland areas (mio. ha)
 ;
 *##################### R SECTION END (OUTPUT DECLARATIONS) #####################

--- a/modules/30_crop/endo_apr21/declarations.gms
+++ b/modules/30_crop/endo_apr21/declarations.gms
@@ -11,6 +11,8 @@ parameters
  p30_snv_shr(t,j)                   Share of semi-natural vegetation in cropland areas (1)
  p30_country_dummy(iso)		        Dummy parameter indicating whether country is affected by selected SNV policy (1)
  i30_avl_cropland_iso(iso)			Available land area for cropland at ISO level (mio. ha)
+ p30_snv_scenario_fader(t_all)      SNV scenario fader (1)
+ p30_rotation_scenario_fader(t_all) Crop rotation scenario fader (1)
 ;
 
 positive variables

--- a/modules/30_crop/endo_apr21/equations.gms
+++ b/modules/30_crop/endo_apr21/equations.gms
@@ -23,13 +23,14 @@
  q30_avl_cropland(j2) ..
    vm_land(j2,"crop") =l= sum(ct, p30_avl_cropland(ct,j2));
 
-*' Optionally, semi-natural vegetation in cropland areas can only include
-*' forest or other land (not grassland or forestry).
- q30_natveg_snv(j2)$s30_snv_natveg_only ..
-            sum(land_natveg, vm_land(j2,land_natveg))
+*' The semi-natural land constraint in cropland areas for sustaining critical regulating NCP
+*' for agricultural production is added on top of land conserved for other reasons
+*' (e.g. conservation of intact ecosystems or protection of biodiversity hotspots).
+ q30_land_snv(j2) ..
+            sum(land_snv, vm_land(j2,land_snv))
             =g=
             sum(ct, p30_snv_shr(ct,j2)) * vm_land(j2,"crop")
-          + sum((ct,land_natveg,consv_type), pm_land_conservation(ct,j2,land_natveg,consv_type));
+          + sum((ct,land_snv,consv_type), pm_land_conservation(ct,j2,land_snv,consv_type));
 
 *' As additional constraints minimum and maximum rotational constraints limit
 *' the placing of crops. On the one hand, these rotational constraints reflect

--- a/modules/30_crop/endo_apr21/equations.gms
+++ b/modules/30_crop/endo_apr21/equations.gms
@@ -24,7 +24,7 @@
    vm_land(j2,"crop") =l= sum(ct, p30_avl_cropland(ct,j2));
 
 *' Optionally, semi-natural vegetation in cropland areas can only include
-*' forest or other land (not grassland).
+*' forest or other land (not grassland or forestry).
  q30_natveg_snv(j2)$s30_snv_natveg_only ..
             sum(land_natveg, vm_land(j2,land_natveg))
             =g=

--- a/modules/30_crop/endo_apr21/equations.gms
+++ b/modules/30_crop/endo_apr21/equations.gms
@@ -20,8 +20,16 @@
 *' can be reduced by constraining the cropland area in favour of other land types,
 *' in order to increase compositional heterogeneity of land types at the cell level.
 
- q30_avl_cropland(j2)  ..
+ q30_avl_cropland(j2) ..
    vm_land(j2,"crop") =l= sum(ct, p30_avl_cropland(ct,j2));
+
+*' Optionally, semi-natural vegetation in cropland areas can only include
+*' forest or other land (not grassland).
+ q30_natveg_snv(j2)$s30_snv_natveg_only ..
+            sum(land_natveg, vm_land(j2,land_natveg))
+            =g=
+            sum(ct, p30_snv_shr(ct,j2)) * vm_land(j2,"crop")
+          + sum((ct,land_natveg,consv_type), pm_land_conservation(ct,j2,land_natveg,consv_type));
 
 *' As additional constraints minimum and maximum rotational constraints limit
 *' the placing of crops. On the one hand, these rotational constraints reflect

--- a/modules/30_crop/endo_apr21/input.gms
+++ b/modules/30_crop/endo_apr21/input.gms
@@ -82,8 +82,9 @@ $if "%c30_rotation_constraints%" == "off" f30_rotation_min_shr(crp30) = 0;
 ********* AVAILABLE CROPLAND *******************************************
 
 scalar
-s30_snv_shr   		Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (1) / 0 /
 ;
 
 table f30_avl_cropland(j,marginal_land30) Available land area for cropland (mio. ha)

--- a/modules/30_crop/endo_apr21/input.gms
+++ b/modules/30_crop/endo_apr21/input.gms
@@ -24,10 +24,10 @@ scalars
 s30_snv_shr   		              Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect 	          Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
-s30_snv_scenario_start		      SNV scnenario start year			/ 2020 /
-s30_snv_scenario_target		      SNV scnenario target year			/ 2030 /
-s30_rotation_scenario_start		  SNV scnenario start year			/ 2020 /
-s30_rotation_scenario_target		SNV scnenario target year			/ 2050 /
+s30_snv_scenario_start		      SNV scenario start year			/ 2020 /
+s30_snv_scenario_target		      SNV scenario target year			/ 2030 /
+s30_rotation_scenario_start		  Rotation scenario start year			/ 2020 /
+s30_rotation_scenario_target		Rotation scenario target year			/ 2050 /
 ;
 
 * Set-switch for countries affected by regional SNV policy

--- a/modules/30_crop/endo_apr21/input.gms
+++ b/modules/30_crop/endo_apr21/input.gms
@@ -23,7 +23,6 @@ $setglobal c30_rotation_constraints  on
 scalars
 s30_snv_shr                     Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect            Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only             Whether only primary and secondary forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
 s30_snv_scenario_start          SNV scenario start year			/ 2020 /
 s30_snv_scenario_target         SNV scenario target year			/ 2030 /
 s30_rotation_scenario_start     Rotation scenario start year			/ 2020 /
@@ -58,6 +57,8 @@ sets
                           TKL,TKM,TLS,TON,TTO,TUN,TUR,TUV,TWN,TZA,
                           UGA,UKR,UMI,URY,USA,UZB,VAT,VCT,VEN,VGB,
                           VIR,VNM,VUT,WLF,WSM,YEM,ZAF,ZMB,ZWE /
+
+land_snv(land) land types allowed in the SNV policy / secdforest, forestry, past, other /
 ;
 
 ********* CROPAREA INITIALISATION **********************************************

--- a/modules/30_crop/endo_apr21/input.gms
+++ b/modules/30_crop/endo_apr21/input.gms
@@ -20,6 +20,16 @@ $setglobal c30_snv_target  none
 $setglobal c30_rotation_constraints  on
 *options: on, off
 
+scalars
+s30_snv_shr   		              Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr_noselect 	          Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
+s30_snv_scenario_start		      SNV scnenario start year			/ 2020 /
+s30_snv_scenario_target		      SNV scnenario target year			/ 2030 /
+s30_rotation_scenario_start		  SNV scnenario start year			/ 2020 /
+s30_rotation_scenario_target		SNV scnenario target year			/ 2050 /
+;
+
 * Set-switch for countries affected by regional SNV policy
 * Default: all iso countries selected
 sets
@@ -81,11 +91,6 @@ $if "%c30_rotation_constraints%" == "off" f30_rotation_min_shr(crp30) = 0;
 
 ********* AVAILABLE CROPLAND *******************************************
 
-scalar
-s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (1) / 0 /
-;
 
 table f30_avl_cropland(j,marginal_land30) Available land area for cropland (mio. ha)
 $ondelim
@@ -99,8 +104,3 @@ $include "./modules/30_crop/endo_apr21/input/avl_cropland_iso.cs3"
 $offdelim
 ;
 
-table f30_scenario_fader(t_all,policy_target30) Fader for cropland policies (unitless)
-$ondelim
-$include "./modules/30_crop/endo_apr21/input/f30_scenario_fader.csv"
-$offdelim
-;

--- a/modules/30_crop/endo_apr21/input.gms
+++ b/modules/30_crop/endo_apr21/input.gms
@@ -23,7 +23,7 @@ $setglobal c30_rotation_constraints  on
 scalars
 s30_snv_shr                     Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect            Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
+s30_snv_natveg_only             Whether only primary and secondary forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
 s30_snv_scenario_start          SNV scenario start year			/ 2020 /
 s30_snv_scenario_target         SNV scenario target year			/ 2030 /
 s30_rotation_scenario_start     Rotation scenario start year			/ 2020 /

--- a/modules/30_crop/endo_apr21/input.gms
+++ b/modules/30_crop/endo_apr21/input.gms
@@ -21,13 +21,13 @@ $setglobal c30_rotation_constraints  on
 *options: on, off
 
 scalars
-s30_snv_shr   		              Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_shr_noselect 	          Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr                     Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr_noselect            Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
-s30_snv_scenario_start		      SNV scenario start year			/ 2020 /
-s30_snv_scenario_target		      SNV scenario target year			/ 2030 /
-s30_rotation_scenario_start		  Rotation scenario start year			/ 2020 /
-s30_rotation_scenario_target		Rotation scenario target year			/ 2050 /
+s30_snv_scenario_start          SNV scenario start year			/ 2020 /
+s30_snv_scenario_target         SNV scenario target year			/ 2030 /
+s30_rotation_scenario_start     Rotation scenario start year			/ 2020 /
+s30_rotation_scenario_target    Rotation scenario target year			/ 2050 /
 ;
 
 * Set-switch for countries affected by regional SNV policy

--- a/modules/30_crop/endo_apr21/input/files
+++ b/modules/30_crop/endo_apr21/input/files
@@ -3,6 +3,5 @@ f30_rotation_max.csv
 f30_rotation_min.csv
 avl_cropland.cs3
 avl_cropland_0.5.mz
-
 f30_croparea_w_initialisation.cs3
 avl_cropland_iso.cs3

--- a/modules/30_crop/endo_apr21/input/files
+++ b/modules/30_crop/endo_apr21/input/files
@@ -3,6 +3,6 @@ f30_rotation_max.csv
 f30_rotation_min.csv
 avl_cropland.cs3
 avl_cropland_0.5.mz
-f30_scenario_fader.csv
+
 f30_croparea_w_initialisation.cs3
 avl_cropland_iso.cs3

--- a/modules/30_crop/endo_apr21/postsolve.gms
+++ b/modules/30_crop/endo_apr21/postsolve.gms
@@ -18,7 +18,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"marginal") = q30_carbon.m(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"marginal")          = q30_bv_ann.m(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"marginal")          = q30_bv_per.m(j,potnatveg);
- oq30_natveg_snv(t,j,"marginal")                = q30_natveg_snv.m(j);
+ oq30_land_snv(t,j,"marginal")                  = q30_land_snv.m(j);
  ov_fallow(t,j,"level")                         = vm_fallow.l(j);
  ov_area(t,j,kcr,w,"level")                     = vm_area.l(j,kcr,w);
  ov_rotation_penalty(t,i,"level")               = vm_rotation_penalty.l(i);
@@ -30,7 +30,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"level")    = q30_carbon.l(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"level")             = q30_bv_ann.l(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"level")             = q30_bv_per.l(j,potnatveg);
- oq30_natveg_snv(t,j,"level")                   = q30_natveg_snv.l(j);
+ oq30_land_snv(t,j,"level")                     = q30_land_snv.l(j);
  ov_fallow(t,j,"upper")                         = vm_fallow.up(j);
  ov_area(t,j,kcr,w,"upper")                     = vm_area.up(j,kcr,w);
  ov_rotation_penalty(t,i,"upper")               = vm_rotation_penalty.up(i);
@@ -42,7 +42,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"upper")    = q30_carbon.up(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"upper")             = q30_bv_ann.up(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"upper")             = q30_bv_per.up(j,potnatveg);
- oq30_natveg_snv(t,j,"upper")                   = q30_natveg_snv.up(j);
+ oq30_land_snv(t,j,"upper")                     = q30_land_snv.up(j);
  ov_fallow(t,j,"lower")                         = vm_fallow.lo(j);
  ov_area(t,j,kcr,w,"lower")                     = vm_area.lo(j,kcr,w);
  ov_rotation_penalty(t,i,"lower")               = vm_rotation_penalty.lo(i);
@@ -54,5 +54,5 @@
  oq30_carbon(t,j,ag_pools,stockType,"lower")    = q30_carbon.lo(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"lower")             = q30_bv_ann.lo(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"lower")             = q30_bv_per.lo(j,potnatveg);
- oq30_natveg_snv(t,j,"lower")                   = q30_natveg_snv.lo(j);
+ oq30_land_snv(t,j,"lower")                     = q30_land_snv.lo(j);
 *##################### R SECTION END (OUTPUT DEFINITIONS) ######################

--- a/modules/30_crop/endo_apr21/postsolve.gms
+++ b/modules/30_crop/endo_apr21/postsolve.gms
@@ -18,6 +18,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"marginal") = q30_carbon.m(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"marginal")          = q30_bv_ann.m(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"marginal")          = q30_bv_per.m(j,potnatveg);
+ oq30_natveg_snv(t,j,"marginal")                = q30_natveg_snv.m(j);
  ov_fallow(t,j,"level")                         = vm_fallow.l(j);
  ov_area(t,j,kcr,w,"level")                     = vm_area.l(j,kcr,w);
  ov_rotation_penalty(t,i,"level")               = vm_rotation_penalty.l(i);
@@ -29,6 +30,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"level")    = q30_carbon.l(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"level")             = q30_bv_ann.l(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"level")             = q30_bv_per.l(j,potnatveg);
+ oq30_natveg_snv(t,j,"level")                   = q30_natveg_snv.l(j);
  ov_fallow(t,j,"upper")                         = vm_fallow.up(j);
  ov_area(t,j,kcr,w,"upper")                     = vm_area.up(j,kcr,w);
  ov_rotation_penalty(t,i,"upper")               = vm_rotation_penalty.up(i);
@@ -40,6 +42,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"upper")    = q30_carbon.up(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"upper")             = q30_bv_ann.up(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"upper")             = q30_bv_per.up(j,potnatveg);
+ oq30_natveg_snv(t,j,"upper")                   = q30_natveg_snv.up(j);
  ov_fallow(t,j,"lower")                         = vm_fallow.lo(j);
  ov_area(t,j,kcr,w,"lower")                     = vm_area.lo(j,kcr,w);
  ov_rotation_penalty(t,i,"lower")               = vm_rotation_penalty.lo(i);
@@ -51,4 +54,5 @@
  oq30_carbon(t,j,ag_pools,stockType,"lower")    = q30_carbon.lo(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"lower")             = q30_bv_ann.lo(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"lower")             = q30_bv_per.lo(j,potnatveg);
+ oq30_natveg_snv(t,j,"lower")                   = q30_natveg_snv.lo(j);
 *##################### R SECTION END (OUTPUT DEFINITIONS) ######################

--- a/modules/30_crop/endo_apr21/preloop.gms
+++ b/modules/30_crop/endo_apr21/preloop.gms
@@ -5,6 +5,11 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
+** Trajectory for cropland scenarios
+* sigmoidal interpolation between start year and target year
+m_sigmoid_interpol(p30_snv_scenario_fader,s30_snv_scenario_start,s30_snv_scenario_target,0,1);
+m_sigmoid_interpol(p30_rotation_scenario_fader,s30_rotation_scenario_start,s30_rotation_scenario_target,0,1);
+
 *due to some rounding errors the input data currently may contain in some cases
 *very small, negative numbers. These numbers have to be set to 0 as area
 *cannot be smaller than 0!
@@ -20,8 +25,3 @@ p30_country_dummy(policy_countries30) = 1;
 * Countries are weighted by available cropland area.
 i30_avl_cropland_iso(iso) = f30_avl_cropland_iso(iso,"%c30_marginal_land%");
 p30_country_snv_weight(i) = sum(i_to_iso(i,iso), p30_country_dummy(iso) * i30_avl_cropland_iso(iso)) / sum(i_to_iso(i,iso), i30_avl_cropland_iso(iso));
-
-** Trajectory for cropland scenarios
-* sigmoidal interpolation between start year and target year
-m_sigmoid_interpol(p30_snv_scenario_fader,s30_snv_scenario_start,s30_snv_scenario_target,0,1);
-m_sigmoid_interpol(p30_rotation_scenario_fader,s30_rotation_scenario_start,s30_rotation_scenario_target,0,1);

--- a/modules/30_crop/endo_apr21/preloop.gms
+++ b/modules/30_crop/endo_apr21/preloop.gms
@@ -20,3 +20,8 @@ p30_country_dummy(policy_countries30) = 1;
 * Countries are weighted by available cropland area.
 i30_avl_cropland_iso(iso) = f30_avl_cropland_iso(iso,"%c30_marginal_land%");
 p30_country_snv_weight(i) = sum(i_to_iso(i,iso), p30_country_dummy(iso) * i30_avl_cropland_iso(iso)) / sum(i_to_iso(i,iso), i30_avl_cropland_iso(iso));
+
+** Trajectory for cropland scenarios
+* sigmoidal interpolation between start year and target year
+m_sigmoid_interpol(p30_snv_scenario_fader,s30_snv_scenario_start,s30_snv_scenario_target,0,1);
+m_sigmoid_interpol(p30_rotation_scenario_fader,s30_rotation_scenario_start,s30_rotation_scenario_target,0,1);

--- a/modules/30_crop/endo_apr21/preloop.gms
+++ b/modules/30_crop/endo_apr21/preloop.gms
@@ -19,4 +19,4 @@ p30_country_dummy(policy_countries30) = 1;
 * share is calculated that translates the countries' influence to regional level.
 * Countries are weighted by available cropland area.
 i30_avl_cropland_iso(iso) = f30_avl_cropland_iso(iso,"%c30_marginal_land%");
-p30_region_snv_shr(i) = sum(i_to_iso(i,iso), p30_country_dummy(iso) * i30_avl_cropland_iso(iso)) / sum(i_to_iso(i,iso), i30_avl_cropland_iso(iso));
+p30_country_snv_weight(i) = sum(i_to_iso(i,iso), p30_country_dummy(iso) * i30_avl_cropland_iso(iso)) / sum(i_to_iso(i,iso), i30_avl_cropland_iso(iso));

--- a/modules/30_crop/endo_apr21/presolve.gms
+++ b/modules/30_crop/endo_apr21/presolve.gms
@@ -31,8 +31,10 @@ crpmin30(crp30) = yes$(f30_rotation_min_shr(crp30) > 0);
 
 *' @code
 *' Minimum semi-natural vegetation (SNV) share is fading in after 2020
-p30_avl_cropland(t,j) = f30_avl_cropland(j,"%c30_marginal_land%") *
-	(1 - f30_scenario_fader(t,"%c30_snv_target%") *
-	(s30_snv_shr * sum(cell(i,j), p30_region_snv_shr(i))
-	+ s30_snv_shr_noselect * sum(cell(i,j), 1-p30_region_snv_shr(i))));
+p30_snv_shr(t,j) = f30_scenario_fader(t,"%c30_snv_target%") *
+	(s30_snv_shr * sum(cell(i,j), p30_country_snv_weight(i))
+	+ s30_snv_shr_noselect * sum(cell(i,j), 1-p30_country_snv_weight(i)));
+
+*' Area potentially available for cropping
+p30_avl_cropland(t,j) = f30_avl_cropland(j,"%c30_marginal_land%") * (1 - p30_snv_shr(t,j));
 *' @stop

--- a/modules/30_crop/endo_apr21/presolve.gms
+++ b/modules/30_crop/endo_apr21/presolve.gms
@@ -31,7 +31,7 @@ crpmin30(crp30) = yes$(f30_rotation_min_shr(crp30) > 0);
 
 *' @code
 *' Minimum semi-natural vegetation (SNV) share is fading in after 2020
-p30_snv_shr(t,j) = f30_scenario_fader(t,"%c30_snv_target%") *
+p30_snv_shr(t,j) = p30_snv_scenario_fader(t) *
 	(s30_snv_shr * sum(cell(i,j), p30_country_snv_weight(i))
 	+ s30_snv_shr_noselect * sum(cell(i,j), 1-p30_country_snv_weight(i)));
 

--- a/modules/30_crop/penalty_apr22/declarations.gms
+++ b/modules/30_crop/penalty_apr22/declarations.gms
@@ -6,11 +6,11 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 parameters
- p30_avl_cropland(t,j)             	    Total available land for crop cultivation (mio. ha)
- p30_country_snv_weight(i)			    SNV policy country weight per region (1)
+ p30_avl_cropland(t,j)                  Total available land for crop cultivation (mio. ha)
+ p30_country_snv_weight(i)              SNV policy country weight per region (1)
  p30_snv_shr(t,j)                       Share of semi-natural vegetation in cropland areas (1)
- p30_country_dummy(iso)		            Dummy parameter indicating whether country is affected by selected SNV policy (1)
- i30_avl_cropland_iso(iso)			    Available land area for cropland at ISO level (mio. ha)
+ p30_country_dummy(iso)                 Dummy parameter indicating whether country is affected by selected SNV policy (1)
+ i30_avl_cropland_iso(iso)              Available land area for cropland at ISO level (mio. ha)
  i30_rotation_incentives(t_all,rota30)  Penalty for violating rotational constraints (USD05MER per ha)
  p30_snv_scenario_fader(t_all)          SNV scenario fader (1)
  p30_rotation_scenario_fader(t_all)     Crop rotation scenario fader (1)

--- a/modules/30_crop/penalty_apr22/declarations.gms
+++ b/modules/30_crop/penalty_apr22/declarations.gms
@@ -18,10 +18,10 @@ parameters
 
 positive variables
 * Fallow land is cropland which is temporarily fallow. Croparea+fallow=cropland
- vm_fallow(j)                   Fallow land (mio. ha)
- vm_area(j,kcr,w)                Agricultural production area (mio. ha)
- vm_rotation_penalty(i)                  Penalty for violating rotational constraints (mio. USD05MER)
- v30_penalty_max_irrig(j,rotamax30) Penalty for violating max rotational constraints on irrigated land (mio. USD05MER)
+ vm_fallow(j)                         Fallow land (mio. ha)
+ vm_area(j,kcr,w)                     Agricultural production area (mio. ha)
+ vm_rotation_penalty(i)               Penalty for violating rotational constraints (mio. USD05MER)
+ v30_penalty_max_irrig(j,rotamax30)   Penalty for violating max rotational constraints on irrigated land (mio. USD05MER)
  v30_penalty(j,rota30) Penalty for violating rotational constraints (mio. USD05MER)
 ;
 

--- a/modules/30_crop/penalty_apr22/declarations.gms
+++ b/modules/30_crop/penalty_apr22/declarations.gms
@@ -6,12 +6,14 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 parameters
- p30_avl_cropland(t,j)             	Total available land for crop cultivation (mio. ha)
- p30_country_snv_weight(i)			SNV policy country weight per region (1)
- p30_snv_shr(t,j)                   Share of semi-natural vegetation in cropland areas (1)
- p30_country_dummy(iso)		        Dummy parameter indicating whether country is affected by selected SNV policy (1)
- i30_avl_cropland_iso(iso)			Available land area for cropland at ISO level (mio. ha)
- i30_rotation_incentives(t_all,rota30)   Penalty for violating rotational constraints (USD05MER per ha)
+ p30_avl_cropland(t,j)             	    Total available land for crop cultivation (mio. ha)
+ p30_country_snv_weight(i)			    SNV policy country weight per region (1)
+ p30_snv_shr(t,j)                       Share of semi-natural vegetation in cropland areas (1)
+ p30_country_dummy(iso)		            Dummy parameter indicating whether country is affected by selected SNV policy (1)
+ i30_avl_cropland_iso(iso)			    Available land area for cropland at ISO level (mio. ha)
+ i30_rotation_incentives(t_all,rota30)  Penalty for violating rotational constraints (USD05MER per ha)
+ p30_snv_scenario_fader(t_all)          SNV scenario fader (1)
+ p30_rotation_scenario_fader(t_all)     Crop rotation scenario fader (1)
 ;
 
 positive variables
@@ -33,8 +35,8 @@ equations
  q30_prod(j,kcr)                      Production of cropped products (mio. tDM)
  q30_carbon(j,ag_pools,stockType)     Cropland above ground carbon content calculation (mio. tC)
  q30_bv_ann(j,potnatveg)              Biodiversity value of annual cropland (mio. ha)
- q30_bv_per(j,potnatveg)         Biodiversity value of perennial cropland (mio. ha)
- q30_natveg_snv(j)               Natural vegetation cover in cropland areas (mio. ha)
+ q30_bv_per(j,potnatveg)              Biodiversity value of perennial cropland (mio. ha)
+ q30_natveg_snv(j)                    Natural vegetation cover in cropland areas (mio. ha)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################

--- a/modules/30_crop/penalty_apr22/declarations.gms
+++ b/modules/30_crop/penalty_apr22/declarations.gms
@@ -52,8 +52,9 @@ parameters
  oq30_rotation_max_irrig(t,j,rotamax30,type) Local maximum rotational constraints (mio. ha)
  oq30_prod(t,j,kcr,type)                     Production of cropped products (mio. tDM)
  oq30_carbon(t,j,ag_pools,stockType,type)    Cropland above ground carbon content calculation (mio. tC)
- oq30_bv_ann(t,j,potnatveg,type)             Biodiversity value of annual cropland (Mha)
- oq30_bv_per(t,j,potnatveg,type)             Biodiversity value of perennial cropland (Mha)
+ oq30_bv_ann(t,j,potnatveg,type)             Biodiversity value of annual cropland (mio. ha)
+ oq30_bv_per(t,j,potnatveg,type)             Biodiversity value of perennial cropland (mio. ha)
+ oq30_natveg_snv(t,j,type)                   Natural vegetation cover in cropland areas (mio. ha)
 ;
 *##################### R SECTION END (OUTPUT DECLARATIONS) #####################
 

--- a/modules/30_crop/penalty_apr22/declarations.gms
+++ b/modules/30_crop/penalty_apr22/declarations.gms
@@ -36,7 +36,7 @@ equations
  q30_carbon(j,ag_pools,stockType)     Cropland above ground carbon content calculation (mio. tC)
  q30_bv_ann(j,potnatveg)              Biodiversity value of annual cropland (mio. ha)
  q30_bv_per(j,potnatveg)              Biodiversity value of perennial cropland (mio. ha)
- q30_natveg_snv(j)                    Natural vegetation cover in cropland areas (mio. ha)
+ q30_land_snv(j)                    Land constraint for the SNV policy in cropland areas (mio. ha)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################
@@ -56,7 +56,7 @@ parameters
  oq30_carbon(t,j,ag_pools,stockType,type)    Cropland above ground carbon content calculation (mio. tC)
  oq30_bv_ann(t,j,potnatveg,type)             Biodiversity value of annual cropland (mio. ha)
  oq30_bv_per(t,j,potnatveg,type)             Biodiversity value of perennial cropland (mio. ha)
- oq30_natveg_snv(t,j,type)                   Natural vegetation cover in cropland areas (mio. ha)
+ oq30_land_snv(t,j,type)                     Land constraint for the SNV policy in cropland areas (mio. ha)
 ;
 *##################### R SECTION END (OUTPUT DECLARATIONS) #####################
 

--- a/modules/30_crop/penalty_apr22/declarations.gms
+++ b/modules/30_crop/penalty_apr22/declarations.gms
@@ -7,7 +7,8 @@
 
 parameters
  p30_avl_cropland(t,j)             	Total available land for crop cultivation (mio. ha)
- p30_region_snv_shr(i)			    SNV share of the region (1)
+ p30_country_snv_weight(i)			SNV policy country weight per region (1)
+ p30_snv_shr(t,j)                   Share of semi-natural vegetation in cropland areas (1)
  p30_country_dummy(iso)		        Dummy parameter indicating whether country is affected by selected SNV policy (1)
  i30_avl_cropland_iso(iso)			Available land area for cropland at ISO level (mio. ha)
  i30_rotation_incentives(t_all,rota30)   Penalty for violating rotational constraints (USD05MER per ha)
@@ -31,8 +32,9 @@ equations
  q30_rotation_max_irrig(j,rotamax30)  Local maximum rotational constraints (mio. ha)
  q30_prod(j,kcr)                      Production of cropped products (mio. tDM)
  q30_carbon(j,ag_pools,stockType)     Cropland above ground carbon content calculation (mio. tC)
- q30_bv_ann(j,potnatveg)              Biodiversity value of annual cropland (Mha)
- q30_bv_per(j,potnatveg)              Biodiversity value of perennial cropland (Mha)
+ q30_bv_ann(j,potnatveg)              Biodiversity value of annual cropland (mio. ha)
+ q30_bv_per(j,potnatveg)         Biodiversity value of perennial cropland (mio. ha)
+ q30_natveg_snv(j)               Natural vegetation cover in cropland areas (mio. ha)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################

--- a/modules/30_crop/penalty_apr22/equations.gms
+++ b/modules/30_crop/penalty_apr22/equations.gms
@@ -23,8 +23,16 @@
 *' can be reduced by constraining the cropland area in favour of other land types,
 *' in order to increase compositional heterogeneity of land types at the cell level.
 
- q30_avl_cropland(j2)  ..
+ q30_avl_cropland(j2) ..
    vm_land(j2,"crop") =l= sum(ct, p30_avl_cropland(ct,j2));
+
+*' Optionally, semi-natural vegetation in cropland areas can only include
+*' forest or other land (not grassland).
+ q30_natveg_snv(j2)$s30_snv_natveg_only ..
+            sum(land_natveg, vm_land(j2,land_natveg))
+            =g=
+            sum(ct, p30_snv_shr(ct,j2)) * vm_land(j2,"crop")
+          + sum((ct,land_natveg,consv_type), pm_land_conservation(ct,j2,land_natveg,consv_type));
 
 *' Rotational constraints prevent over-specialization. In this module realization,
 *' they are implemented via a penalty payment if the constraints are violated.

--- a/modules/30_crop/penalty_apr22/equations.gms
+++ b/modules/30_crop/penalty_apr22/equations.gms
@@ -27,7 +27,7 @@
    vm_land(j2,"crop") =l= sum(ct, p30_avl_cropland(ct,j2));
 
 *' Optionally, semi-natural vegetation in cropland areas can only include
-*' forest or other land (not grassland).
+*' forest or other land (not grassland or forestry).
  q30_natveg_snv(j2)$s30_snv_natveg_only ..
             sum(land_natveg, vm_land(j2,land_natveg))
             =g=

--- a/modules/30_crop/penalty_apr22/equations.gms
+++ b/modules/30_crop/penalty_apr22/equations.gms
@@ -26,13 +26,14 @@
  q30_avl_cropland(j2) ..
    vm_land(j2,"crop") =l= sum(ct, p30_avl_cropland(ct,j2));
 
-*' Optionally, semi-natural vegetation in cropland areas can only include
-*' forest or other land (not grassland or forestry).
- q30_natveg_snv(j2)$s30_snv_natveg_only ..
-            sum(land_natveg, vm_land(j2,land_natveg))
+*' The semi-natural land constraint in cropland areas for sustaining critical regulating NCP
+*' for agricultural production is added on top of land conserved for other reasons
+*' (e.g. conservation of intact ecosystems or protection of biodiversity hotspots).
+ q30_land_snv(j2) ..
+            sum(land_snv, vm_land(j2,land_snv))
             =g=
             sum(ct, p30_snv_shr(ct,j2)) * vm_land(j2,"crop")
-          + sum((ct,land_natveg,consv_type), pm_land_conservation(ct,j2,land_natveg,consv_type));
+          + sum((ct,land_snv,consv_type), pm_land_conservation(ct,j2,land_snv,consv_type));
 
 *' Rotational constraints prevent over-specialization. In this module realization,
 *' they are implemented via a penalty payment if the constraints are violated.

--- a/modules/30_crop/penalty_apr22/input.gms
+++ b/modules/30_crop/penalty_apr22/input.gms
@@ -27,13 +27,13 @@ $setglobal c30_rotation_scenario_speed  by2050
 * options: none, by2030, by2020
 
 scalars
-s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
-s30_snv_scenario_start		SNV scnenario start year			/ 2020 /
-s30_snv_scenario_target		SNV scnenario target year			/ 2030 /
-s30_rotation_scenario_start		SNV scnenario start year			/ 2020 /
-s30_rotation_scenario_target		SNV scnenario target year			/ 2050 /
+s30_snv_shr   		              Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr_noselect 	          Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
+s30_snv_scenario_start		      SNV scenario start year			/ 2020 /
+s30_snv_scenario_target		      SNV scenario target year			/ 2030 /
+s30_rotation_scenario_start		  Rotation scenario start year			/ 2020 /
+s30_rotation_scenario_target		Rotation scenario target year			/ 2050 /
 ;
 
 * Set-switch for countries affected by regional SNV policy

--- a/modules/30_crop/penalty_apr22/input.gms
+++ b/modules/30_crop/penalty_apr22/input.gms
@@ -29,7 +29,6 @@ $setglobal c30_rotation_scenario_speed  by2050
 scalars
 s30_snv_shr                     Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect            Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only             Whether only primary and secondary forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
 s30_snv_scenario_start          SNV scenario start year			/ 2020 /
 s30_snv_scenario_target         SNV scenario target year			/ 2030 /
 s30_rotation_scenario_start     Rotation scenario start year			/ 2020 /
@@ -64,6 +63,8 @@ sets
                           TKL,TKM,TLS,TON,TTO,TUN,TUR,TUV,TWN,TZA,
                           UGA,UKR,UMI,URY,USA,UZB,VAT,VCT,VEN,VGB,
                           VIR,VNM,VUT,WLF,WSM,YEM,ZAF,ZMB,ZWE /
+
+land_snv(land) land types allowed in the SNV policy / secdforest, forestry, past, other /
 ;
 
 ********* CROPAREA INITIALISATION **********************************************

--- a/modules/30_crop/penalty_apr22/input.gms
+++ b/modules/30_crop/penalty_apr22/input.gms
@@ -27,13 +27,13 @@ $setglobal c30_rotation_scenario_speed  by2050
 * options: none, by2030, by2020
 
 scalars
-s30_snv_shr   		              Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_shr_noselect 	          Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr                     Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr_noselect            Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
-s30_snv_scenario_start		      SNV scenario start year			/ 2020 /
-s30_snv_scenario_target		      SNV scenario target year			/ 2030 /
-s30_rotation_scenario_start		  Rotation scenario start year			/ 2020 /
-s30_rotation_scenario_target		Rotation scenario target year			/ 2050 /
+s30_snv_scenario_start          SNV scenario start year			/ 2020 /
+s30_snv_scenario_target         SNV scenario target year			/ 2030 /
+s30_rotation_scenario_start     Rotation scenario start year			/ 2020 /
+s30_rotation_scenario_target    Rotation scenario target year			/ 2050 /
 ;
 
 * Set-switch for countries affected by regional SNV policy

--- a/modules/30_crop/penalty_apr22/input.gms
+++ b/modules/30_crop/penalty_apr22/input.gms
@@ -11,7 +11,7 @@ $setglobal c30_bioen_type  all
 $setglobal c30_bioen_water  rainfed
 * options: rainfed, irrigated, all
 
-$setglobal c30_marginal_land  all_marginal
+$setglobal c30_marginal_land  q33_marginal
 * options: all_marginal, q33_marginal, no_marginal
 
 $setglobal c30_snv_target  none
@@ -85,8 +85,9 @@ $offdelim
 ********* AVAILABLE CROPLAND *******************************************
 
 scalar
-s30_snv_shr   		Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (1) / 0 /
 ;
 
 table f30_avl_cropland(j,marginal_land30) Available land area for cropland (mio. ha)

--- a/modules/30_crop/penalty_apr22/input.gms
+++ b/modules/30_crop/penalty_apr22/input.gms
@@ -29,7 +29,7 @@ $setglobal c30_rotation_scenario_speed  by2050
 scalars
 s30_snv_shr                     Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect            Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
+s30_snv_natveg_only             Whether only primary and secondary forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
 s30_snv_scenario_start          SNV scenario start year			/ 2020 /
 s30_snv_scenario_target         SNV scenario target year			/ 2030 /
 s30_rotation_scenario_start     Rotation scenario start year			/ 2020 /

--- a/modules/30_crop/penalty_apr22/input.gms
+++ b/modules/30_crop/penalty_apr22/input.gms
@@ -26,6 +26,16 @@ $setglobal c30_rotation_scenario  default
 $setglobal c30_rotation_scenario_speed  by2050
 * options: none, by2030, by2020
 
+scalars
+s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
+s30_snv_scenario_start		SNV scnenario start year			/ 2020 /
+s30_snv_scenario_target		SNV scnenario target year			/ 2030 /
+s30_rotation_scenario_start		SNV scnenario start year			/ 2020 /
+s30_rotation_scenario_target		SNV scnenario target year			/ 2050 /
+;
+
 * Set-switch for countries affected by regional SNV policy
 * Default: all iso countries selected
 sets
@@ -84,12 +94,6 @@ $offdelim
 
 ********* AVAILABLE CROPLAND *******************************************
 
-scalar
-s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (1) / 0 /
-;
-
 table f30_avl_cropland(j,marginal_land30) Available land area for cropland (mio. ha)
 $ondelim
 $include "./modules/30_crop/penalty_apr22/input/avl_cropland.cs3"
@@ -102,8 +106,3 @@ $include "./modules/30_crop/penalty_apr22/input/avl_cropland_iso.cs3"
 $offdelim
 ;
 
-table f30_scenario_fader(t_all,policy_target30) Fader for scenario implementation speed (unitless)
-$ondelim
-$include "./modules/30_crop/penalty_apr22/input/f30_scenario_fader.csv"
-$offdelim
-;

--- a/modules/30_crop/penalty_apr22/input/files
+++ b/modules/30_crop/penalty_apr22/input/files
@@ -3,6 +3,5 @@ f30_rotation_incentives.csv
 f30_rotation_rules.csv
 avl_cropland.cs3
 avl_cropland_0.5.mz
-
 f30_croparea_w_initialisation.cs3
 avl_cropland_iso.cs3

--- a/modules/30_crop/penalty_apr22/input/files
+++ b/modules/30_crop/penalty_apr22/input/files
@@ -3,6 +3,6 @@ f30_rotation_incentives.csv
 f30_rotation_rules.csv
 avl_cropland.cs3
 avl_cropland_0.5.mz
-f30_scenario_fader.csv
+
 f30_croparea_w_initialisation.cs3
 avl_cropland_iso.cs3

--- a/modules/30_crop/penalty_apr22/postsolve.gms
+++ b/modules/30_crop/penalty_apr22/postsolve.gms
@@ -22,6 +22,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"marginal")    = q30_carbon.m(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"marginal")             = q30_bv_ann.m(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"marginal")             = q30_bv_per.m(j,potnatveg);
+ oq30_natveg_snv(t,j,"marginal")                   = q30_natveg_snv.m(j);
  ov_fallow(t,j,"level")                            = vm_fallow.l(j);
  ov_area(t,j,kcr,w,"level")                        = vm_area.l(j,kcr,w);
  ov_rotation_penalty(t,i,"level")                  = vm_rotation_penalty.l(i);
@@ -37,6 +38,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"level")       = q30_carbon.l(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"level")                = q30_bv_ann.l(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"level")                = q30_bv_per.l(j,potnatveg);
+ oq30_natveg_snv(t,j,"level")                      = q30_natveg_snv.l(j);
  ov_fallow(t,j,"upper")                            = vm_fallow.up(j);
  ov_area(t,j,kcr,w,"upper")                        = vm_area.up(j,kcr,w);
  ov_rotation_penalty(t,i,"upper")                  = vm_rotation_penalty.up(i);
@@ -52,6 +54,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"upper")       = q30_carbon.up(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"upper")                = q30_bv_ann.up(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"upper")                = q30_bv_per.up(j,potnatveg);
+ oq30_natveg_snv(t,j,"upper")                      = q30_natveg_snv.up(j);
  ov_fallow(t,j,"lower")                            = vm_fallow.lo(j);
  ov_area(t,j,kcr,w,"lower")                        = vm_area.lo(j,kcr,w);
  ov_rotation_penalty(t,i,"lower")                  = vm_rotation_penalty.lo(i);
@@ -67,4 +70,5 @@
  oq30_carbon(t,j,ag_pools,stockType,"lower")       = q30_carbon.lo(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"lower")                = q30_bv_ann.lo(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"lower")                = q30_bv_per.lo(j,potnatveg);
+ oq30_natveg_snv(t,j,"lower")                      = q30_natveg_snv.lo(j);
 *##################### R SECTION END (OUTPUT DEFINITIONS) ######################

--- a/modules/30_crop/penalty_apr22/postsolve.gms
+++ b/modules/30_crop/penalty_apr22/postsolve.gms
@@ -22,7 +22,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"marginal")    = q30_carbon.m(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"marginal")             = q30_bv_ann.m(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"marginal")             = q30_bv_per.m(j,potnatveg);
- oq30_natveg_snv(t,j,"marginal")                   = q30_natveg_snv.m(j);
+ oq30_land_snv(t,j,"marginal")                     = q30_land_snv.m(j);
  ov_fallow(t,j,"level")                            = vm_fallow.l(j);
  ov_area(t,j,kcr,w,"level")                        = vm_area.l(j,kcr,w);
  ov_rotation_penalty(t,i,"level")                  = vm_rotation_penalty.l(i);
@@ -38,7 +38,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"level")       = q30_carbon.l(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"level")                = q30_bv_ann.l(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"level")                = q30_bv_per.l(j,potnatveg);
- oq30_natveg_snv(t,j,"level")                      = q30_natveg_snv.l(j);
+ oq30_land_snv(t,j,"level")                        = q30_land_snv.l(j);
  ov_fallow(t,j,"upper")                            = vm_fallow.up(j);
  ov_area(t,j,kcr,w,"upper")                        = vm_area.up(j,kcr,w);
  ov_rotation_penalty(t,i,"upper")                  = vm_rotation_penalty.up(i);
@@ -54,7 +54,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"upper")       = q30_carbon.up(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"upper")                = q30_bv_ann.up(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"upper")                = q30_bv_per.up(j,potnatveg);
- oq30_natveg_snv(t,j,"upper")                      = q30_natveg_snv.up(j);
+ oq30_land_snv(t,j,"upper")                        = q30_land_snv.up(j);
  ov_fallow(t,j,"lower")                            = vm_fallow.lo(j);
  ov_area(t,j,kcr,w,"lower")                        = vm_area.lo(j,kcr,w);
  ov_rotation_penalty(t,i,"lower")                  = vm_rotation_penalty.lo(i);
@@ -70,5 +70,5 @@
  oq30_carbon(t,j,ag_pools,stockType,"lower")       = q30_carbon.lo(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"lower")                = q30_bv_ann.lo(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"lower")                = q30_bv_per.lo(j,potnatveg);
- oq30_natveg_snv(t,j,"lower")                      = q30_natveg_snv.lo(j);
+ oq30_land_snv(t,j,"lower")                        = q30_land_snv.lo(j);
 *##################### R SECTION END (OUTPUT DEFINITIONS) ######################

--- a/modules/30_crop/penalty_apr22/preloop.gms
+++ b/modules/30_crop/penalty_apr22/preloop.gms
@@ -5,11 +5,16 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
-* create crop rotation scenario
+** Trajectory for cropland scenarios
+* sigmoidal interpolation between start year and target year
+m_sigmoid_interpol(p30_snv_scenario_fader,s30_snv_scenario_start,s30_snv_scenario_target,0,1);
+m_sigmoid_interpol(p30_rotation_scenario_fader,s30_rotation_scenario_start,s30_rotation_scenario_target,0,1);
 
+
+** create crop rotation scenario
 i30_rotation_incentives(t_all,rota30)=
-  f30_rotation_incentives(rota30,"default") * (1-f30_scenario_fader(t_all,"%c30_rotation_scenario_speed%"))+
-  f30_rotation_incentives(rota30,"%c30_rotation_scenario%") * (f30_scenario_fader(t_all,"%c30_rotation_scenario_speed%"));
+  f30_rotation_incentives(rota30,"default") * (1-p30_rotation_scenario_fader(t_all)) +
+  f30_rotation_incentives(rota30,"%c30_rotation_scenario%") * (p30_rotation_scenario_fader(t_all));
 
 
 *due to some rounding errors the input data currently may contain in some cases

--- a/modules/30_crop/penalty_apr22/preloop.gms
+++ b/modules/30_crop/penalty_apr22/preloop.gms
@@ -26,4 +26,4 @@ p30_country_dummy(policy_countries30) = 1;
 * share is calculated that translates the countries' influence to regional level.
 * Countries are weighted by available cropland area.
 i30_avl_cropland_iso(iso) = f30_avl_cropland_iso(iso,"%c30_marginal_land%");
-p30_region_snv_shr(i) = sum(i_to_iso(i,iso), p30_country_dummy(iso) * i30_avl_cropland_iso(iso)) / sum(i_to_iso(i,iso), i30_avl_cropland_iso(iso));
+p30_country_snv_weight(i) = sum(i_to_iso(i,iso), p30_country_dummy(iso) * i30_avl_cropland_iso(iso)) / sum(i_to_iso(i,iso), i30_avl_cropland_iso(iso));

--- a/modules/30_crop/penalty_apr22/presolve.gms
+++ b/modules/30_crop/penalty_apr22/presolve.gms
@@ -24,10 +24,12 @@ vm_area.up(j,bioen_type_30,bioen_water_30)=Inf;
 
 *' @code
 *' Minimum semi-natural vegetation (SNV) share is fading in after 2020
-p30_avl_cropland(t,j) = f30_avl_cropland(j,"%c30_marginal_land%") *
-	(1 - f30_scenario_fader(t,"%c30_snv_target%") *
-	(s30_snv_shr * sum(cell(i,j), p30_region_snv_shr(i))
-	+ s30_snv_shr_noselect * sum(cell(i,j), 1-p30_region_snv_shr(i))));
+p30_snv_shr(t,j) = f30_scenario_fader(t,"%c30_snv_target%") *
+	(s30_snv_shr * sum(cell(i,j), p30_country_snv_weight(i))
+	+ s30_snv_shr_noselect * sum(cell(i,j), 1-p30_country_snv_weight(i)));
+
+*' Area potentially available for cropping
+p30_avl_cropland(t,j) = f30_avl_cropland(j,"%c30_marginal_land%") * (1 - p30_snv_shr(t,j));
 *' @stop
 
 * only activate constraints which are binding

--- a/modules/30_crop/penalty_apr22/presolve.gms
+++ b/modules/30_crop/penalty_apr22/presolve.gms
@@ -24,7 +24,7 @@ vm_area.up(j,bioen_type_30,bioen_water_30)=Inf;
 
 *' @code
 *' Minimum semi-natural vegetation (SNV) share is fading in after 2020
-p30_snv_shr(t,j) = f30_scenario_fader(t,"%c30_snv_target%") *
+p30_snv_shr(t,j) = p30_snv_scenario_fader(t) *
 	(s30_snv_shr * sum(cell(i,j), p30_country_snv_weight(i))
 	+ s30_snv_shr_noselect * sum(cell(i,j), 1-p30_country_snv_weight(i)));
 

--- a/modules/30_crop/rotation_apr22/declarations.gms
+++ b/modules/30_crop/rotation_apr22/declarations.gms
@@ -7,7 +7,8 @@
 
 parameters
  p30_avl_cropland(t,j)             	Total available land for crop cultivation (mio. ha)
- p30_region_snv_shr(i)			SNV share of the region (1)
+ p30_country_snv_weight(i)			SNV policy country weight per region (1)
+ p30_snv_shr(t,j)                   Share of semi-natural vegetation in cropland areas (1)
  p30_country_dummy(iso)		        Dummy parameter indicating whether country is affected by selected SNV policy (1)
  i30_avl_cropland_iso(iso)			Available land area for cropland at ISO level (mio. ha)
  i30_rotation_max_shr(t_all,rotamax30) Maximum share of a certain crop group on cropland (ha per ha)
@@ -29,8 +30,9 @@ equations
  q30_rotation_max_irrig(j,rotamax30)    Local maximum rotational constraints (mio. ha)
  q30_prod(j,kcr)                        Production of cropped products (mio. tDM)
  q30_carbon(j,ag_pools,stockType)       Cropland above ground carbon content calculation (mio. tC)
- q30_bv_ann(j,potnatveg)                Biodiversity value of annual cropland (Mha)
- q30_bv_per(j,potnatveg)                Biodiversity value of perennial cropland (Mha)
+ q30_bv_ann(j,potnatveg)                Biodiversity value of annual cropland (mio. ha)
+ q30_bv_per(j,potnatveg)         Biodiversity value of perennial cropland (mio. ha)
+ q30_natveg_snv(j)               Natural vegetation cover in cropland areas (mio. ha)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################

--- a/modules/30_crop/rotation_apr22/declarations.gms
+++ b/modules/30_crop/rotation_apr22/declarations.gms
@@ -34,7 +34,7 @@ equations
  q30_carbon(j,ag_pools,stockType)       Cropland above ground carbon content calculation (mio. tC)
  q30_bv_ann(j,potnatveg)                Biodiversity value of annual cropland (mio. ha)
  q30_bv_per(j,potnatveg)                Biodiversity value of perennial cropland (mio. ha)
- q30_natveg_snv(j)                      Natural vegetation cover in cropland areas (mio. ha)
+ q30_land_snv(j)                    Land constraint for the SNV policy in cropland areas (mio. ha)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################
@@ -51,7 +51,7 @@ parameters
  oq30_carbon(t,j,ag_pools,stockType,type)    Cropland above ground carbon content calculation (mio. tC)
  oq30_bv_ann(t,j,potnatveg,type)             Biodiversity value of annual cropland (mio. ha)
  oq30_bv_per(t,j,potnatveg,type)             Biodiversity value of perennial cropland (mio. ha)
- oq30_natveg_snv(t,j,type)                   Natural vegetation cover in cropland areas (mio. ha)
+ oq30_land_snv(t,j,type)                     Land constraint for the SNV policy in cropland areas (mio. ha)
 ;
 *##################### R SECTION END (OUTPUT DECLARATIONS) #####################
 

--- a/modules/30_crop/rotation_apr22/declarations.gms
+++ b/modules/30_crop/rotation_apr22/declarations.gms
@@ -6,13 +6,15 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 parameters
- p30_avl_cropland(t,j)             	Total available land for crop cultivation (mio. ha)
- p30_country_snv_weight(i)			SNV policy country weight per region (1)
- p30_snv_shr(t,j)                   Share of semi-natural vegetation in cropland areas (1)
- p30_country_dummy(iso)		        Dummy parameter indicating whether country is affected by selected SNV policy (1)
- i30_avl_cropland_iso(iso)			Available land area for cropland at ISO level (mio. ha)
- i30_rotation_max_shr(t_all,rotamax30) Maximum share of a certain crop group on cropland (ha per ha)
- i30_rotation_min_shr(t_all,rotamin30) Minimum share of a certain crop group on cropland (ha per ha)
+ p30_avl_cropland(t,j)             	    Total available land for crop cultivation (mio. ha)
+ p30_country_snv_weight(i)			    SNV policy country weight per region (1)
+ p30_snv_shr(t,j)                       Share of semi-natural vegetation in cropland areas (1)
+ p30_country_dummy(iso)		            Dummy parameter indicating whether country is affected by selected SNV policy (1)
+ i30_avl_cropland_iso(iso)			    Available land area for cropland at ISO level (mio. ha)
+ i30_rotation_max_shr(t_all,rotamax30)  Maximum share of a certain crop group on cropland (ha per ha)
+ i30_rotation_min_shr(t_all,rotamin30)  Minimum share of a certain crop group on cropland (ha per ha)
+ p30_snv_scenario_fader(t_all)          SNV scenario fader (1)
+ p30_rotation_scenario_fader(t_all)     Crop rotation scenario fader (1)
 ;
 
 positive variables
@@ -31,8 +33,8 @@ equations
  q30_prod(j,kcr)                        Production of cropped products (mio. tDM)
  q30_carbon(j,ag_pools,stockType)       Cropland above ground carbon content calculation (mio. tC)
  q30_bv_ann(j,potnatveg)                Biodiversity value of annual cropland (mio. ha)
- q30_bv_per(j,potnatveg)         Biodiversity value of perennial cropland (mio. ha)
- q30_natveg_snv(j)               Natural vegetation cover in cropland areas (mio. ha)
+ q30_bv_per(j,potnatveg)                Biodiversity value of perennial cropland (mio. ha)
+ q30_natveg_snv(j)                      Natural vegetation cover in cropland areas (mio. ha)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################

--- a/modules/30_crop/rotation_apr22/declarations.gms
+++ b/modules/30_crop/rotation_apr22/declarations.gms
@@ -47,8 +47,9 @@ parameters
  oq30_rotation_max_irrig(t,j,rotamax30,type) Local maximum rotational constraints (mio. ha)
  oq30_prod(t,j,kcr,type)                     Production of cropped products (mio. tDM)
  oq30_carbon(t,j,ag_pools,stockType,type)    Cropland above ground carbon content calculation (mio. tC)
- oq30_bv_ann(t,j,potnatveg,type)             Biodiversity value of annual cropland (Mha)
- oq30_bv_per(t,j,potnatveg,type)             Biodiversity value of perennial cropland (Mha)
+ oq30_bv_ann(t,j,potnatveg,type)             Biodiversity value of annual cropland (mio. ha)
+ oq30_bv_per(t,j,potnatveg,type)             Biodiversity value of perennial cropland (mio. ha)
+ oq30_natveg_snv(t,j,type)                   Natural vegetation cover in cropland areas (mio. ha)
 ;
 *##################### R SECTION END (OUTPUT DECLARATIONS) #####################
 

--- a/modules/30_crop/rotation_apr22/declarations.gms
+++ b/modules/30_crop/rotation_apr22/declarations.gms
@@ -6,11 +6,11 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 parameters
- p30_avl_cropland(t,j)             	    Total available land for crop cultivation (mio. ha)
- p30_country_snv_weight(i)			    SNV policy country weight per region (1)
+ p30_avl_cropland(t,j)                  Total available land for crop cultivation (mio. ha)
+ p30_country_snv_weight(i)              SNV policy country weight per region (1)
  p30_snv_shr(t,j)                       Share of semi-natural vegetation in cropland areas (1)
- p30_country_dummy(iso)		            Dummy parameter indicating whether country is affected by selected SNV policy (1)
- i30_avl_cropland_iso(iso)			    Available land area for cropland at ISO level (mio. ha)
+ p30_country_dummy(iso)                 Dummy parameter indicating whether country is affected by selected SNV policy (1)
+ i30_avl_cropland_iso(iso)              Available land area for cropland at ISO level (mio. ha)
  i30_rotation_max_shr(t_all,rotamax30)  Maximum share of a certain crop group on cropland (ha per ha)
  i30_rotation_min_shr(t_all,rotamin30)  Minimum share of a certain crop group on cropland (ha per ha)
  p30_snv_scenario_fader(t_all)          SNV scenario fader (1)

--- a/modules/30_crop/rotation_apr22/declarations.gms
+++ b/modules/30_crop/rotation_apr22/declarations.gms
@@ -19,9 +19,9 @@ parameters
 
 positive variables
 * Fallow land is cropland which is temporarily fallow. Croparea+fallow=cropland
- vm_fallow(j)                   Fallow land (mio. ha)
- vm_area(j,kcr,w)                Agricultural production area (mio. ha)
- vm_rotation_penalty(i)                  Penalty for violating rotational constraints (USD05MER)
+ vm_fallow(j)                           Fallow land (mio. ha)
+ vm_area(j,kcr,w)                       Agricultural production area (mio. ha)
+ vm_rotation_penalty(i)                 Penalty for violating rotational constraints (USD05MER)
 ;
 
 equations

--- a/modules/30_crop/rotation_apr22/equations.gms
+++ b/modules/30_crop/rotation_apr22/equations.gms
@@ -20,9 +20,16 @@
 *' can be reduced by constraining the cropland area in favour of other land types,
 *' in order to increase compositional heterogeneity of land types at the cell level.
 
- q30_avl_cropland(j2)  ..
+ q30_avl_cropland(j2) ..
    vm_land(j2,"crop") =l= sum(ct, p30_avl_cropland(ct,j2));
 
+*' Optionally, semi-natural vegetation in cropland areas can only include
+*' forest or other land (not grassland).
+ q30_natveg_snv(j2)$s30_snv_natveg_only ..
+            sum(land_natveg, vm_land(j2,land_natveg))
+            =g=
+            sum(ct, p30_snv_shr(ct,j2)) * vm_land(j2,"crop")
+          + sum((ct,land_natveg,consv_type), pm_land_conservation(ct,j2,land_natveg,consv_type));
 *' As additional constraints minimum and maximum rotational constraints limit
 *' the placing of crops. On the one hand, these rotational constraints reflect
 *' crop rotations limiting the share a specific crop can cover of the total area

--- a/modules/30_crop/rotation_apr22/equations.gms
+++ b/modules/30_crop/rotation_apr22/equations.gms
@@ -24,7 +24,7 @@
    vm_land(j2,"crop") =l= sum(ct, p30_avl_cropland(ct,j2));
 
 *' Optionally, semi-natural vegetation in cropland areas can only include
-*' forest or other land (not grassland).
+*' forest or other land (not grassland or forestry).
  q30_natveg_snv(j2)$s30_snv_natveg_only ..
             sum(land_natveg, vm_land(j2,land_natveg))
             =g=

--- a/modules/30_crop/rotation_apr22/equations.gms
+++ b/modules/30_crop/rotation_apr22/equations.gms
@@ -23,13 +23,15 @@
  q30_avl_cropland(j2) ..
    vm_land(j2,"crop") =l= sum(ct, p30_avl_cropland(ct,j2));
 
-*' Optionally, semi-natural vegetation in cropland areas can only include
-*' forest or other land (not grassland or forestry).
- q30_natveg_snv(j2)$s30_snv_natveg_only ..
-            sum(land_natveg, vm_land(j2,land_natveg))
+*' The semi-natural land constraint in cropland areas for sustaining critical regulating NCP
+*' for agricultural production is added on top of land conserved for other reasons
+*' (e.g. conservation of intact ecosystems or protection of biodiversity hotspots).
+ q30_land_snv(j2) ..
+            sum(land_snv, vm_land(j2,land_snv))
             =g=
             sum(ct, p30_snv_shr(ct,j2)) * vm_land(j2,"crop")
-          + sum((ct,land_natveg,consv_type), pm_land_conservation(ct,j2,land_natveg,consv_type));
+          + sum((ct,land_snv,consv_type), pm_land_conservation(ct,j2,land_snv,consv_type));
+
 *' As additional constraints minimum and maximum rotational constraints limit
 *' the placing of crops. On the one hand, these rotational constraints reflect
 *' crop rotations limiting the share a specific crop can cover of the total area

--- a/modules/30_crop/rotation_apr22/input.gms
+++ b/modules/30_crop/rotation_apr22/input.gms
@@ -27,13 +27,13 @@ $setglobal c30_rotation_scenario_speed  by2050
 * options: none, by2030, by2020
 
 scalars
-s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
-s30_snv_scenario_start		SNV scnenario start year			/ 2020 /
-s30_snv_scenario_target		SNV scnenario target year			/ 2030 /
-s30_rotation_scenario_start		SNV scnenario start year			/ 2020 /
-s30_rotation_scenario_target		SNV scnenario target year			/ 2050 /
+s30_snv_shr   		              Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr_noselect 	          Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
+s30_snv_scenario_start		      SNV scenario start year			/ 2020 /
+s30_snv_scenario_target		      SNV scenario target year			/ 2030 /
+s30_rotation_scenario_start		  Rotation scenario start year			/ 2020 /
+s30_rotation_scenario_target		Rotation scenario target year			/ 2050 /
 ;
 
 * Set-switch for countries affected by regional SNV policy

--- a/modules/30_crop/rotation_apr22/input.gms
+++ b/modules/30_crop/rotation_apr22/input.gms
@@ -26,6 +26,16 @@ $setglobal c30_rotation_scenario  default
 $setglobal c30_rotation_scenario_speed  by2050
 * options: none, by2030, by2020
 
+scalars
+s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
+s30_snv_scenario_start		SNV scnenario start year			/ 2020 /
+s30_snv_scenario_target		SNV scnenario target year			/ 2030 /
+s30_rotation_scenario_start		SNV scnenario start year			/ 2020 /
+s30_rotation_scenario_target		SNV scnenario target year			/ 2050 /
+;
+
 * Set-switch for countries affected by regional SNV policy
 * Default: all iso countries selected
 sets
@@ -85,12 +95,6 @@ $if "%c30_rotation_constraints%" == "off" f30_rotation_min_shr(crp30) = 0;
 
 ********* AVAILABLE CROPLAND *******************************************
 
-scalar
-s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (1) / 0 /
-;
-
 table f30_avl_cropland(j,marginal_land30) Available land area for cropland (mio. ha)
 $ondelim
 $include "./modules/30_crop/rotation_apr22/input/avl_cropland.cs3"
@@ -103,8 +107,3 @@ $include "./modules/30_crop/rotation_apr22/input/avl_cropland_iso.cs3"
 $offdelim
 ;
 
-table f30_scenario_fader(t_all,policy_target30) Fader for scenario implementation speed (unitless)
-$ondelim
-$include "./modules/30_crop/rotation_apr22/input/f30_scenario_fader.csv"
-$offdelim
-;

--- a/modules/30_crop/rotation_apr22/input.gms
+++ b/modules/30_crop/rotation_apr22/input.gms
@@ -11,7 +11,7 @@ $setglobal c30_bioen_type  all
 $setglobal c30_bioen_water  rainfed
 * options: rainfed, irrigated, all
 
-$setglobal c30_marginal_land  all_marginal
+$setglobal c30_marginal_land  q33_marginal
 * options: all_marginal, q33_marginal, no_marginal
 
 $setglobal c30_snv_target  none
@@ -86,8 +86,9 @@ $if "%c30_rotation_constraints%" == "off" f30_rotation_min_shr(crp30) = 0;
 ********* AVAILABLE CROPLAND *******************************************
 
 scalar
-s30_snv_shr   		Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr   		    Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect 	Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_natveg_only   Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (1) / 0 /
 ;
 
 table f30_avl_cropland(j,marginal_land30) Available land area for cropland (mio. ha)

--- a/modules/30_crop/rotation_apr22/input.gms
+++ b/modules/30_crop/rotation_apr22/input.gms
@@ -29,7 +29,6 @@ $setglobal c30_rotation_scenario_speed  by2050
 scalars
 s30_snv_shr                     Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect            Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only             Whether only primary and secondary forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
 s30_snv_scenario_start          SNV scenario start year			/ 2020 /
 s30_snv_scenario_target         SNV scenario target year			/ 2030 /
 s30_rotation_scenario_start     Rotation scenario start year			/ 2020 /
@@ -64,6 +63,8 @@ sets
                           TKL,TKM,TLS,TON,TTO,TUN,TUR,TUV,TWN,TZA,
                           UGA,UKR,UMI,URY,USA,UZB,VAT,VCT,VEN,VGB,
                           VIR,VNM,VUT,WLF,WSM,YEM,ZAF,ZMB,ZWE /
+
+land_snv(land) land types allowed in the SNV policy / secdforest, forestry, past, other /
 ;
 
 ********* CROPAREA INITIALISATION **********************************************

--- a/modules/30_crop/rotation_apr22/input.gms
+++ b/modules/30_crop/rotation_apr22/input.gms
@@ -27,13 +27,13 @@ $setglobal c30_rotation_scenario_speed  by2050
 * options: none, by2030, by2020
 
 scalars
-s30_snv_shr   		              Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_shr_noselect 	          Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr                     Share of available cropland that is witheld for other land cover types (1) / 0 /
+s30_snv_shr_noselect            Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
-s30_snv_scenario_start		      SNV scenario start year			/ 2020 /
-s30_snv_scenario_target		      SNV scenario target year			/ 2030 /
-s30_rotation_scenario_start		  Rotation scenario start year			/ 2020 /
-s30_rotation_scenario_target		Rotation scenario target year			/ 2050 /
+s30_snv_scenario_start          SNV scenario start year			/ 2020 /
+s30_snv_scenario_target         SNV scenario target year			/ 2030 /
+s30_rotation_scenario_start     Rotation scenario start year			/ 2020 /
+s30_rotation_scenario_target    Rotation scenario target year			/ 2050 /
 ;
 
 * Set-switch for countries affected by regional SNV policy

--- a/modules/30_crop/rotation_apr22/input.gms
+++ b/modules/30_crop/rotation_apr22/input.gms
@@ -29,7 +29,7 @@ $setglobal c30_rotation_scenario_speed  by2050
 scalars
 s30_snv_shr                     Share of available cropland that is witheld for other land cover types (1) / 0 /
 s30_snv_shr_noselect            Share of available cropland that is witheld for other land cover types (1) / 0 /
-s30_snv_natveg_only             Whether only forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
+s30_snv_natveg_only             Whether only primary and secondary forest and other land are allowed as semi-natural vegetation in cropland areas (0=no 1=yes) / 0 /
 s30_snv_scenario_start          SNV scenario start year			/ 2020 /
 s30_snv_scenario_target         SNV scenario target year			/ 2030 /
 s30_rotation_scenario_start     Rotation scenario start year			/ 2020 /

--- a/modules/30_crop/rotation_apr22/input/files
+++ b/modules/30_crop/rotation_apr22/input/files
@@ -3,6 +3,5 @@ f30_rotation_max_scen.csv
 f30_rotation_min_scen.csv
 avl_cropland.cs3
 avl_cropland_0.5.mz
-
 f30_croparea_w_initialisation.cs3
 avl_cropland_iso.cs3

--- a/modules/30_crop/rotation_apr22/input/files
+++ b/modules/30_crop/rotation_apr22/input/files
@@ -3,6 +3,6 @@ f30_rotation_max_scen.csv
 f30_rotation_min_scen.csv
 avl_cropland.cs3
 avl_cropland_0.5.mz
-f30_scenario_fader.csv
+
 f30_croparea_w_initialisation.cs3
 avl_cropland_iso.cs3

--- a/modules/30_crop/rotation_apr22/postsolve.gms
+++ b/modules/30_crop/rotation_apr22/postsolve.gms
@@ -19,6 +19,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"marginal")    = q30_carbon.m(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"marginal")             = q30_bv_ann.m(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"marginal")             = q30_bv_per.m(j,potnatveg);
+ oq30_natveg_snv(t,j,"marginal")                   = q30_natveg_snv.m(j);
  ov_fallow(t,j,"level")                            = vm_fallow.l(j);
  ov_area(t,j,kcr,w,"level")                        = vm_area.l(j,kcr,w);
  ov_rotation_penalty(t,i,"level")                  = vm_rotation_penalty.l(i);
@@ -31,6 +32,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"level")       = q30_carbon.l(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"level")                = q30_bv_ann.l(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"level")                = q30_bv_per.l(j,potnatveg);
+ oq30_natveg_snv(t,j,"level")                      = q30_natveg_snv.l(j);
  ov_fallow(t,j,"upper")                            = vm_fallow.up(j);
  ov_area(t,j,kcr,w,"upper")                        = vm_area.up(j,kcr,w);
  ov_rotation_penalty(t,i,"upper")                  = vm_rotation_penalty.up(i);
@@ -43,6 +45,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"upper")       = q30_carbon.up(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"upper")                = q30_bv_ann.up(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"upper")                = q30_bv_per.up(j,potnatveg);
+ oq30_natveg_snv(t,j,"upper")                      = q30_natveg_snv.up(j);
  ov_fallow(t,j,"lower")                            = vm_fallow.lo(j);
  ov_area(t,j,kcr,w,"lower")                        = vm_area.lo(j,kcr,w);
  ov_rotation_penalty(t,i,"lower")                  = vm_rotation_penalty.lo(i);
@@ -55,4 +58,5 @@
  oq30_carbon(t,j,ag_pools,stockType,"lower")       = q30_carbon.lo(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"lower")                = q30_bv_ann.lo(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"lower")                = q30_bv_per.lo(j,potnatveg);
+ oq30_natveg_snv(t,j,"lower")                      = q30_natveg_snv.lo(j);
 *##################### R SECTION END (OUTPUT DEFINITIONS) ######################

--- a/modules/30_crop/rotation_apr22/postsolve.gms
+++ b/modules/30_crop/rotation_apr22/postsolve.gms
@@ -19,7 +19,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"marginal")    = q30_carbon.m(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"marginal")             = q30_bv_ann.m(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"marginal")             = q30_bv_per.m(j,potnatveg);
- oq30_natveg_snv(t,j,"marginal")                   = q30_natveg_snv.m(j);
+ oq30_land_snv(t,j,"marginal")                     = q30_land_snv.m(j);
  ov_fallow(t,j,"level")                            = vm_fallow.l(j);
  ov_area(t,j,kcr,w,"level")                        = vm_area.l(j,kcr,w);
  ov_rotation_penalty(t,i,"level")                  = vm_rotation_penalty.l(i);
@@ -32,7 +32,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"level")       = q30_carbon.l(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"level")                = q30_bv_ann.l(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"level")                = q30_bv_per.l(j,potnatveg);
- oq30_natveg_snv(t,j,"level")                      = q30_natveg_snv.l(j);
+ oq30_land_snv(t,j,"level")                        = q30_land_snv.l(j);
  ov_fallow(t,j,"upper")                            = vm_fallow.up(j);
  ov_area(t,j,kcr,w,"upper")                        = vm_area.up(j,kcr,w);
  ov_rotation_penalty(t,i,"upper")                  = vm_rotation_penalty.up(i);
@@ -45,7 +45,7 @@
  oq30_carbon(t,j,ag_pools,stockType,"upper")       = q30_carbon.up(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"upper")                = q30_bv_ann.up(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"upper")                = q30_bv_per.up(j,potnatveg);
- oq30_natveg_snv(t,j,"upper")                      = q30_natveg_snv.up(j);
+ oq30_land_snv(t,j,"upper")                        = q30_land_snv.up(j);
  ov_fallow(t,j,"lower")                            = vm_fallow.lo(j);
  ov_area(t,j,kcr,w,"lower")                        = vm_area.lo(j,kcr,w);
  ov_rotation_penalty(t,i,"lower")                  = vm_rotation_penalty.lo(i);
@@ -58,5 +58,5 @@
  oq30_carbon(t,j,ag_pools,stockType,"lower")       = q30_carbon.lo(j,ag_pools,stockType);
  oq30_bv_ann(t,j,potnatveg,"lower")                = q30_bv_ann.lo(j,potnatveg);
  oq30_bv_per(t,j,potnatveg,"lower")                = q30_bv_per.lo(j,potnatveg);
- oq30_natveg_snv(t,j,"lower")                      = q30_natveg_snv.lo(j);
+ oq30_land_snv(t,j,"lower")                        = q30_land_snv.lo(j);
 *##################### R SECTION END (OUTPUT DEFINITIONS) ######################

--- a/modules/30_crop/rotation_apr22/preloop.gms
+++ b/modules/30_crop/rotation_apr22/preloop.gms
@@ -30,4 +30,4 @@ p30_country_dummy(policy_countries30) = 1;
 * share is calculated that translates the countries' influence to regional level.
 * Countries are weighted by available cropland area.
 i30_avl_cropland_iso(iso) = f30_avl_cropland_iso(iso,"%c30_marginal_land%");
-p30_region_snv_shr(i) = sum(i_to_iso(i,iso), p30_country_dummy(iso) * i30_avl_cropland_iso(iso)) / sum(i_to_iso(i,iso), i30_avl_cropland_iso(iso));
+p30_country_snv_weight(i) = sum(i_to_iso(i,iso), p30_country_dummy(iso) * i30_avl_cropland_iso(iso)) / sum(i_to_iso(i,iso), i30_avl_cropland_iso(iso));

--- a/modules/30_crop/rotation_apr22/preloop.gms
+++ b/modules/30_crop/rotation_apr22/preloop.gms
@@ -5,15 +5,21 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
-* create crop rotation scenario
 
+** Trajectory for cropland scenarios
+* sigmoidal interpolation between start year and target year
+m_sigmoid_interpol(p30_snv_scenario_fader,s30_snv_scenario_start,s30_snv_scenario_target,0,1);
+m_sigmoid_interpol(p30_rotation_scenario_fader,s30_rotation_scenario_start,s30_rotation_scenario_target,0,1);
+
+
+** create crop rotation scenario
 i30_rotation_max_shr(t_all,rotamax30)=
-  f30_rotation_max_shr(rotamax30,"default") * (1-f30_scenario_fader(t_all,"%c30_rotation_scenario_speed%"))+
-  f30_rotation_max_shr(rotamax30,"%c30_rotation_scenario%") * (f30_scenario_fader(t_all,"%c30_rotation_scenario_speed%"));
+  f30_rotation_max_shr(rotamax30,"default") * (1-p30_rotation_scenario_fader(t_all))+
+  f30_rotation_max_shr(rotamax30,"%c30_rotation_scenario%") * (p30_rotation_scenario_fader(t_all));
 
 i30_rotation_min_shr(t_all,rotamin30)=
-  f30_rotation_min_shr(rotamin30,"default") * (1-f30_scenario_fader(t_all,"%c30_rotation_scenario_speed%"))+
-  f30_rotation_min_shr(rotamin30,"%c30_rotation_scenario%") * (f30_scenario_fader(t_all,"%c30_rotation_scenario_speed%"));
+  f30_rotation_min_shr(rotamin30,"default") * (1-p30_rotation_scenario_fader(t_all))+
+  f30_rotation_min_shr(rotamin30,"%c30_rotation_scenario%") * (p30_rotation_scenario_fader(t_all));
 
 
 *due to some rounding errors the input data currently may contain in some cases
@@ -31,3 +37,4 @@ p30_country_dummy(policy_countries30) = 1;
 * Countries are weighted by available cropland area.
 i30_avl_cropland_iso(iso) = f30_avl_cropland_iso(iso,"%c30_marginal_land%");
 p30_country_snv_weight(i) = sum(i_to_iso(i,iso), p30_country_dummy(iso) * i30_avl_cropland_iso(iso)) / sum(i_to_iso(i,iso), i30_avl_cropland_iso(iso));
+

--- a/modules/30_crop/rotation_apr22/presolve.gms
+++ b/modules/30_crop/rotation_apr22/presolve.gms
@@ -24,10 +24,12 @@ vm_area.up(j,bioen_type_30,bioen_water_30)=Inf;
 
 *' @code
 *' Minimum semi-natural vegetation (SNV) share is fading in after 2020
-p30_avl_cropland(t,j) = f30_avl_cropland(j,"%c30_marginal_land%") *
-	(1 - f30_scenario_fader(t,"%c30_snv_target%") *
-	(s30_snv_shr * sum(cell(i,j), p30_region_snv_shr(i))
-	+ s30_snv_shr_noselect * sum(cell(i,j), 1-p30_region_snv_shr(i))));
+p30_snv_shr(t,j) = f30_scenario_fader(t,"%c30_snv_target%") *
+	(s30_snv_shr * sum(cell(i,j), p30_country_snv_weight(i))
+	+ s30_snv_shr_noselect * sum(cell(i,j), 1-p30_country_snv_weight(i)));
+
+*' Area potentially available for cropping
+p30_avl_cropland(t,j) = f30_avl_cropland(j,"%c30_marginal_land%") * (1 - p30_snv_shr(t,j));
 *' @stop
 
 * only activate constraints which are binding

--- a/modules/30_crop/rotation_apr22/presolve.gms
+++ b/modules/30_crop/rotation_apr22/presolve.gms
@@ -24,7 +24,7 @@ vm_area.up(j,bioen_type_30,bioen_water_30)=Inf;
 
 *' @code
 *' Minimum semi-natural vegetation (SNV) share is fading in after 2020
-p30_snv_shr(t,j) = f30_scenario_fader(t,"%c30_snv_target%") *
+p30_snv_shr(t,j) = p30_snv_scenario_fader(t) *
 	(s30_snv_shr * sum(cell(i,j), p30_country_snv_weight(i))
 	+ s30_snv_shr_noselect * sum(cell(i,j), 1-p30_country_snv_weight(i)));
 


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- Added an option (`s30_snv_natveg_only`) to the `default.cfg` for deciding whether all non-cropland land types qualify as SNV or only primforest, secdforest and otherland (i.e. 'natveg'). 

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `gams main.gms action=c`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Default run based on the current version of the fork from which PR is made
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate

## Test runs:

![Resources_Land_Cover_Cropland_PR487](https://user-images.githubusercontent.com/50408549/206114240-03b5a516-5f18-4fee-b2ae-a9b49d0c4413.png)
![Emissions_CO2_Land_Land_use_Change_PR487](https://user-images.githubusercontent.com/50408549/206114248-d639476d-82e2-43e0-b77e-20e85920c39f.png)
![Productivity_Landuse_Intensity_Indicator_Tau_PR487](https://user-images.githubusercontent.com/50408549/206114252-a1a5f93d-8ae3-4b8c-9199-445302ac34bd.png)


![Resources_Land_Cover_Cropland_SNVRework](https://user-images.githubusercontent.com/50408549/205976544-47668732-66a4-4746-83df-b944d7dbe52c.png)
![Emissions_CO2_Land_Land_use_Change_SNVRework](https://user-images.githubusercontent.com/50408549/205976535-d6c52b25-47e7-4465-bb57-e918c3bc612c.png)

