### PR TITLE
DEPENDENCIES -> DESCRIPTION because of renv snapshot logic

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -14,17 +14,9 @@ if (!"https://rse.pik-potsdam.de/r/packages" %in% getOption("repos")) {
 
 # bootstrapping, will only run once after this repo is freshly cloned
 if (isTRUE(rownames(installed.packages(priority = "NA")) == "renv")) {
-  if (file.exists("DESCRIPTION") && !identical(readLines("DESCRIPTION"), readLines("DEPENDENCIES"))) {
-    warning("Unexpected DESCRIPTION file found, try removing it. Will not install dependencies.")
-  } else {
-    message("R package dependencies are not installed in this renv, installing now...")
-    renv::install("yaml", prompt = FALSE) # yaml is required to find dependencies in Rmd files
-    # renv will only consider a file called DESCRIPTION, so rename DEPENDENCIES
-    file.copy("DEPENDENCIES", "DESCRIPTION")
-    renv::hydrate() # auto-detect and install all dependencies
-    file.remove("DESCRIPTION")
-    message("Finished installing R package dependencies.")
-  }
+  message("R package dependencies are not installed in this renv, installing now...")
+  renv::hydrate() # auto-detect and install all dependencies
+  message("Finished installing R package dependencies.")
 }
 
 # source global .Rprofile (very important to load user specific settings)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,7 @@
 Package: magpiemodel
+Description: Refer to README.md for a description of the MAgPIE model.
+    This file only lists dependencies and is called DESCRIPTION for
+    technical reasons.
 Imports:
     callr,
     citation,
@@ -36,3 +39,4 @@ Imports:
 Suggests:
     goxygen,
     qgraph
+Encoding: UTF-8


### PR DESCRIPTION
## :bird: Description of this PR :bird:

When creating a renv.lock file (via `renv::snapshot`) renv only records versions of packages that "really are dependencies". To determine this renv crawls all R files and reads a file called DESCRIPTION, that's why this PR renames our DEPENDENCIES file to DESCRIPTION.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
