### PR TITLE
Bugfix Food and Material module results until 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **config** added `s38_target_labor_share`, `s38_targetyear_labor_share` and `s38_target_fulfillment` to define labor share target scnarios
 - **38_factor_costs** changed name of set `req` to `factors` (also used in 11_costs, 57_maccs, 70_livestock)
 - **38_factos_costs** sticky_labor realization: included option to set a labor share target
+- **15_food** changed `anthro_iso_jun22` realisation such that results in case of `exo_diet = 1/0` and `exo_waste = 1/0` are identical until 2020
 
 ### added
 - **scripts** added start script which starts an empty model just regenerating a previous run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **38_factor_costs** changed name of set `req` to `factors` (also used in 11_costs, 57_maccs, 70_livestock)
 - **38_factos_costs** sticky_labor realization: included option to set a labor share target
 - **15_food** changed `anthro_iso_jun22` realisation such that results in case of `exo_diet = 1/0` and `exo_waste = 1/0` are identical until 2020
+- **62_material** Bioplastic demand identical in all scenarios until 2020
 
 ### added
 - **scripts** added start script which starts an empty model just regenerating a previous run

--- a/modules/15_food/anthro_iso_jun22/exodietmacro.gms
+++ b/modules/15_food/anthro_iso_jun22/exodietmacro.gms
@@ -336,6 +336,11 @@ $endif
   p15_bmi_shr_calibrated(t,iso,sex,age,bmi_group15) = p15_bmi_shr_calibrated(t,iso,sex,age,bmi_group15) * (1-i15_exo_foodscen_fader(t,iso))
                       + p15_bmi_shr_target(t,iso,sex,age,bmi_group15) * i15_exo_foodscen_fader(t,iso);
 
+
+);
+*' End of special postprocessing food demand scenarios.
+
+
 *' 4.) The fourth step estimates the calorie supply at household level by multiplying
 *' daily per capita calorie intake with the demand2intake ratio that was estimated
 *' previously. It assures that if commodities with higher food waste ratio are
@@ -351,11 +356,6 @@ $endif
   p15_demand2intake_ratio(t,iso) = 1$(p15_intake_total(t,iso) = 0) +
          (sum(kfo,p15_kcal_pc_iso(t,iso,kfo)) / p15_intake_total(t,iso))$(
            p15_intake_total(t,iso) > 0);
-
-);
-*' End of special postprocessing food demand scenarios.
-
-
 
 
 * ###### Exogenous food waste scenario

--- a/modules/15_food/anthro_iso_jun22/exodietmacro.gms
+++ b/modules/15_food/anthro_iso_jun22/exodietmacro.gms
@@ -352,9 +352,6 @@ $endif
          (sum(kfo,p15_kcal_pc_iso(t,iso,kfo)) / p15_intake_total(t,iso))$(
            p15_intake_total(t,iso) > 0);
 
-  p15_demand2intake_ratio_detail(t,iso,kfo)=1$(p15_intake_detail(t,iso,kfo) = 0) +
-  (p15_kcal_pc_iso(t,iso,kfo) / p15_intake_detail(t,iso,kfo))$(p15_intake_detail(t,iso,kfo) > 0);
-
 );
 *' End of special postprocessing food demand scenarios.
 
@@ -372,6 +369,8 @@ $endif
                       = p15_demand2intake_ratio(t,iso)*(1-i15_exo_foodscen_fader(t,iso))
                         + s15_waste_scen*i15_exo_foodscen_fader(t,iso);
 
+);
+
 *' waste calculation by crop type
 
     p15_waste_pc(t,iso,kfo)$(sum(kfo2, p15_waste_pc(t,iso,kfo2))<>0) = p15_waste_pc(t,iso,kfo) / sum(kfo2, p15_waste_pc(t,iso,kfo2))*
@@ -380,12 +379,9 @@ $endif
 *' Waste ratio is applied
     p15_kcal_pc_iso(t,iso,kfo) = p15_intake_detail(t,iso,kfo) + p15_waste_pc(t,iso,kfo);
 
+*' Demand intake detail
     p15_demand2intake_ratio_detail(t,iso,kfo)=1$(p15_intake_detail(t,iso,kfo) = 0) +
                   (p15_kcal_pc_iso(t,iso,kfo) / p15_intake_detail(t,iso,kfo))$(p15_intake_detail(t,iso,kfo) > 0);
-
-);
-
-
 
 
 *' The country-level parameter p15_kcal_pc_iso is aggregated to the

--- a/modules/62_material/exo_flexreg_apr16/equations.gms
+++ b/modules/62_material/exo_flexreg_apr16/equations.gms
@@ -15,7 +15,7 @@
 *' depending on a scaling factor. This scaling factor is calculated as the
 *' ratio beween the food demand from last timestep and the food demand from
 *' the last historical time step. If an exogenous target for bioplastic production
-*' is set, material demand (substrate) for bioplastic production is included. 
+*' is set, increasing material demand (substrate) for bioplastic production is included. 
 *' For historic years it is assumed that this demand is already part of the
 *' general material demand, therefore the double-counted demand is subtracted.
 

--- a/modules/62_material/exo_flexreg_apr16/preloop.gms
+++ b/modules/62_material/exo_flexreg_apr16/preloop.gms
@@ -13,8 +13,10 @@
 * midpoint and maximum for future years. Global bioplastic demand is distributed to regions
 * proportional to population due to lack of better data.
 
+p62_dem_bioplastic(t,i) = f62_hist_dem_bioplastic(t) * (im_pop(t,i) / sum(i2, im_pop(t,i2)));
+p62_dem_bioplastic(t,i)$(m_year(t)>2020) = p62_dem_bioplastic("y2020",i);
+
 if (s62_max_dem_bioplastic <> 0,
-  p62_dem_bioplastic(t,i) = f62_hist_dem_bioplastic(t) * (im_pop(t,i) / sum(i2, im_pop(t,i2)));
   s62_growth_rate_bioplastic = log((s62_max_dem_bioplastic/f62_hist_dem_bioplastic("y2020")) - 1)/(s62_midpoint_dem_bioplastic-2020);
   p62_dem_bioplastic(t,i)$(m_year(t)>2020) = s62_max_dem_bioplastic / (1 + exp(-s62_growth_rate_bioplastic*(m_year(t)-s62_midpoint_dem_bioplastic))) * (im_pop(t,i) / sum(i2, im_pop(t,i2)));
 );

--- a/modules/62_material/exo_flexreg_apr16/preloop.gms
+++ b/modules/62_material/exo_flexreg_apr16/preloop.gms
@@ -15,7 +15,7 @@
 * Global bioplastic demand is distributed to regions proportional to population due to lack of better data.
 
 p62_dem_bioplastic(t,i) = f62_hist_dem_bioplastic(t) * (im_pop(t,i) / sum(i2, im_pop(t,i2)));
-p62_dem_bioplastic(t,i)$(m_year(t)>2020) = p62_dem_bioplastic("y2020",i);
+p62_dem_bioplastic(t,i)$(m_year(t)>2020) = f62_hist_dem_bioplastic("y2020") * (im_pop("y2020",i) / sum(i2, im_pop("y2020",i2)));
 
 if (s62_max_dem_bioplastic <> 0,
   s62_growth_rate_bioplastic = log((s62_max_dem_bioplastic/f62_hist_dem_bioplastic("y2020")) - 1)/(s62_midpoint_dem_bioplastic-2020);

--- a/modules/62_material/exo_flexreg_apr16/preloop.gms
+++ b/modules/62_material/exo_flexreg_apr16/preloop.gms
@@ -9,9 +9,10 @@
  p62_dem_food_lastcalibyear(i) = 1;
  p62_dem_bioplastic(t,i) = 0;
 
-* Bioplastic demand is based on historic values up to 2020, and a logistic function with given
-* midpoint and maximum for future years. Global bioplastic demand is distributed to regions
-* proportional to population due to lack of better data.
+* Bioplastic demand is based on historic values up to 2020, and either kept constant for
+* future years, or following a logistic function with given midpoint and maximum if a 
+* bioplastic production target is exogenously set. 
+* Global bioplastic demand is distributed to regions proportional to population due to lack of better data.
 
 p62_dem_bioplastic(t,i) = f62_hist_dem_bioplastic(t) * (im_pop(t,i) / sum(i2, im_pop(t,i2)));
 p62_dem_bioplastic(t,i)$(m_year(t)>2020) = p62_dem_bioplastic("y2020",i);

--- a/modules/62_material/exo_flexreg_apr16/realization.gms
+++ b/modules/62_material/exo_flexreg_apr16/realization.gms
@@ -12,9 +12,9 @@
 *' material module based on historical data. The assumption that material demand
 *' grows proportional to food demand is a simplification that can be justified
 *' by the minor importance of non-bioenergy material usage of agricultural products.
-*' In addition, biomass demand for bioplastic production can be included, with 
-*' future bioplastic production following a logistic curve with exogenously defined 
-*' target production.
+*' In addition, biomass demand for bioplastic production is included, with 
+*' future bioplastic production kept constant or following a logistic curve 
+*' if a bioplastic production target is exogenously set.
 
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "sets" $include "./modules/62_material/exo_flexreg_apr16/sets.gms"

--- a/modules/62_material/module.gms
+++ b/modules/62_material/module.gms
@@ -15,8 +15,8 @@
 *' category, the use for bioenergy (oils and ethanol) has been excluded
 *' and is accounted for in the demand for bioenergy. Material demand in this
 *' context can be considered as a subset of "other utils" category of FAO.
-*' In addition, future material demand for bioplastic production can be included
-*' by setting a target bioplastic demand.
+*' In addition, increasing material demand for bioplastic production can be
+*' included by setting a target bioplastic demand.
 
 *' @authors Benjamin Bodirsky, Debbora Leip
 


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- This PR makes sure that results in case of exo_diet = 1/0 and exo_waste = 1/0 are identical until 2020.
- Bioplastic demand identical in all scenarios until 2020

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

![Resources_Land_Cover_Cropland-82](https://user-images.githubusercontent.com/16921122/212538371-baa60e7f-8124-4302-89da-b3da91221c09.png)
![Resources_Land_Cover_Cropland-83](https://user-images.githubusercontent.com/16921122/212538374-185df7c9-50d9-471a-86a5-48359b104374.png)
![Emissions_CO2_Land_Land_use_Change-57](https://user-images.githubusercontent.com/16921122/212538400-a2cc0a7a-1f5a-488a-9122-ec51815254a8.png)
![Water_Environmental_flow_violation_volume](https://user-images.githubusercontent.com/16921122/212538433-33d7e84b-59df-4ee9-8772-2ed5e225a2d9.png)

![Resources_Land_Cover_Cropland-84](https://user-images.githubusercontent.com/16921122/212632069-3437223f-c891-4caa-a3a3-356da7dbd59e.png)
![Demand_for_bioplastic](https://user-images.githubusercontent.com/16921122/212632100-73f5f3b5-074b-4d42-9b75-92a863e14f8a.png)


### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : 0.38 h
  - This PR's default :  0.4 h

![newplot-13](https://user-images.githubusercontent.com/16921122/212538361-f3a4a40c-12ca-4770-89f2-0dceab61844f.png)

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
