### PR TITLE
bugfix pasture suitabilty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### fixed
 - **56_ghg_policy** the renamed switch `c56_mute_ghgprices_until` is now always used for coupled as well as standalone runs. 
+- **31_past** fixed pasture suitability to SSP2 before and including 2020 (only relevant for grassland implementation)
 
 
 ## [4.6.4] - 2023-02-22

--- a/modules/31_past/endo_jun13/not_used.txt
+++ b/modules/31_past/endo_jun13/not_used.txt
@@ -2,3 +2,4 @@ name,type,reason
 pcm_land, input, not needed
 vm_tau,input,questionnaire
 fm_pastr_tau_hist,input,questionnaire
+sm_fix_SSP2, input, not needed

--- a/modules/31_past/grasslands_apr22/preloop.gms
+++ b/modules/31_past/grasslands_apr22/preloop.gms
@@ -6,6 +6,7 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 i31_manpast_suit(t_all,j) = f31_pastr_suitability(t_all,j,"%c31_past_suit_scen%");
+i31_manpast_suit(t_all,j)$(m_year(t_all) <= sm_fix_SSP2) = f31_pastr_suitability(t_all,j,"ssp245");
 pc31_grass(j,grassland) = f31_LUH2v2("y1995",j,grassland);
 
 

--- a/modules/31_past/static/not_used.txt
+++ b/modules/31_past/static/not_used.txt
@@ -4,3 +4,4 @@ vm_yld, input, not needed
 pm_land_conservation,input,questionnaire
 vm_tau,input,questionnaire
 fm_pastr_tau_hist,input,questionnaire
+sm_fix_SSP2, input, not needed


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- Numbers in f31_pastr_suitability.cs3 differ before 2020 for different scenarios, which results in different model outcomes for the historic perid. This PR fixes this problem by setting values to SSP2 defaults before and including 2020.
- **31_past** fixed pasture suitability to SSP2 before and including 2020 (only relevant for grassland implementation)

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [ ] RSE review done (at least 1)
