### PR TITLE
Efp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### changed
+- **42_water_demand** replaced `f42_env_flow_policy` with macro
 - **30_crop** replaced `f30_scenario_fader` with macro
 - **30_crop/config** changed switch `c30_rotation_scenario_speed` to `s30_rotation_scenario_target`
 - **30_crop/config** changed switch `c30_snv_target` to `s30_snv_scenario_target`

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$model <- "main.gms"   #def = "main.gms"
 cfg$input <- c(regional    = "rev4.77_h12_magpie.tgz",
                cellular    = "rev4.77_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.77_h12_validation.tgz",
-               additional  = "additional_data_rev4.34.tgz",
+               additional  = "additional_data_rev4.36.tgz",
                calibration = "calibration_H12_per_ton_fao_may22_glo_07Dec22.tgz")
 
 # NOTE: It is recommended to recalibrate the model when changing cellular input data

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -930,7 +930,7 @@ cfg$gms$c38_fac_req <- "glo"        # default "glo"
 
 # * Only relevant for sticky_labor implementation: scalar to determine until which year
 # * the capital need (per unit of output) should be fixed to start value (i.e. not
-# * allowing for subsititution between labor and capital).
+# * allowing for substitution between labor and capital).
 
 cfg$gms$s38_fix_capital_need <- 2020    # default 2020
 
@@ -1017,6 +1017,14 @@ cfg$gms$s42_irrigation_efficiency <- 0.66       # def=0.66
 # * (on):    global EFP policy
 # * (mixed): EFP policy only in hic regions
 cfg$gms$c42_env_flow_policy <- "off"             # def = "off"
+
+# * Start and target year of environmental flow protection policy ('c42_env_flow_policy').
+# * Defines when linear fading in of policy starts and when the target of
+# * full protection based on 's42_env_flow_scenario' is reached
+# * Start year:
+cfg$gms$s42_efp_startyear <- 2020       # def = 2020
+# * Target year (year when full protection is reached):
+cfg$gms$s42_efp_targetyear <- 2040       # def = 2040
 
 # * Switch and specification of countries for which environmental flow policy
 # * shall apply.

--- a/core/macros.gms
+++ b/core/macros.gms
@@ -75,10 +75,10 @@ $macro m_fillmissingyears(input,sets) loop(t_all, \
 
 * macro for linear interpolation
 $macro m_linear_interpol(input,start_year,target_year,start_value,target_value) \
-	input(t_all)$(m_year(t_all) >= start_year AND m_year(t_all) <= target_year) = ((m_year(t_all)-start_year) / (target_year-start_year));	\
+	input(t_all)$(m_year(t_all) > start_year AND m_year(t_all) < target_year) = ((m_year(t_all)-start_year) / (target_year-start_year));	\
 	input(t_all) = start_value + input(t_all) * (target_value-start_value);	\
-    input(t_all)$(m_year(t_all) <= start_year) = start_value; \
-    input(t_all)$(m_year(t_all) >= target_year) = target_value;
+  input(t_all)$(m_year(t_all) <= start_year) = start_value; \
+  input(t_all)$(m_year(t_all) >= target_year) = target_value;
 
 * macro for sigmoid interpolation (S-shaped curve)
 $macro m_sigmoid_interpol(input,start_year,target_year,start_value,target_value) \

--- a/main.gms
+++ b/main.gms
@@ -147,24 +147,24 @@ $title magpie
 *##################### R SECTION START (VERSION INFO) ##########################
 * 
 * Used data set: rev4.77_h12_magpie.tgz
-* md5sum: f0fb0888f1f711442377a380887dbbfa
-* Repository: /p/projects/rd3mod/mirror/rse.pik-potsdam.de/data/magpie/public
+* md5sum: NA
+* Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
 * Used data set: rev4.77_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz
-* md5sum: fe9ad2782602695b706836e84f6b569f
-* Repository: /p/projects/rd3mod/mirror/rse.pik-potsdam.de/data/magpie/public
+* md5sum: NA
+* Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
 * Used data set: rev4.77_h12_validation.tgz
-* md5sum: 7bb2104776a43e1f1293f50d08e20877
-* Repository: /p/projects/rd3mod/mirror/rse.pik-potsdam.de/data/magpie/public
+* md5sum: NA
+* Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
-* Used data set: additional_data_rev4.32.tgz
-* md5sum: 721ffbc57edddfb5e9b76546c51906f2
-* Repository: /p/projects/rd3mod/mirror/rse.pik-potsdam.de/data/magpie/public
+* Used data set: additional_data_rev4.33.tgz
+* md5sum: NA
+* Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
-* Used data set: calibration_H12+ir2rf_05Oct22.tgz
-* md5sum: 788b8e32ea1bd83c5c8f8987d9f05265
-* Repository: /p/projects/rd3mod/mirror/rse.pik-potsdam.de/data/magpie/public
+* Used data set: calibration_H12_per_ton_fao_may22_glo_23Nov22.tgz
+* md5sum: NA
+* Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
 * Low resolution: c200
 * High resolution: 0.5
@@ -193,7 +193,7 @@ $title magpie
 * * Call: withCallingHandlers(expr, message = messageHandler, warning = warningHandler,     error = errorHandler)
 * 
 * 
-* Last modification (input data): Wed Nov 16 17:14:42 2022
+* Last modification (input data): Thu Dec 08 10:40:17 2022
 * 
 *###################### R SECTION END (VERSION INFO) ###########################
 

--- a/modules/42_water_demand/agr_sector_aug13/declarations.gms
+++ b/modules/42_water_demand/agr_sector_aug13/declarations.gms
@@ -12,7 +12,8 @@ parameters
  i42_env_flows_base(t,j)    	      Environmental flow requirements if no protection policy is in place  (mio. m^3)
  ic42_env_flow_policy(i)            Determines whether environmental flow protection is enforced in the current time step (1)
  i42_env_flow_policy(t,i)           Determines whether environmental flow protection is enforced (1)
-* country-specific scenario switch
+ p42_efp(t_all,scen42)              Determines whether environmental flow protection is enforced and its fading in of environmental flow policy (1)
+ p42_efp_fader(t_all)               Determines the fading in of environmental flow policy (1)
  p42_country_dummy(iso)             Dummy parameter indicating whether country is affected by EFP (1)
  p42_EFP_region_shr(t_all,i)        Weighted share of region with regards to EFP (1)
  ic42_pumping_cost(i)               Parameter to capture values for pumping costs in a particular time step (USD05MER per m^3)

--- a/modules/42_water_demand/agr_sector_aug13/input.gms
+++ b/modules/42_water_demand/agr_sector_aug13/input.gms
@@ -6,18 +6,17 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 scalars
+s42_reserved_fraction            Fraction of available water that is reserved for manufacturing electricity and domestic use (1) / 0.5 /
 
-s42_reserved_fraction  Fraction of available water that is reserved for manufacturing electricity and domestic use (1) / 0.5 /
-
-s42_irrig_eff_scenario     Scenario for irrigation efficiency     (1)       / 2 /
+s42_irrig_eff_scenario           Scenario for irrigation efficiency     (1)       / 2 /
 *                                      1: global static value
 *                                      2: regional static values from CS
 *                                      3: gdp driven increase
 
-s42_irrigation_efficiency              Value of irrigation efficiency       (1)        / 0.66 /
+s42_irrigation_efficiency        Value of irrigation efficiency       (1)        / 0.66 /
 *                                      Only if global static value is requested
 
-s42_env_flow_scenario              EFP scenario.     (1)          / 2 /
+s42_env_flow_scenario            EFP scenario.     (1)          / 2 /
 *                                  0: don't consider environmental flows.
 *                                                                          s42_env_flow_base_fraction and
 *                                                                          s42_env_flow_fraction have no effect.
@@ -29,8 +28,11 @@ s42_env_flow_scenario              EFP scenario.     (1)          / 2 /
 *                                     results and a calculation algorithm by Smakhtin 2004.
 *                                                                          s42_env_flow_fraction has no effect.
 
+* Linear fading in of environmental flow policy between startyear and targetyear
+s42_efp_startyear                  Environmental flow policy start year   / 2020 /
+s42_efp_targetyear                 Environmental flow policy target year  / 2040 /
+
 s42_env_flow_base_fraction         Fraction of available water that is reserved for the environment where no EFP policy is implemented (1) / 0.05 /
-* 									(determined in the file EFR_protection_policy.csv)
 s42_env_flow_fraction              Fraction of available water that is reserved for under protection policies (1) / 0.2 /
 s42_pumping                        Switch to activate pumping cost settings (1) / 0 /
 s42_multiplier_startyear           Year from which pumping costs multiplier will be implemented (1) / 1995 /
@@ -41,6 +43,38 @@ $setglobal c42_watdem_scenario  cc
 *   options:  cc        (climate change)
 *             nocc      (no climate change)
 *             nocc_hist (no climate change after year defined by sm_fix_cc)
+
+table f42_wat_req_kve(t_all,j,kve) LPJmL annual water demand for irrigation per ha (m^3 per yr)
+$ondelim
+$include "./modules/42_water_demand/input/lpj_airrig.cs2"
+$offdelim
+;
+$if "%c42_watdem_scenario%" == "nocc" f42_wat_req_kve(t_all,j,kve) = f42_wat_req_kve("y1995",j,kve);
+$if "%c42_watdem_scenario%" == "nocc_hist" f42_wat_req_kve(t_all,j,kve)$(m_year(t_all) > sm_fix_cc) = f42_wat_req_kve(t_all,j,kve)$(m_year(t_all) = sm_fix_cc);
+
+m_fillmissingyears(f42_wat_req_kve,"j,kve");
+
+
+parameter f42_wat_req_kli(kli) Average water requirements of livestock commodities per region per tDM per year (m^3)
+/
+$ondelim
+$include "./modules/42_water_demand/input/f42_wat_req_fao.csv"
+$offdelim
+/;
+
+
+* Environmental flow policy
+$setglobal c42_env_flow_policy  off
+
+parameter f42_env_flows(t_all,j) Environmental flow requirements from LPJ and Smakhtin algorithm (mio. m^3)
+/
+$ondelim
+$include "./modules/42_water_demand/input/lpj_envflow_grper.cs2"
+$offdelim
+/;
+$if "%c42_watdem_scenario%" == "nocc" f42_env_flows(t_all,j) = f42_env_flows("y1995",j);
+$if "%c42_watdem_scenario%" == "nocc_hist" f42_env_flows(t_all,j)$(m_year(t_all) > sm_fix_cc) = f42_env_flows(t_all,j)$(m_year(t_all) = sm_fix_cc);
+m_fillmissingyears(f42_env_flows,"j");
 
 * Set-switch for countries affected by EFP
 * Default: all iso countries selected
@@ -73,44 +107,7 @@ sets
 ;
 
 
-table f42_wat_req_kve(t_all,j,kve) LPJmL annual water demand for irrigation per ha (m^3 per yr)
-$ondelim
-$include "./modules/42_water_demand/input/lpj_airrig.cs2"
-$offdelim
-;
-$if "%c42_watdem_scenario%" == "nocc" f42_wat_req_kve(t_all,j,kve) = f42_wat_req_kve("y1995",j,kve);
-$if "%c42_watdem_scenario%" == "nocc_hist" f42_wat_req_kve(t_all,j,kve)$(m_year(t_all) > sm_fix_cc) = f42_wat_req_kve(t_all,j,kve)$(m_year(t_all) = sm_fix_cc);
-
-m_fillmissingyears(f42_wat_req_kve,"j,kve");
-
-
-parameter f42_wat_req_kli(kli) Average water requirements of livestock commodities per region per tDM per year (m^3)
-/
-$ondelim
-$include "./modules/42_water_demand/input/f42_wat_req_fao.csv"
-$offdelim
-/;
-
-
-parameter f42_env_flows(t_all,j) Environmental flow requirements from LPJ and Smakhtin algorithm (mio. m^3)
-/
-$ondelim
-$include "./modules/42_water_demand/input/lpj_envflow_grper.cs2"
-$offdelim
-/;
-$if "%c42_watdem_scenario%" == "nocc" f42_env_flows(t_all,j) = f42_env_flows("y1995",j);
-$if "%c42_watdem_scenario%" == "nocc_hist" f42_env_flows(t_all,j)$(m_year(t_all) > sm_fix_cc) = f42_env_flows(t_all,j)$(m_year(t_all) = sm_fix_cc);
-m_fillmissingyears(f42_env_flows,"j");
-
-$setglobal c42_env_flow_policy  off
-
-table f42_env_flow_policy(t_all,scen42) EFP policies (1)
-$ondelim
-$include "./modules/42_water_demand/input/f42_env_flow_policy.cs3"
-$offdelim
-;
-
-*Costs of pumping are calculated for India as per methodology in forthcoming paper by Singh et.al.
+* Costs of pumping are calculated for India as per methodology in forthcoming paper by Singh et.al.
 parameter
 f42_pumping_cost(t_all,i) Cost of pumping irrigation water (USD05MER per m^3)
 /

--- a/modules/42_water_demand/agr_sector_aug13/preloop.gms
+++ b/modules/42_water_demand/agr_sector_aug13/preloop.gms
@@ -9,3 +9,9 @@ i42_wat_req_k(t,j,kve) = f42_wat_req_kve(t,j,kve);
 i42_env_flows(t,j) = f42_env_flows(t,j);
 
 i42_wat_req_k(t,j,kli) = f42_wat_req_kli(kli);
+
+* Trajectory for environmental flow policy
+* (linear interpolation from start year to target year)
+p42_efp(t_all,"off") = 0;
+m_linear_interpol(p42_efp_fader, s42_efp_startyear, s42_efp_targetyear, 0, 1);
+p42_efp(t_all, "on") = p42_efp_fader(t_all);

--- a/modules/42_water_demand/agr_sector_aug13/presolve.gms
+++ b/modules/42_water_demand/agr_sector_aug13/presolve.gms
@@ -16,11 +16,11 @@ p42_EFP_region_shr(t_all,i) = sum(i_to_iso(i,iso), p42_country_dummy(iso) * im_p
 
 * Environmental policy switch:
 $ifthen "%c42_env_flow_policy%" == "mixed"
-  i42_env_flow_policy(t,i) = (im_development_state(t,i) * f42_env_flow_policy(t,"on")) * p42_EFP_region_shr(t,i)
-                       + f42_env_flow_policy(t,"off") * (1-p42_EFP_region_shr(t,i));
+  i42_env_flow_policy(t,i) = (im_development_state(t,i) * p42_efp(t,"on")) * p42_EFP_region_shr(t,i)
+                       + p42_efp(t,"off") * (1-p42_EFP_region_shr(t,i));
 $else
-  i42_env_flow_policy(t,i) = f42_env_flow_policy(t,"%c42_env_flow_policy%") * p42_EFP_region_shr(t,i)
-                       + f42_env_flow_policy(t,"off") * (1-p42_EFP_region_shr(t,i));
+  i42_env_flow_policy(t,i) = p42_efp(t,"%c42_env_flow_policy%") * p42_EFP_region_shr(t,i)
+                       + p42_efp(t,"off") * (1-p42_EFP_region_shr(t,i));
 $endif
 
 

--- a/modules/42_water_demand/agr_sector_aug13/presolve.gms
+++ b/modules/42_water_demand/agr_sector_aug13/presolve.gms
@@ -5,6 +5,40 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
+* Agricultural water demand
+ic42_wat_req_k(j,k) = i42_wat_req_k(t,j,k);
+
+* Irrigation efficiency
+if (m_year(t) <= sm_fix_SSP2,
+ v42_irrig_eff.fx(j) = 1 / (1+2.718282**((-22160-sum(cell(i,j), im_gdp_pc_mer("y1995",i))) / 37767));
+else
+ if ((s42_irrig_eff_scenario = 1),
+ 	v42_irrig_eff.fx(j) = s42_irrigation_efficiency;
+ Elseif (s42_irrig_eff_scenario = 2),
+ 	v42_irrig_eff.fx(j) = 1 / (1+2.718282**((-22160-sum(cell(i,j), im_gdp_pc_mer("y1995",i))) / 37767));
+ Elseif (s42_irrig_eff_scenario=3),
+	v42_irrig_eff.fx(j) = 1 / (1+2.718282**((-22160-sum(cell(i,j), im_gdp_pc_mer(t,i))) / 37767));
+ );
+);
+
+* Pumping cost in the current time step
+ic42_pumping_cost(i) = 0;
+
+* Pumping cost settings will be only executed when s42_pumping is set to 1
+if ((s42_pumping = 1),
+ ic42_pumping_cost(i) = f42_pumping_cost(t,i);
+* Pumping cost sensitivity test implmentation
+  if (m_year(t) > s42_multiplier_startyear,
+   ic42_pumping_cost(i) = f42_pumping_cost(t,i) * s42_multiplier;
+  );
+);
+
+* Water withdrawals in other sectors (manufacturing, electricity, domestic, ecosystem)
+* (assign s42_reserved_fraction to manufacturing for simplicity)
+vm_watdem.fx("manufacturing",j) = sum(wat_src, im_wat_avail(t,wat_src,j)) * s42_reserved_fraction;
+vm_watdem.fx("electricity",j) = 0;
+vm_watdem.fx("domestic",j) = 0;
+
 * Country switch to determine countries for which EFP holds.
 * In the default case, the EFP affects all countries when activated.
 p42_country_dummy(iso) = 0;
@@ -23,54 +57,17 @@ $else
                        + p42_efp(t,"off") * (1-p42_EFP_region_shr(t,i));
 $endif
 
-
-
-* Agricultural water demand
-ic42_wat_req_k(j,k) = i42_wat_req_k(t,j,k);
 ic42_env_flow_policy(i) = i42_env_flow_policy(t,i);
 
-* water withdrawals in other sectors (manufacturing, electricity, domestic, ecosystem)
-* (assign s42_reserved_fraction to manufacturing for simplicity)
-vm_watdem.fx("manufacturing",j) = sum(wat_src, im_wat_avail(t,wat_src,j)) * s42_reserved_fraction;
-vm_watdem.fx("electricity",j) = 0;
-vm_watdem.fx("domestic",j) = 0;
-
-*Environmental flow scenarios depending on the switch s42_env_flow_scenario
+* Environmental flow scenarios depending on the switch s42_env_flow_scenario
 i42_env_flows_base(t,j) = s42_env_flow_base_fraction * sum(wat_src, im_wat_avail(t,wat_src,j));
 
-if((s42_env_flow_scenario=0),
+if ((s42_env_flow_scenario = 0),
  i42_env_flows_base(t,j) = 0;
  i42_env_flows(t,j) = 0;
-Elseif(s42_env_flow_scenario=1),
+Elseif (s42_env_flow_scenario = 1),
   i42_env_flows(t,j) = s42_env_flow_fraction * sum(wat_src, im_wat_avail(t,wat_src,j));
 );
 
-vm_watdem.fx("ecosystem",j) = sum(cell(i,j), i42_env_flows_base(t,j) * (1-ic42_env_flow_policy(i)) +
-                                                          i42_env_flows(t,j) * ic42_env_flow_policy(i));
-
-
-* irrigation efficiency
-if(m_year(t) <= sm_fix_SSP2,
- v42_irrig_eff.fx(j) = 1/(1+2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
-else
- if((s42_irrig_eff_scenario = 1),
- 	v42_irrig_eff.fx(j) = s42_irrigation_efficiency;
- Elseif (s42_irrig_eff_scenario=2),
- 	v42_irrig_eff.fx(j) = 1/(1+2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
- Elseif (s42_irrig_eff_scenario=3),
-	v42_irrig_eff.fx(j) = 1/(1+2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer(t,i)))/37767));
- );
-);
-
-
-*Pumping cost in the current time step
-  ic42_pumping_cost(i) = 0;
-
-*Pumping cost settings will be only executed when s42_pumping is set to 1
-if ((s42_pumping = 1),
-ic42_pumping_cost(i) = f42_pumping_cost(t,i);
-*Pumping cost sensitivity test implmentation
-  if(m_year(t) > s42_multiplier_startyear,
-  ic42_pumping_cost(i) = f42_pumping_cost(t,i)*s42_multiplier;
-  );
-);
+vm_watdem.fx("ecosystem",j) = sum(cell(i,j), i42_env_flows_base(t,j) * (1 - ic42_env_flow_policy(i)) +
+                                              i42_env_flows(t,j) * ic42_env_flow_policy(i));

--- a/modules/42_water_demand/agr_sector_aug13/realization.gms
+++ b/modules/42_water_demand/agr_sector_aug13/realization.gms
@@ -5,7 +5,7 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
-*' @description  
+*' @description
 *'
 *' This realization models agricultural sector water demand endogenously, while other sectors are kept exogenous;
 *' Various settings for environmental water demand described below.
@@ -68,6 +68,8 @@
 *'
 *' Whether a potential EFP policy takes effect is determined by the parameter
 *' `f42_env_flow_policy`.
+*' The speed of transitioning to full environmental flow protection is determined
+*' by specifying the start (`s42_efp_startyear`) and target (`s42_efp_targetyear`) year.
 *'
 *' @limitations The module uses the "conveyance efficiency times management
 *' factor" for irrigation efficiency. Therefore, the management factor is

--- a/modules/42_water_demand/all_sectors_aug13/declarations.gms
+++ b/modules/42_water_demand/all_sectors_aug13/declarations.gms
@@ -12,14 +12,15 @@ parameters
  i42_env_flows_base(t,j)            Environmental flow requirements in case of no policy (mio m^3)
  ic42_env_flow_policy(i)            Determines whether environmental flow protection is enforced in the current time step (1)
  i42_env_flow_policy(t,i)           Determines whether environmental flow protection is enforced (1)
-* country-specific scenario switch
+ p42_efp(t_all,scen42)              Determines whether environmental flow protection is enforced and its fading in of environmental flow policy (1)
+ p42_efp_fader(t_all)               Determines the fading in of environmental flow policy (1)
  p42_country_dummy(iso)             Dummy parameter indicating whether country is affected by EFP (1)
  p42_EFP_region_shr(t_all,i)        Weighted share of region with regards to EFP (1)
  ic42_pumping_cost(i)               Parameter to capture values for pumping costs in a particular time step (USD05MER per m^3)
 ;
 
 equations
- q42_water_demand(wat_dem,j)         Water withdrawals of different sectors (mio. m^3 per yr)
+ q42_water_demand(wat_dem,j)        Water withdrawals of different sectors (mio. m^3 per yr)
  q42_water_cost(i)                  Total cost of pumping irrigation water (USD05MER per yr)
 ;
 

--- a/modules/42_water_demand/all_sectors_aug13/input.gms
+++ b/modules/42_water_demand/all_sectors_aug13/input.gms
@@ -6,21 +6,20 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 scalars
-
 s42_watdem_nonagr_scenario         Scenario for non agricultural water demand from WATERGAP     (1)             / 2 /
 *                                                                                1: SSP1
 *                                                                                2: SSP2
 *                                                                                3: SSP3
 
-s42_irrig_eff_scenario     Scenario for irrigation efficiency      (1)      / 2 /
+s42_irrig_eff_scenario             Scenario for irrigation efficiency      (1)      / 2 /
 *                                      1: global static value
 *                                      2: regional static values from CS
 *                                      3: gdp driven increase
 
-s42_irrigation_efficiency              Value of irrigation efficiency.         (1)      / 0.66 /
+s42_irrigation_efficiency          Value of irrigation efficiency         (1)      / 0.66 /
 *                                      Only if global static value is requested
 
-s42_env_flow_scenario              Environmental flow protection scenario.         (1)      / 2 /
+s42_env_flow_scenario              Environmental flow protection scenario         (1)      / 2 /
 *                                  0: don't consider environmental flows.
 *                                                                          s42_env_flow_base_fraction and
 *                                                                          s42_env_flow_fraction have no effect.
@@ -32,10 +31,11 @@ s42_env_flow_scenario              Environmental flow protection scenario.      
 *                                     results and a calculation algorithm by Smakhtin 2004.
 *                                                                          s42_env_flow_fraction has no effect.
 
+* Linear fading in of environmental flow policy between startyear and targetyear
+s42_efp_startyear                  Environmental flow policy start year   / 2020 /
+s42_efp_targetyear                 Environmental flow policy target year  / 2040 /
 s42_env_flow_base_fraction         Fraction of available water that is reserved for the environment if no EFR protection policy is implemented (1)           / 0.05 /
-*                                                                    (determined in the file
-*                                                                   EFR_protection_policy.csv)
-s42_env_flow_fraction              Fraction of available water that is reserved for under protection policies (1) / 0.2 /
+s42_env_flow_fraction              Fraction of available water that is reserved under protection policies (1) / 0.2 /
 s42_pumping                        Switch to activate pumping cost settings (1) / 0 /
 s42_multiplier_startyear           Year from which pumping costs multiplier will be implemented (1) / 1995 /
 s42_multiplier                     multiplier to change pumping costs for sensitivity analysis takes numeric values (1)  / 0 /
@@ -113,13 +113,7 @@ m_fillmissingyears(f42_env_flows,"j");
 
 $setglobal c42_env_flow_policy  off
 
-table f42_env_flow_policy(t_all,scen42) EFP policies (1)
-$ondelim
-$include "./modules/42_water_demand/input/f42_env_flow_policy.cs3"
-$offdelim
-;
-
-*Costs of pumping are calculated for India as per methodology in forthcoming paper by Singh et.al.
+* Costs of pumping are calculated for India as per methodology in forthcoming paper by Singh et.al.
 parameter
 f42_pumping_cost(t_all,i) Cost of pumping irrigation water (USD05MER per m^3)
 /

--- a/modules/42_water_demand/all_sectors_aug13/preloop.gms
+++ b/modules/42_water_demand/all_sectors_aug13/preloop.gms
@@ -9,3 +9,9 @@ i42_wat_req_k(t,j,kve) = f42_wat_req_kve(t,j,kve);
 i42_env_flows(t,j) = f42_env_flows(t,j);
 
 i42_wat_req_k(t,j,kli) = f42_wat_req_kli(kli);
+
+* Trajectory for environmental flow policy
+* (linear interpolation from start year to target year)
+p42_efp(t_all,"off") = 0;
+m_linear_interpol(p42_efp_fader, s42_efp_startyear, s42_efp_targetyear, 0, 1);
+p42_efp(t_all, "on") = p42_efp_fader(t_all);

--- a/modules/42_water_demand/all_sectors_aug13/presolve.gms
+++ b/modules/42_water_demand/all_sectors_aug13/presolve.gms
@@ -5,6 +5,31 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
+* Agricultural water demand
+ic42_wat_req_k(j,k) = i42_wat_req_k(t,j,k);
+
+
+* Water withdrawals in manufacturing, electricity, domestic, ecosystem
+* depends on the socioeconomic scenario
+if ((s42_watdem_nonagr_scenario = 1),
+ vm_watdem.fx(watdem_ineldo,j) = f42_watdem_ineldo(t,j,"ssp1",watdem_ineldo);
+Elseif(s42_watdem_nonagr_scenario = 2),
+ vm_watdem.fx(watdem_ineldo,j) = f42_watdem_ineldo(t,j,"ssp2",watdem_ineldo);
+Elseif(s42_watdem_nonagr_scenario = 3),
+ vm_watdem.fx(watdem_ineldo,j) = f42_watdem_ineldo(t,j,"ssp3",watdem_ineldo);
+);
+
+
+* Environmental flow scenarios depending on the switch s42_env_flow_scenario
+i42_env_flows_base(t,j) = s42_env_flow_base_fraction * sum(wat_src, im_wat_avail(t,wat_src,j));
+
+if ((s42_env_flow_scenario = 0),
+  i42_env_flows_base(t,j) = 0;
+  i42_env_flows(t,j) = 0;
+Elseif (s42_env_flow_scenario = 1),
+  i42_env_flows(t,j) = s42_env_flow_fraction * sum(wat_src, im_wat_avail(t,wat_src,j));
+);
+
 * Country switch to determine countries for which EFP holds.
 * In the default case, the EFP affects all countries when activated.
 p42_country_dummy(iso) = 0;
@@ -16,65 +41,40 @@ p42_EFP_region_shr(t_all,i) = sum(i_to_iso(i,iso), p42_country_dummy(iso) * im_p
 
 * Environmental policy switch:
 $ifthen "%c42_env_flow_policy%" == "mixed"
-  i42_env_flow_policy(t,i) = (im_development_state(t,i) * f42_env_flow_policy(t,"on")) * p42_EFP_region_shr(t,i)
-                       + f42_env_flow_policy(t,"off") * (1-p42_EFP_region_shr(t,i));
+  i42_env_flow_policy(t,i) = (im_development_state(t,i) * p42_efp(t,"on")) * p42_EFP_region_shr(t,i)
+                       + p42_efp(t,"off") * (1-p42_EFP_region_shr(t,i));
 $else
-  i42_env_flow_policy(t,i) = f42_env_flow_policy(t,"%c42_env_flow_policy%") * p42_EFP_region_shr(t,i)
-                       + f42_env_flow_policy(t,"off") * (1-p42_EFP_region_shr(t,i));
+  i42_env_flow_policy(t,i) = p42_efp(t,"%c42_env_flow_policy%") * p42_EFP_region_shr(t,i)
+                       + p42_efp(t,"off") * (1-p42_EFP_region_shr(t,i));
 $endif
 
-
-
-* Agricultural water demand
-ic42_wat_req_k(j,k) = i42_wat_req_k(t,j,k);
 ic42_env_flow_policy(i) = i42_env_flow_policy(t,i);
 
-* water withdrawals in manufacturing, electricity, domestic, ecosystem
-* depends on the socioeconomic scenario
-if((s42_watdem_nonagr_scenario = 1),
- vm_watdem.fx(watdem_ineldo,j) = f42_watdem_ineldo(t,j,"ssp1",watdem_ineldo);
-Elseif(s42_watdem_nonagr_scenario = 2),
- vm_watdem.fx(watdem_ineldo,j) = f42_watdem_ineldo(t,j,"ssp2",watdem_ineldo);
-Elseif(s42_watdem_nonagr_scenario = 3),
- vm_watdem.fx(watdem_ineldo,j) = f42_watdem_ineldo(t,j,"ssp3",watdem_ineldo);
-);
-
-*Environmental flow scenarios depending on the switch s42_env_flow_scenario
-i42_env_flows_base(t,j) = s42_env_flow_base_fraction * sum(wat_src, im_wat_avail(t,wat_src,j));
-
-if((s42_env_flow_scenario=0),
- i42_env_flows_base(t,j) = 0;
- i42_env_flows(t,j) = 0;
-Elseif(s42_env_flow_scenario=1),
-  i42_env_flows(t,j) = s42_env_flow_fraction * sum(wat_src, im_wat_avail(t,wat_src,j));
-);
-
 vm_watdem.fx("ecosystem",j) = sum(cell(i,j), i42_env_flows_base(t,j) * (1-ic42_env_flow_policy(i)) +
-                                                          i42_env_flows(t,j) * ic42_env_flow_policy(i));
+                                             i42_env_flows(t,j) * ic42_env_flow_policy(i));
 
-
-* irrigation efficiency
-if(m_year(t) <= sm_fix_SSP2,
- v42_irrig_eff.fx(j) = 1/(1+2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
+* Irrigation efficiency
+if (m_year(t) <= sm_fix_SSP2,
+ v42_irrig_eff.fx(j) = 1 / (1 + 2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
 else
- if((s42_irrig_eff_scenario = 1),
+ if ((s42_irrig_eff_scenario = 1),
  	v42_irrig_eff.fx(j) = s42_irrigation_efficiency;
- Elseif (s42_irrig_eff_scenario=2),
- 	v42_irrig_eff.fx(j) = 1/(1+2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
- Elseif (s42_irrig_eff_scenario=3),
-	v42_irrig_eff.fx(j) = 1/(1+2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer(t,i)))/37767));
+ Elseif (s42_irrig_eff_scenario = 2),
+ 	v42_irrig_eff.fx(j) = 1 / (1 + 2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
+ Elseif (s42_irrig_eff_scenario = 3),
+	v42_irrig_eff.fx(j) = 1 / (1 + 2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer(t,i)))/37767));
  );
 );
 
 
-*Pumping cost in the current time step
-  ic42_pumping_cost(i) = 0;
+* Pumping cost in the current time step
+ic42_pumping_cost(i) = 0;
 
-*Pumping cost settings will be only executed when s42_pumping is set to 1
+* Pumping cost settings will be only executed when s42_pumping is set to 1
 if ((s42_pumping = 1),
-ic42_pumping_cost(i) = f42_pumping_cost(t,i);
-*Pumping cost sensitivity test implmentation
+ ic42_pumping_cost(i) = f42_pumping_cost(t,i);
+* Pumping cost sensitivity test implmentation
   if(m_year(t) > s42_multiplier_startyear,
-  ic42_pumping_cost(i) = f42_pumping_cost(t,i)*s42_multiplier;
+   ic42_pumping_cost(i) = f42_pumping_cost(t,i) * s42_multiplier;
   );
 );

--- a/modules/42_water_demand/all_sectors_aug13/presolve.gms
+++ b/modules/42_water_demand/all_sectors_aug13/presolve.gms
@@ -8,6 +8,32 @@
 * Agricultural water demand
 ic42_wat_req_k(j,k) = i42_wat_req_k(t,j,k);
 
+* Irrigation efficiency
+if (m_year(t) <= sm_fix_SSP2,
+ v42_irrig_eff.fx(j) = 1 / (1 + 2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
+else
+ if ((s42_irrig_eff_scenario = 1),
+ 	v42_irrig_eff.fx(j) = s42_irrigation_efficiency;
+ Elseif (s42_irrig_eff_scenario = 2),
+ 	v42_irrig_eff.fx(j) = 1 / (1 + 2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
+ Elseif (s42_irrig_eff_scenario = 3),
+	v42_irrig_eff.fx(j) = 1 / (1 + 2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer(t,i)))/37767));
+ );
+);
+
+
+* Pumping cost in the current time step
+ic42_pumping_cost(i) = 0;
+
+* Pumping cost settings will be only executed when s42_pumping is set to 1
+if ((s42_pumping = 1),
+ ic42_pumping_cost(i) = f42_pumping_cost(t,i);
+* Pumping cost sensitivity test implmentation
+  if(m_year(t) > s42_multiplier_startyear,
+   ic42_pumping_cost(i) = f42_pumping_cost(t,i) * s42_multiplier;
+  );
+);
+
 
 * Water withdrawals in manufacturing, electricity, domestic, ecosystem
 * depends on the socioeconomic scenario
@@ -50,31 +76,5 @@ $endif
 
 ic42_env_flow_policy(i) = i42_env_flow_policy(t,i);
 
-vm_watdem.fx("ecosystem",j) = sum(cell(i,j), i42_env_flows_base(t,j) * (1-ic42_env_flow_policy(i)) +
+vm_watdem.fx("ecosystem",j) = sum(cell(i,j), i42_env_flows_base(t,j) * (1 - ic42_env_flow_policy(i)) +
                                              i42_env_flows(t,j) * ic42_env_flow_policy(i));
-
-* Irrigation efficiency
-if (m_year(t) <= sm_fix_SSP2,
- v42_irrig_eff.fx(j) = 1 / (1 + 2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
-else
- if ((s42_irrig_eff_scenario = 1),
- 	v42_irrig_eff.fx(j) = s42_irrigation_efficiency;
- Elseif (s42_irrig_eff_scenario = 2),
- 	v42_irrig_eff.fx(j) = 1 / (1 + 2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer("y1995",i)))/37767));
- Elseif (s42_irrig_eff_scenario = 3),
-	v42_irrig_eff.fx(j) = 1 / (1 + 2.718282**((-22160-sum(cell(i,j),im_gdp_pc_mer(t,i)))/37767));
- );
-);
-
-
-* Pumping cost in the current time step
-ic42_pumping_cost(i) = 0;
-
-* Pumping cost settings will be only executed when s42_pumping is set to 1
-if ((s42_pumping = 1),
- ic42_pumping_cost(i) = f42_pumping_cost(t,i);
-* Pumping cost sensitivity test implmentation
-  if(m_year(t) > s42_multiplier_startyear,
-   ic42_pumping_cost(i) = f42_pumping_cost(t,i) * s42_multiplier;
-  );
-);

--- a/modules/42_water_demand/all_sectors_aug13/realization.gms
+++ b/modules/42_water_demand/all_sectors_aug13/realization.gms
@@ -7,8 +7,9 @@
 
 *' @description
 *'
-*' This realization models agricultural sector water demand endogenously, as described in the first realization,
-*' Manufacturing, electricity and domestic demand are explicitly accounted in various scenarios;
+*' This realization models agricultural sector water withdrawals endogenously,
+*' as described in the first realization.
+*' Manufacturing, electricity and domestic demand are explicitly accounted for in various scenarios;
 *' Various settings (same as in previous realization) for environmental water demand described below.
 *'
 *' *Agricultural water demand*:
@@ -17,9 +18,9 @@
 *' cropland `vm_area(j,kcr,"irrigated")` and livestock production
 *' `vm_prod(j,kli)`.
 *'
-*' *Non agricultural human water demand*:
+*' *Non agricultural human water withdrawals*:
 *'
-*' For manufacturing, electricity and domestic demand, three scenarios of the
+*' For manufacturing, electricity and domestic withdrawals, three scenarios of the
 *' WATERGAP model provided by @wada_modeling_2016 are used:
 *'
 *' * SSP1
@@ -50,6 +51,9 @@
 *'   `s42_protected_fraction`. In the case of the absence of an environmental
 *'   flow protection policy, a base protection can be specified:
 *'   `s42_env_flow_base_fraction`. It defaults to 5 % of available water.
+*'
+*' The speed of transitioning to full environmental flow protection is determined
+*' by specifying the start (`s42_efp_startyear`) and target (`s42_efp_targetyear`) year.
 *'
 *' @limitations The module uses the "conveyance efficiency times management
 *' factor" for irrigation efficiency. Therefore, the management factor is

--- a/modules/42_water_demand/all_sectors_aug13/sets.gms
+++ b/modules/42_water_demand/all_sectors_aug13/sets.gms
@@ -21,5 +21,4 @@ sets
 	scen42_to_dev(scen42,dev) Mapping between EFP and economic development status
       /	off		. (lic, mic)
        	on		. (hic) /
-
 ;

--- a/modules/42_water_demand/input/files
+++ b/modules/42_water_demand/input/files
@@ -2,6 +2,5 @@
 lpj_airrig.cs2
 lpj_envflow_grper.cs2
 watdem_nonagr_grper.cs3
-f42_env_flow_policy.cs3
 f42_wat_req_fao.csv
 f42_pumping_cost.cs4


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- This PR flexibilizes the selection of the start year and target year of the fading in of the Environmental Flow Policy
- Previously, it faded in "linearly" through the file f42_env_flow_policy.csv and alternative scenarios (e.g. the India country case studies used extra files to set different start and target years (f42_env_flow_policy_india.csv))
- Now the start and target year can be set through s42_efp_startyear and s42_efp_targetyear. The policy then fades in truly linearly using a macro

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - Fading is now linear (before it was nearly linear), minor changes as can be seen in the results shown below


- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
 


### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : 0.3666597
  - This PR's default :  0.38881999

Slightly better runtime

<img width="618" alt="runtime" src="https://user-images.githubusercontent.com/39262100/207313430-1dff71bf-99c7-48be-b8c0-52c6e0963fc3.PNG">


Some results: 
Tau unchanged
<img width="591" alt="EFP_tau" src="https://user-images.githubusercontent.com/39262100/207312318-ec631682-425f-4744-9f46-389b56e51473.PNG">

Area actually irrigated 
<img width="607" alt="EFP_AAI" src="https://user-images.githubusercontent.com/39262100/207312387-b34db864-de53-4cf1-93b6-a8bae6609c3e.PNG">

Withdrawal comparing EFP off with EFP on (old and new)
<img width="604" alt="EFPwithdrawal" src="https://user-images.githubusercontent.com/39262100/207312444-51781b25-9e80-4840-9046-bd1bd8e012bb.PNG">

Withdrawal with example of different start and end year compared to previous default
<img width="600" alt="withdrawalNEWSCEN" src="https://user-images.githubusercontent.com/39262100/207312518-32cd841c-e63f-423b-afc3-b2507a58ec4f.PNG">


## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
