### PR TITLE
Changes in the best_calib selection criterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### fixed
 - **scripts** fixed a bug where renvs for high resolution runs were missing some packages
 - **44_biodiversity** added regional layer `i` in `bii_target` realisation to make it compatible with the high-resolution parallel optimization output script
-- **scripts** fixed in the calc_calib.R script the saving of calib_factors used in each iteration to ensure that they correspond with the divergence reported. Changed divergence from zero to NA for those iterations where calib_factors are above the limit. The best_calib selection criterion was changed from selecting the factors of the iteration with the lowest standard deviation to the selection, for each region, of the factor of the iteration with the lowest divergence. Also, factors from the first iteration are now not considered, and if two different factors had the same divergence for a region, the one of the latest iteration is picked.
+- **scripts** fixed in the calc_calib.R script the saving of calib_factors used in each iteration to ensure that they correspond to the divergence reported. Changed divergence from zero to NA for those iterations where calib_factors are above the limit. The best_calib selection criterion was changed from selecting the factors of the iteration with the lowest standard deviation to the selection, for each region, of the factor of the iteration with the lowest divergence. Also, factors from the first iteration are now not considered, and if two different factors had the same divergence for a region, the one of the latest iteration is picked.
 
 ### removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### fixed
 - **44_biodiversity** added regional layer `i` in `bii_target` realisation to make it compatible with the high-resolution parallel optimization output script
--**scripts** fixed in the calc_calib.R script the saving of calib_factors used in each iteration to ensure that they correspond with the divergence reported. Changed divergence from zero to NA for those iterations where calib_factors are above the limit. The best_calib selection criterion was changed from selecting the factors of the iteration with the lowest standard deviation to the selection, for each region, the factor of the iteration with the lowest divergence. Also, factors from the first iteration are now not considered, and if two different factors had the same divergence for a region, the one of the latest iteration is now picked.
+-**scripts** fixed in the calc_calib.R script the saving of calib_factors used in each iteration to ensure that they correspond with the divergence reported. Changed divergence from zero to NA for those iterations where calib_factors are above the limit. The best_calib selection criterion was changed from selecting the factors of the iteration with the lowest standard deviation to the selection, for each region, of the factor of the iteration with the lowest divergence. Also, factors from the first iteration are now not considered, and if two different factors had the same divergence for a region, the one of the latest iteration is picked.
 
 ### removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **config** scenario_fsec.csv updated to new biodiversity scenario
 - **scripts** fsec.R and project_FSEC_Scenarios.R include capitalSubst and landscapeElements scenarios
 - **scripts** highres.R changed default resolution to c1000
+- **scripts** recalibrate.R and recalibrate_realization were modified to always use best_calib for the yield calibration.
 
 ### added
 - **15_food** half_overweight scenario added
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### fixed
 - **44_biodiversity** added regional layer `i` in `bii_target` realisation to make it compatible with the high-resolution parallel optimization output script
+-**scripts** fixed in the calc_calib.R script the saving of calib_factors used in each iteration to ensure that they correspond with the divergence reported. Changed divergence from zero to NA for those iterations where calib_factors are above the limit. The best_calib selection criterion was changed from selecting the factors of the iteration with the lowest standard deviation to the selection, for each region, the factor of the iteration with the lowest divergence. Also, factors from the first iteration are now not considered, and if two different factors had the same divergence for a region, the one of the latest iteration is now picked.
 
 ### removed
 -

--- a/scripts/calibration/calc_calib.R
+++ b/scripts/calibration/calc_calib.R
@@ -10,28 +10,29 @@
 # ***              based on a pre run of magpie                     ***
 # *********************************************************************
 
-calibration_run<-function(putfolder,calib_magpie_name,logoption=3){
+calibration_run <- function(putfolder, calib_magpie_name, logoption = 3) {
 
   require(lucode2)
 
   # create putfolder for the calib run
-  unlink(putfolder,recursive=TRUE)
+  unlink(putfolder, recursive = TRUE)
   dir.create(putfolder)
 
   # create a modified magpie.gms for the calibration run
-  unlink(paste(calib_magpie_name,".gms",sep=""))
+  unlink(paste(calib_magpie_name, ".gms", sep = ""))
   unlink("fulldata.gdx")
 
-  if(!file.copy("main.gms",paste(calib_magpie_name,".gms",sep=""))){
-    stop(paste("Unable to create",paste(calib_magpie_name,".gms",sep="")))
+  if (!file.copy("main.gms", paste(calib_magpie_name, ".gms", sep = ""))) {
+    stop(paste("Unable to create", paste(calib_magpie_name, ".gms", sep = "")))
   }
-  lucode2::manipulateConfig(paste(calib_magpie_name,".gms",sep=""),c_timesteps=1)
-  lucode2::manipulateConfig(paste(calib_magpie_name,".gms",sep=""),s_use_gdx=0)
-  file.copy(paste(calib_magpie_name,".gms",sep=""),putfolder)
+  lucode2::manipulateConfig(paste(calib_magpie_name, ".gms", sep = ""), c_timesteps = 1)
+  lucode2::manipulateConfig(paste(calib_magpie_name, ".gms", sep = ""), s_use_gdx = 0)
+  file.copy(paste(calib_magpie_name, ".gms", sep = ""), putfolder)
 
   # execute calibration run
-  system(paste("gams ",calib_magpie_name,".gms"," -errmsg=1 -PUTDIR ./",putfolder," -LOGOPTION=",logoption,sep=""),wait=TRUE)
-  file.copy("fulldata.gdx",putfolder)
+  system(paste("gams ", calib_magpie_name, ".gms", " -errmsg=1 -PUTDIR ./", putfolder, " -LOGOPTION=", logoption,
+               sep = ""), wait = TRUE)
+  file.copy("fulldata.gdx", putfolder)
 }
 
 # get ratio between modelled area and reference area
@@ -39,14 +40,14 @@ get_areacalib <- function(gdx_file) {
   require(magclass)
   require(magpie4)
   require(gdx)
-  data <- readGDX(gdx_file,"pm_land_start")[,,c("crop","past")]
-  data <- dimSums(data,dim = 1.2)
-  magpie <- land(gdx_file)[,,c("crop","past")]
-  if(nregions(magpie)!=nregions(data) | !all(getRegions(magpie) %in% getRegions(data))) {
+  data <- readGDX(gdx_file, "pm_land_start")[, , c("crop", "past")]
+  data <- dimSums(data, dim = 1.2)
+  magpie <- land(gdx_file)[, , c("crop", "past")]
+  if (nregions(magpie) != nregions(data) || !all(getCells(magpie) %in% getCells(data))) {
     stop("Regions in MAgPIE do not agree with regions in reference calibration area data set!")
   }
-  out <- magpie/data
-  out[out==0] <- 1
+  out <- magpie / data
+  out[out == 0] <- 1
   out[is.na(out)] <- 1
   return(magpiesort(out))
 }
@@ -58,117 +59,122 @@ get_yieldcalib <- function(gdx_file) {
 
   prep <- function(x) {
     # use maiz as surrogate for all crops
-    elem <- c("maiz","pasture")
-    y <- collapseNames(x[,,"rainfed"][,,elem])
-    getNames(y) <- c("crop","past")
-    return(superAggregate(y,level="reg",aggr_type="mean", na.rm=TRUE))
+    elem <- c("maiz", "pasture")
+    y <- collapseNames(x[, , "rainfed"][, , elem])
+    getNames(y) <- c("crop", "past")
+    return(superAggregate(y, level = "reg", aggr_type = "mean", na.rm = TRUE))
   }
 
-  y_ini <- prep(readGDX(gdx_file, "i14_yields","i14_yields_calib", 
+  y_ini <- prep(readGDX(gdx_file, "i14_yields", "i14_yields_calib",
                         format = "first_found", react = "silent"))
-  y     <- prep(readGDX(gdx_file,"vm_yld")[,,"l"])
+  y     <- prep(readGDX(gdx_file, "vm_yld")[, , "l"])
 
-  out <- y/y_ini
-  out[out==0] <- 1
+  out <- y / y_ini
+  out[out == 0] <- 1
   out[is.na(out)] <- 1
   return(magpiesort(out))
 }
 
 # Calculate the correction factor and save it
-update_calib<-function(gdx_file, calib_accuracy=0.1, calibrate_pasture=TRUE,calibrate_cropland=TRUE,damping_factor=0.8, calib_file, crop_max=2, calibration_step="",n_maxcalib=20, best_calib = FALSE){
+update_calib <- function(gdx_file, calib_accuracy = 0.1, calibrate_pasture = TRUE, calibrate_cropland = TRUE,
+                         damping_factor = 0.8, calib_file, crop_max = 2, calibration_step = "",
+                         n_maxcalib = 20, best_calib = FALSE) {
   require(magclass)
   require(magpie4)
-  if(!(modelstat(gdx_file)[1,1,1]%in%c(1,2,7))) stop("Calibration run infeasible")
+  if (!(modelstat(gdx_file)[1, 1, 1] %in% c(1, 2, 7))) stop("Calibration run infeasible")
 
   area_factor  <- get_areacalib(gdx_file)
   tc_factor    <- get_yieldcalib(gdx_file)
   calib_correction <- area_factor * tc_factor
-  calib_divergence <- abs(calib_correction-1)
+  calib_divergence <- abs(calib_correction - 1)
 
-  calib_factor          <- readGDX(gdx_file,"f14_yld_calib")
-  calib_factor_calc     <- calib_factor * (damping_factor*(calib_correction-1) + 1)
+  calib_factor          <- readGDX(gdx_file, "f14_yld_calib")
+  calib_factor_calc     <- calib_factor * (damping_factor * (calib_correction - 1) + 1)
 
-  if(!is.null(crop_max)) {
-    above_limit <- (calib_factor[,,"crop"] > crop_max)
-    calib_factor[,,"crop"][above_limit]  <- crop_max
-    calib_divergence[getRegions(calib_factor),,"crop"][above_limit] <- NA
+  if (!is.null(crop_max)) {
+    above_limit <- (calib_factor[, , "crop"] > crop_max)
+    calib_factor[, , "crop"][above_limit]  <- crop_max
+    calib_divergence[getCells(calib_factor), , "crop"][above_limit] <- NA
   }
-  if(!calibrate_pasture)  {
-    calib_factor[,,"past"] <- 1
-    calib_divergence[,,"past"] <- 0
+  if (!calibrate_pasture) {
+    calib_factor[, , "past"] <- 1
+    calib_divergence[, , "past"] <- 0
   }
-  if(!calibrate_cropland) {
-    calib_factor[,,"crop"] <- 1
-    calib_divergence[,,"crop"] <- 0
+  if (!calibrate_cropland) {
+    calib_factor[, , "crop"] <- 1
+    calib_divergence[, , "crop"] <- 0
   }
 
   ### write down current calib factors (and area_factors) for tracking
-  write_log <- function(x,file,calibration_step) {
-    x <- add_dimension(x, dim=3.1, add="iteration", nm=calibration_step)
-    try(write.magpie(round(setYears(x,NULL),3), file, append = (calibration_step!=1)))
+  write_log <- function(x, file, calibration_step) {
+    x <- add_dimension(x, dim = 3.1, add = "iteration", nm = calibration_step)
+    try(write.magpie(round(setYears(x, NULL), 3), file, append = (calibration_step != 1)))
   }
 
-  write_log(calib_correction, "calib_correction.cs3" , calibration_step)
-  write_log(calib_divergence,  "calib_divergence.cs3" , calibration_step)
+  write_log(calib_correction, "calib_correction.cs3", calibration_step)
+  write_log(calib_divergence,  "calib_divergence.cs3", calibration_step)
   write_log(area_factor,       "calib_area_factor.cs3", calibration_step)
-  write_log(tc_factor,         "calib_tc_factor.cs3"  , calibration_step)
-  write_log(calib_factor,       "calib_factor.cs3"     , calibration_step)
+  write_log(tc_factor,         "calib_tc_factor.cs3", calibration_step)
+  write_log(calib_factor,       "calib_factor.cs3", calibration_step)
 
   # in case of sufficient convergence, stop here (no additional update of
   # calibration factors!)
-  if(all(calib_divergence <= calib_accuracy) |  calibration_step==n_maxcalib) {
+  if (all(calib_divergence <= calib_accuracy) ||  calibration_step == n_maxcalib) {
+    ### Depending on the selected calibration selection type (best_calib FALSE or TRUE)
+    # the reported and used regional calibration factors can be either the ones of the last iteration,
+    # or the "best" based on the iteration value with the lowest divergence.
+    if (best_calib == TRUE) {
 
-  ### Depending on the selected calibration selection type (best_calib FALSE or TRUE)
-  # the reported and used regional calibration factors can be either the ones of the last iteration,
-  # or the "best" based on the iteration value with the lowest divergence.
-     if (best_calib == TRUE) {
-    
-      calib_best<-new.magpie(cells_and_regions = getCells(calib_divergence),years = getYears(calib_divergence),names = c("crop","past"))
-      calib_best_div <- new.magpie(cells_and_regions = getCells(calib_divergence), years = getYears(calib_divergence), names = c("crop", "past"))
-      divergence_data<-read.magpie("calib_divergence.cs3")
-      factors_data<-read.magpie("calib_factor.cs3")
-      
-      for (i in getCells(calib_best)){
+      calib_best <- new.magpie(cells_and_regions = getCells(calib_divergence),
+                               years = getYears(calib_divergence), names = c("crop", "past"))
+      calib_best_div <- new.magpie(cells_and_regions = getCells(calib_divergence),
+                                   years = getYears(calib_divergence), names = c("crop", "past"))
+      divergence_data <- read.magpie("calib_divergence.cs3")
+      factors_data <- read.magpie("calib_factor.cs3")
 
-      factors_data_sub_crop <- as.data.frame(factors_data[i, , "crop"])
-      n_iterations <- nrow(factors_data_sub_crop)
-      factors_data_sub_crop <- factors_data_sub_crop[2:n_iterations, ]
-      divergence_data_sub_crop <- as.data.frame(divergence_data[i, , "crop"])[2:n_iterations, ]
-      factors_data_sub_past <- as.data.frame(factors_data[i, , "past"])[2:n_iterations, ]
-      divergence_data_sub_past <- as.data.frame(divergence_data[i, , "past"])[2:n_iterations, ]
-      
+      for (i in getCells(calib_best)) {
 
-      min_index_crop<-max(which(divergence_data_sub_crop$Value==min(divergence_data_sub_crop$Value,na.rm = TRUE))
-      min_index_past<-max(which(divergence_data_sub_past$Value==min(divergence_data_sub_past$Value,na.rm = TRUE)))
-     
-      calib_best[i,NULL,"crop"]<-factors_data_sub_crop[min_index_crop,"Value"]
-      calib_best[i,NULL,"past"]<-factors_data_sub_past[min_index_past,"Value"]
-      calib_best_div[i, NULL, "crop"] <- divergence_data_sub_crop[min_index_crop, "Value"]
-      calib_best_div[i, NULL, "past"] <- divergence_data_sub_crop[min_index_past, "Value"]
+        factors_data_sub_crop <- as.data.frame(factors_data[i, , "crop"])
+        n_iterations <- nrow(factors_data_sub_crop)
+        factors_data_sub_crop <- factors_data_sub_crop[2:n_iterations, ]
+        divergence_data_sub_crop <- as.data.frame(divergence_data[i, , "crop"])[2:n_iterations, ]
+        factors_data_sub_past <- as.data.frame(factors_data[i, , "past"])[2:n_iterations, ]
+        divergence_data_sub_past <- as.data.frame(divergence_data[i, , "past"])[2:n_iterations, ]
+
+
+        min_index_crop <- max(which(divergence_data_sub_crop$Value == min(divergence_data_sub_crop$Value,
+                                                                          na.rm = TRUE)))
+        min_index_past <- max(which(divergence_data_sub_past$Value == min(divergence_data_sub_past$Value,
+                                                                          na.rm = TRUE)))
+
+        calib_best[i, NULL, "crop"] <- factors_data_sub_crop[min_index_crop, "Value"]
+        calib_best[i, NULL, "past"] <- factors_data_sub_past[min_index_past, "Value"]
+        calib_best_div[i, NULL, "crop"] <- divergence_data_sub_crop[min_index_crop, "Value"]
+        calib_best_div[i, NULL, "past"] <- divergence_data_sub_crop[min_index_past, "Value"]
       }
+      comment <- c(" description: Regional yield calibration file",
+                   " unit: -",
+                   paste0(" note: Best calibration factor from the run"),
+                   " origin: scripts/calibration/calc_calib.R (path relative to model main directory)",
+                   paste0(" creation date: ", date()))
+      write.magpie(round(setYears(calib_best, NULL), 2), calib_file, comment = comment)
+
+      write_log(calib_best,     "calib_factor.cs3", "best")
+      write_log(calib_best_div, "calib_divergence.cs3", "best")
+      ####
+      return(TRUE)
+    } else {
+      return(TRUE)
+    }
+  } else {
     comment <- c(" description: Regional yield calibration file",
                  " unit: -",
-                 paste0(" note: Best calibration factor from the run"),
+                 paste0(" note: Calibration step ", calibration_step),
                  " origin: scripts/calibration/calc_calib.R (path relative to model main directory)",
-                 paste0(" creation date: ",date()))
-    write.magpie(round(setYears(calib_best,NULL),2), calib_file, comment = comment)
-
-    write_log(calib_best,     "calib_factor.cs3"     , "best")
-    write_log(calib_best_div, "calib_divergence.cs3", "best")
-####
-  return(TRUE)
-}else{
-  return(TRUE)
-}
-}else{
-  comment <- c(" description: Regional yield calibration file",
-               " unit: -",
-               paste0(" note: Calibration step ",calibration_step),
-               " origin: scripts/calibration/calc_calib.R (path relative to model main directory)",
-               paste0(" creation date: ",date()))
-  write.magpie(round(setYears(calib_factor_calc,NULL),2), calib_file, comment = comment)
-  return(FALSE)
-}
+                 paste0(" creation date: ", date()))
+    write.magpie(round(setYears(calib_factor_calc, NULL), 2), calib_file, comment = comment)
+    return(FALSE)
+  }
 
 
 }
@@ -178,7 +184,7 @@ calibrate_magpie <- function(n_maxcalib = 1,
                              calib_accuracy = 0.1,
                              calibrate_pasture = FALSE,
                              calibrate_cropland = TRUE,
-                             crop_max =2,
+                             crop_max = 2,
                              calib_magpie_name = "magpie_calib",
                              damping_factor = 0.6,
                              calib_file = "modules/14_yields/input/f14_yld_calib.csv",
@@ -190,19 +196,22 @@ calibrate_magpie <- function(n_maxcalib = 1,
 
   require(magclass)
 
-  if(file.exists(calib_file)) file.remove(calib_file)
-  for(i in 1:n_maxcalib){
-    cat(paste("\nStarting yield calibration iteration",i,"\n"))
-    calibration_run(putfolder=putfolder, calib_magpie_name=calib_magpie_name, logoption=logoption)
-    if(debug) file.copy(paste0(putfolder,"/fulldata.gdx"),paste0("fulldata_calib",i,".gdx"))
-    done <- update_calib(gdx_file=paste0(putfolder,"/fulldata.gdx"),calib_accuracy=calib_accuracy, calibrate_pasture=calibrate_pasture,calibrate_cropland=calibrate_cropland,crop_max=crop_max,damping_factor=damping_factor, calib_file=calib_file, calibration_step=i,n_maxcalib=n_maxcalib,best_calib = best_calib)
-    if(done){
+  if (file.exists(calib_file)) file.remove(calib_file)
+  for (i in 1:n_maxcalib) {
+    cat(paste("\nStarting yield calibration iteration", i, "\n"))
+    calibration_run(putfolder = putfolder, calib_magpie_name = calib_magpie_name, logoption = logoption)
+    if (debug) file.copy(paste0(putfolder, "/fulldata.gdx"), paste0("fulldata_calib", i, ".gdx"))
+    done <- update_calib(gdx_file = paste0(putfolder, "/fulldata.gdx"), calib_accuracy = calib_accuracy,
+                         calibrate_pasture = calibrate_pasture, calibrate_cropland = calibrate_cropland,
+                         crop_max = crop_max, damping_factor = damping_factor, calib_file = calib_file,
+                         calibration_step = i, n_maxcalib = n_maxcalib, best_calib = best_calib)
+    if (done) {
       break
     }
   }
 
   # delete calib_magpie_gms in the main folder
-  unlink(paste0(calib_magpie_name,".*"))
+  unlink(paste0(calib_magpie_name, ".*"))
   unlink("fulldata.gdx")
 
   cat("\nYield calibration finished\n")

--- a/scripts/start/extra/recalibrate.R
+++ b/scripts/start/extra/recalibrate.R
@@ -23,5 +23,6 @@ cfg$recalibrate_landconversion_cost <- "ifneeded"
 cfg$title <- "calib_run"
 cfg$output <- c("rds_report","validation_short")
 cfg$force_replace <- TRUE
+cfg$best_calib <- TRUE
 start_run(cfg,codeCheck=FALSE)
 magpie4::submitCalibration("H12")

--- a/scripts/start/extra/recalibrate_realizations.R
+++ b/scripts/start/extra/recalibrate_realizations.R
@@ -33,11 +33,8 @@ cfg$gms$c_timesteps <- "calib"
 for (r in realizations) {
   cfg$gms$factor_costs <- r
 
-  if (r == "sticky_feb18") {
-    cfg$best_calib <- TRUE
-  } else {
-    cfg$best_calib <- FALSE
-  }
+  cfg$best_calib <- TRUE
+
 
   for (fac_req in c("reg", "glo")) {
     cfg$gms$c38_fac_req <- fac_req


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- In this pull request the calc_calib.R was fixed to ensure that the reported calib_factors reported correspond to the divergence of the iteration, and to select the factors, per region, that correspond to the lowest divergence.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

 **Comparison between old best_calib with the PR's best_calib (tag=Test2)**
1. Sticky- Improvement ( runs without land-conversion costs calibration)

![image](https://user-images.githubusercontent.com/55435245/216035288-cd530f6b-202b-4523-8a5d-417c48c2fecb.png)
   
2.  PerTon- Improvement ( runs without land-conversion costs calibration)
   
![image](https://user-images.githubusercontent.com/55435245/216035157-820276a9-ddd6-4afe-9a66-fd4c6636f209.png)


### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
