### PR TITLE
add cluster_resolution output script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### added
 - **56_ghg_policy** added switch `s56_minimum_cprice`
 - **config** minimum CO2 price (`s56_minimum_cprice`) of 5 USD per tCO2 (18 USD per tC) for all future time steps in case of NDC policy to guide land-use decisions
+- **scripts** added cluster_resolution output script which writes landuse data on cluster resolution to a shapefile
 
 ### removed
 - **56_ghg_policy** removed `s56_ghgprice_phase_in` and `s56_ghgprice_start`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### added
 - **56_ghg_policy** added switch `s56_minimum_cprice`
 - **config** minimum CO2 price (`s56_minimum_cprice`) of 5 USD per tCO2 (18 USD per tC) for all future time steps in case of NDC policy to guide land-use decisions
-- **scripts** added cluster_resolution output script which writes landuse data on cluster resolution to a shapefile
+- **scripts** added output script which writes landuse data on cluster resolution to a shapefile
 
 ### removed
 - **56_ghg_policy** removed `s56_ghgprice_phase_in` and `s56_ghgprice_start`

--- a/scripts/output/extra/cluster_resolution.R
+++ b/scripts/output/extra/cluster_resolution.R
@@ -1,0 +1,50 @@
+# |  (C) 2008-2023 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+# |  Contact: magpie@pik-potsdam.de
+
+# --------------------------------------------------------------
+# description: Write land use information on cluster level to a shapefile
+# comparison script: FALSE
+# ---------------------------------------------------------------
+
+if (!exists("source_include")) {
+  outputdir <- Sys.glob("output/*")[[1]]
+  lucode2::readArgs("outputdir")
+}
+
+landUse <- magpie4::land(file.path(outputdir, "fulldata.gdx"),
+                         dir = outputdir,
+                         level = "cell")
+stopifnot(identical(names(dimnames(landUse)), c("j.region", "t", "land")))
+
+clustermap <- Sys.glob(file.path(outputdir, "clustermap_*.rds"))
+if (length(clustermap) == 0) {
+  stop("no clustermap file found")
+} else if (length(clustermap) > 1) {
+  warning("found multiple clustermaps, using ", clustermap[[1]])
+  clustermap <- clustermap[[1]]
+}
+clustermap <- readRDS(clustermap)
+
+cells <- magclass::getCells(landUse)
+clusterMagclass <- magclass::new.magpie(cells, names = "clusterId", fill = seq_along(cells))
+clusterMagclass <- madrat::toolAggregate(clusterMagclass, clustermap, from = "cluster", to = "cell")
+
+clusterPolygons <- terra::as.polygons(magclass::as.SpatRaster(clusterMagclass))
+clusterPolygons <- terra::merge(clusterPolygons, magclass::as.data.frame(landUse, rev = 3),
+                                by.x = "clusterId", by.y = "region")
+names(clusterPolygons) <- c("clusterId", "region", "year", "landtype", "value")
+
+clusterIdToCountry <- clustermap$country
+names(clusterIdToCountry) <- as.integer(sub("^[A-Z]{3}\\.", "", clustermap$cluster))
+clusterPolygons$country <- clusterIdToCountry[clusterPolygons$clusterId]
+clusterPolygons <- clusterPolygons[, c("clusterId", "country", "region", "year", "landtype", "value")]
+
+terra::crs(clusterPolygons) <- "+proj=longlat +datum=WGS84 +no_defs"
+
+outfile <- file.path(outputdir, "cluster_resolution.shp")
+message("Writing ", outfile)
+terra::writeVector(clusterPolygons, outfile, overwrite = TRUE)


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- add cluster_resolution output extra script that writes shapefile with landuse data on cluster resolution to be used as basis for downscaling

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [x] RSE review done (at least 1)
