### PR TITLE
max calib factor divergence to max divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **56_ghg_policy** renamed `cfg$mute_ghgprices_until` to `cfg$gms$c56_mute_ghgprices_until` and changed the default to `y2030`, i.e. no GHG emission pricing in the AFOLU sector before (and including) 2030. This setting will be also used in coupled REMIND-MAgPIE runs.
 - **scripts** Disaggregation of land use to 0.5° now takes land conservation into account - i.e. cropland expansion is not mapped to areas that are subject to land conservation
 - **scripts** Disaggregation of BII merged into standard extra/disaggregation.R
+- **scripts** calc_calib.R bug fix. If the calibration factor of a region is equal to the maximum allowed value, its divergence is set the maximum allowed divergence.
 
 ### added
 - **56_ghg_policy** added switch `s56_minimum_cprice`

--- a/scripts/calibration/calc_calib.R
+++ b/scripts/calibration/calc_calib.R
@@ -94,7 +94,7 @@ update_calib <- function(gdx_file, calib_accuracy = 0.1, calibrate_pasture = TRU
   if (!is.null(crop_max)) {
     above_limit <- (calib_factor[, , "crop"] > crop_max)
     calib_factor[, , "crop"][above_limit]  <- crop_max
-    calib_divergence[getCells(calib_factor), , "crop"][above_limit] <- NA
+    calib_divergence[getCells(calib_factor), , "crop"][above_limit] <- calib_accuracy
   }
   if (!calibrate_pasture) {
     calib_factor[, , "past"] <- 1
@@ -162,8 +162,12 @@ update_calib <- function(gdx_file, calib_accuracy = 0.1, calibrate_pasture = TRU
       write_log(calib_best,     "calib_factor.cs3", "best")
       write_log(calib_best_div, "calib_divergence.cs3", "best")
       ####
+      if (any(calib_best) == crop_max) message("Note: A region or a few regions have a calibration factor equal to the maximum possible.
+      Check for possible reasons/inconsistencies.")
       return(TRUE)
     } else {
+      if (any(calib_factor) == crop_max) message("Note: A region or a few regions have a calibration factor equal to the maximum possible.
+      Check for possible reasons/inconsistencies.")
       return(TRUE)
     }
   } else {


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- In this PR, when a calibration factor has a value equal to the maximum, its divergence is set to the maximum allowed value. Before, it was set to NA, which generated issues. Also, this is done to avoid additional unnecessary iterations.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
