### PR TITLE
fix renv for HR runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **config** scenario_fsec.csv updated to new biodiversity scenario
 - **scripts** fsec.R and project_FSEC_Scenarios.R include capitalSubst and landscapeElements scenarios
 - **scripts** highres.R changed default resolution to c1000
+- **scripts** when manually running output scripts for multiple runs the lockfile is only created once
 
 ### added
 - **15_food** half_overweight scenario added
@@ -21,14 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **scripts** added restart points after each time step from which the model can now be restarted if the simulation aborts at some point
 - **scripts** added SLURM dayMax submission type for standby QOS
 
-### fixed
-- **scripts** fixed a bug where renvs for high resolution runs were missing some packages
-- **44_biodiversity** added regional layer `i` in `bii_target` realisation to make it compatible with the high-resolution parallel optimization output script
-
 ### removed
 -
 
 ### fixed
+- **scripts** fixed a bug where renvs for high resolution runs were missing some packages
+- **44_biodiversity** added regional layer `i` in `bii_target` realisation to make it compatible with the high-resolution parallel optimization output script
 - **59_som** division by zero prevented by if condition
 - **14_yields** nl_fix updated to current equation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **scripts** added SLURM dayMax submission type for standby QOS
 
 ### fixed
+- **scripts** fixed a bug where renvs for high resolution runs were missing some packages
 - **44_biodiversity** added regional layer `i` in `bii_target` realisation to make it compatible with the high-resolution parallel optimization output script
 
 ### removed

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -45,7 +45,7 @@ cfg$input <- c(regional    = "rev4.79_h12_magpie.tgz",
 #below it will get merged into cfg$repositories
 
 cfg$repositories <- append(list("https://rse.pik-potsdam.de/data/magpie/public"=NULL),
-                               getOption("magpie_repos"))
+                           getOption("magpie_repos"))
 
 
 

--- a/output.R
+++ b/output.R
@@ -194,22 +194,28 @@ runOutputs <- function(comp=NULL, output=NULL, outputdir=NULL, submit=NULL) {
   # Write a separate lockfile called {datetime}_{outputscript}_renv.lock into outputdir
   # unless the renv from outputdir itself was used to run output.R
   if (!is.null(renv::project())) {
+    freshLockfile <- withr::local_tempfile()
+
+    message("Generating lockfile... ", appendLF = FALSE)
+    utils::capture.output({
+      utils::capture.output({
+        renv::snapshot(lockfile = freshLockfile, prompt = FALSE)
+      }, type = "message")
+    })
+    message("done.")
+
     datetime <- format(Sys.time(), "%Y-%m-%dT%H%M%S")
     scriptName <- gsub("/", "-", paste(sub("\\.R$", "", output), collapse = "--"))
+
     for (runFolder in setdiff(normalizePath(outputdir), normalizePath(renv::project()))) {
-      lockfile <- file.path(runFolder, "renv.lock")
-      newLockfile <- gsub("//", "/", file.path(runFolder, paste0(datetime, "__", scriptName, "__renv.lock")))
+      newLockfile <- file.path(runFolder, paste0(datetime, "__", scriptName, "__renv.lock"))
 
-      utils::capture.output({
-        utils::capture.output({
-          renv::snapshot(lockfile = newLockfile, prompt = FALSE)
-        }, type = "message")
-      })
+      file.copy(freshLockfile, newLockfile)
 
-      if (!file.exists(lockfile)) {
-        warning(normalizePath(lockfile), " does not exist.")
+      if (!file.exists(file.path(runFolder, "renv.lock"))) {
+        warning(normalizePath(runFolder), "/renv.lock does not exist.")
         message("Lockfile written to ", newLockfile)
-      } else if (identical(readLines(lockfile), readLines(newLockfile))) {
+      } else if (identical(readLines(file.path(runFolder, "renv.lock")), readLines(newLockfile))) {
         file.remove(newLockfile)
       } else {
         message("Lockfile written to ", newLockfile)

--- a/scripts/output/extra/highres.R
+++ b/scripts/output/extra/highres.R
@@ -37,13 +37,10 @@ resultsarchive <- "/p/projects/rd3mod/models/results/magpie"
 # Load start_run(cfg) function which is needed to start MAgPIE runs
 source("scripts/start_functions.R")
 
-# wait some seconds (random between 5-30 sec) to avoid conflicts with locking the model folder (.lock file)
-Sys.sleep(runif(1, 5, 30))
-
 highres <- function(cfg) {
   #lock the model folder
-  lock_id <- gms::model_lock(timeout1=1,check_interval=runif(1, 10, 30))
-  on.exit(gms::model_unlock(lock_id), add=TRUE)
+  lockId <- gms::model_lock(timeout1 = 1)
+  withr::defer(gms::model_unlock(lockId))
 
   if(any(!(modelstat(gdx) %in% c(2,7)))) stop("Modelstat different from 2 or 7 detected")
 
@@ -106,7 +103,7 @@ highres <- function(cfg) {
                               paste0(cfg$results_folder,"/","magpie_y1995.gdx"))
   cfg$gms$s_use_gdx <- 1
   cfg$gms$s80_optfile <- 1
-  
+
   #max resources for parallel runs
   cfg$qos <- "standby_maxMem_dayMax"
 
@@ -161,9 +158,9 @@ highres <- function(cfg) {
   Sys.sleep(2)
 
   start_run(cfg,codeCheck=FALSE,lock_model=FALSE)
-  
+
   Sys.sleep(1)
-  
+
   if (file.exists("modules/32_forestry/input/f32_max_aff_area.cs4")) file.remove("modules/32_forestry/input/f32_max_aff_area.cs4")
 
 }

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -285,6 +285,7 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
       renv::init() # will overwrite renv.lock if existing...
       file.rename("_renv.lock", "renv.lock") # so we need this rename
       renv::restore(prompt = FALSE)
+      message("renv creation done.")
     }
 
     renvLogPath <- file.path(cfg$results_folder, "log_renv.txt")

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -264,26 +264,36 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
   if (is.null(renv::project())) {
     message("No active renv project found, not using renv.")
   } else {
-    message("Generating lockfile '", file.path(cfg$results_folder, "renv.lock"), "'... ", appendLF = FALSE)
-    # suppress output of renv::snapshot
-    utils::capture.output({
+    # this script always runs in repo root, so we can check whether the main renv is loaded with:
+    if (normalizePath(renv::project()) == normalizePath(".")) {
+      message("Generating lockfile in '", cfg$results_folder, "'... ", appendLF = FALSE)
+      # suppress output of renv::snapshot
       utils::capture.output({
-        # snapshot current main renv into run folder
-        renv::snapshot(lockfile = file.path(cfg$results_folder, "main_renv.lock"), prompt = FALSE)
-      }, type = "message")
-    })
-    message("done.")
+        utils::capture.output({
+          # snapshot current main renv into run folder
+          renv::snapshot(lockfile = file.path(cfg$results_folder, "_renv.lock"), prompt = FALSE)
+        }, type = "message")
+      })
+      message("done.")
+    } else {
+      # a run renv is loaded, we are presumably starting a HR follow up run
+      message("Copying lockfile into '", cfg$results_folder, "'")
+      file.copy(renv::paths$lockfile(), file.path(cfg$results_folder, "_renv.lock"))
+    }
 
-    message("Creating renv in '", cfg$results_folder, "'... ", appendLF = FALSE)
     createResultsfolderRenv <- function() {
       renv::init() # will overwrite renv.lock if existing...
-      file.rename("main_renv.lock", "renv.lock") # so we need this rename
+      file.rename("_renv.lock", "renv.lock") # so we need this rename
       renv::restore(prompt = FALSE)
     }
+
+    renvLogPath <- file.path(cfg$results_folder, "log_renv.txt")
+    message("Initializing run renv, see '", renvLogPath, "'...", appendLF = FALSE)
     # init renv in a separate session so the libPaths of the current session remain unchanged
     callr::r(createResultsfolderRenv,
              wd = cfg$results_folder,
-             env = c(RENV_PATHS_LIBRARY = "renv/library"))
+             env = c(RENV_PATHS_LIBRARY = "renv/library"),
+             stdout = renvLogPath, stderr = "2>&1")
     message("done.")
   }
 


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- HR renvs were missing packages (raster, ncdf4), this PR fixes that
- manually running output.R for multiple runs will now only create lockfile once and copy to each run folder; this should improve performance a lot for these cases

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [x] RSE review done (at least 1)
