### PR TITLE
bugfix in extra/disaggregation.R

### DIFF
--- a/scripts/output/extra/disaggregation.R
+++ b/scripts/output/extra/disaggregation.R
@@ -128,8 +128,8 @@ target_year <- cfg$gms$c30_snv_target                     # target year of SNV p
 if(is.null(target_year)){target_year <- cfg$gms$c30_set_aside_target}
 snv_pol_fader  <- readGDX(gdx,"f30_scenario_fader","f30_set_aside_fader",
                           format="first_found", react = "silent")[,,target_year]
-if(is.null(snv_pol_fader)){
-snv_pol_fader <- readGDX(gdx,"p30_snv_scenario_fader",format="first_found")
+if (is.null(snv_pol_fader)) {
+  snv_pol_fader <- readGDX(gdx, "p30_snv_scenario_fader", format = "first_found")
 }
 
 

--- a/scripts/output/extra/disaggregation.R
+++ b/scripts/output/extra/disaggregation.R
@@ -126,7 +126,12 @@ avl_cropland_hr <- file.path(outputdir, "avl_cropland_0.5.mz")       # available
 marginal_land <- cfg$gms$c30_marginal_land                      # marginal land scenario
 target_year <- cfg$gms$c30_snv_target                     # target year of SNV policy (default: "none")
 if(is.null(target_year)){target_year <- cfg$gms$c30_set_aside_target}
-snv_pol_fader  <- readGDX(gdx,"f30_scenario_fader","f30_set_aside_fader", format="first_found")[,,target_year]
+snv_pol_fader  <- readGDX(gdx,"f30_scenario_fader","f30_set_aside_fader",
+                          format="first_found", react = "silent")[,,target_year]
+if(is.null(snv_pol_fader)){
+snv_pol_fader <- readGDX(gdx,"p30_snv_scenario_fader",format="first_found")
+}
+
 
 # Start interpolation (use interpolateAvlCroplandWeighted from luscale)
 print("Disaggregation")

--- a/scripts/output/extra/disaggregation_BII.R
+++ b/scripts/output/extra/disaggregation_BII.R
@@ -116,8 +116,8 @@ if (is.null(target_year)) {
 }
 snv_pol_fader  <- readGDX(gdx,"f30_scenario_fader","f30_set_aside_fader",
                           format="first_found", react = "silent")[,,target_year]
-if(is.null(snv_pol_fader)){
-snv_pol_fader <- readGDX(gdx,"p30_snv_scenario_fader",format="first_found")
+if (is.null(snv_pol_fader)) {
+  snv_pol_fader <- readGDX(gdx, "p30_snv_scenario_fader", format = "first_found")
 }
 
 # Sort and rename

--- a/scripts/output/extra/disaggregation_BII.R
+++ b/scripts/output/extra/disaggregation_BII.R
@@ -110,8 +110,13 @@ snv_pol_shr[snv_pol_iso,,] <- snv_pol_select
 
 avl_cropland_hr <- file.path(outputdir, "avl_cropland_0.5.mz")    # available cropland (at high resolution)
 marginal_land   <- cfg$gms$c30_marginal_land                      # marginal land scenario
-target_year     <- cfg$gms$c30_snv_target                   # target year of SNV policy (default: "none")
-snv_pol_fader <- readGDX(gdx, "f30_scenario_fader", format = "first_found")[, , target_year]
+target_year <- cfg$gms$c30_snv_target                     # target year of SNV policy (default: "none")
+if(is.null(target_year)){target_year <- cfg$gms$c30_set_aside_target}
+snv_pol_fader  <- readGDX(gdx,"f30_scenario_fader","f30_set_aside_fader",
+                          format="first_found", react = "silent")[,,target_year]
+if(is.null(snv_pol_fader)){
+snv_pol_fader <- readGDX(gdx,"p30_snv_scenario_fader",format="first_found")
+}
 
 # Sort and rename
 land_ini_hr <- land_ini_hr[,,getNames(land_ini_lr)]

--- a/scripts/output/extra/disaggregation_BII.R
+++ b/scripts/output/extra/disaggregation_BII.R
@@ -111,7 +111,9 @@ snv_pol_shr[snv_pol_iso,,] <- snv_pol_select
 avl_cropland_hr <- file.path(outputdir, "avl_cropland_0.5.mz")    # available cropland (at high resolution)
 marginal_land   <- cfg$gms$c30_marginal_land                      # marginal land scenario
 target_year <- cfg$gms$c30_snv_target                     # target year of SNV policy (default: "none")
-if(is.null(target_year)){target_year <- cfg$gms$c30_set_aside_target}
+if (is.null(target_year)) {
+  target_year <- cfg$gms$c30_set_aside_target
+}
 snv_pol_fader  <- readGDX(gdx,"f30_scenario_fader","f30_set_aside_fader",
                           format="first_found", react = "silent")[,,target_year]
 if(is.null(snv_pol_fader)){


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- Bugfix in extra/disaggregation.R

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `gams main.gms action=c`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Default run based on the current version of the fork from which PR is made
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
