### PR TITLE
on.exit -> withr::defer

### DIFF
--- a/scripts/insertheader/insertheader.R
+++ b/scripts/insertheader/insertheader.R
@@ -34,7 +34,7 @@ insertheader <- function(maindir=".",
   }
 
   cwd <- getwd()
-  on.exit(setwd(cwd))
+  withr::defer(setwd(cwd))
   setwd(maindir)
 
   if(is.null(oldkey)) oldkey <- key

--- a/scripts/insertheader/insertheader.R
+++ b/scripts/insertheader/insertheader.R
@@ -33,9 +33,7 @@ insertheader <- function(maindir=".",
     return(gsub(".*(\\..*)","\\1",basename(file)))
   }
 
-  cwd <- getwd()
-  withr::defer(setwd(cwd))
-  setwd(maindir)
+  withr::local_dir(maindir)
 
   if(is.null(oldkey)) oldkey <- key
 

--- a/scripts/output/extra/disaggregation.R
+++ b/scripts/output/extra/disaggregation.R
@@ -38,9 +38,7 @@ bii_hr_out_file <- file.path(outputdir, "cell.bii_0.5.mz")
 
 cfg <- gms::loadConfig(file.path(outputdir, "config.yml"))
 
-sizelimit <- getOption("magclass_sizeLimit")
-options(magclass_sizeLimit = 1e+12)
-on.exit(options(magclass_sizeLimit = sizelimit))
+withr::local_options(list(magclass_sizeLimit = 1e+12))
 
 if (length(map_file) == 0) stop("Could not find map file!")
 if (length(map_file) > 1) {

--- a/scripts/output/extra/disaggregation_LUH2.R
+++ b/scripts/output/extra/disaggregation_LUH2.R
@@ -59,9 +59,7 @@ convertLUH2 <- function(x) {
 
 }
 
-sizelimit <- getOption("magclass_sizeLimit")
-options(magclass_sizeLimit = 1e+12)
-on.exit(options(magclass_sizeLimit = sizelimit))
+withr::local_options(list(magclass_sizeLimit = 1e+12))
 
 
 #### Spatial mapping

--- a/scripts/output/extra/emulator.R
+++ b/scripts/output/extra/emulator.R
@@ -33,7 +33,7 @@ collect_data_and_make_emulator <- function(outputdir,name_of_fit="linear") {
 
   # lock the model (other emulaotr scripts have to wait until this one finished)
   lock_id <- gms::model_lock(file=".lockemu")
-  on.exit(gms::model_unlock(lock_id,file=".lockemu"))
+  withr::defer(gms::model_unlock(lock_id,file=".lockemu"))
 
   results_path <- "output"
 

--- a/scripts/output/projects/inms_reporting_reg.R
+++ b/scripts/output/projects/inms_reporting_reg.R
@@ -35,7 +35,7 @@ if(!exists("source_include")) {
 print(paste0("script started for output directory",outputdir))
 
 wdbefore=getwd()
-on.exit(setwd(wdbefore))
+withr::defer(setwd(wdbefore))
 setwd(outputdir)
 
 cfg <- gms::loadConfig("config.yml")

--- a/scripts/output/projects/inms_reporting_reg.R
+++ b/scripts/output/projects/inms_reporting_reg.R
@@ -34,9 +34,7 @@ if(!exists("source_include")) {
 
 print(paste0("script started for output directory",outputdir))
 
-wdbefore=getwd()
-withr::defer(setwd(wdbefore))
-setwd(outputdir)
+withr::local_dir(outputdir)
 
 cfg <- gms::loadConfig("config.yml")
 title <- cfg$title

--- a/scripts/performance_test.R
+++ b/scripts/performance_test.R
@@ -52,9 +52,7 @@ performance_start <- function(cfg="default.cfg",modulepath="modules/",id="perfor
 performance_collect <- function(id="performance",results_folder="output/",plot=TRUE) {
   require(magpie4)
   require(lucode2)
-  maindir <- getwd()
-  withr::defer(setwd(maindir))
-  setwd(results_folder)
+  withr::local_dir(results_folder)
   folders <- grep(paste("^",id,"__",sep=""),list.dirs(full.names = FALSE, recursive = FALSE),value=TRUE)
   tmp <- grep(paste("^",id,"__default",sep=""),folders)
   default <- folders[tmp]

--- a/scripts/performance_test.R
+++ b/scripts/performance_test.R
@@ -53,7 +53,7 @@ performance_collect <- function(id="performance",results_folder="output/",plot=T
   require(magpie4)
   require(lucode2)
   maindir <- getwd()
-  on.exit(setwd(maindir))
+  withr::defer(setwd(maindir))
   setwd(results_folder)
   folders <- grep(paste("^",id,"__",sep=""),list.dirs(full.names = FALSE, recursive = FALSE),value=TRUE)
   tmp <- grep(paste("^",id,"__default",sep=""),folders)

--- a/scripts/start/Rprofile.R
+++ b/scripts/start/Rprofile.R
@@ -30,12 +30,12 @@ setSnapshot <- function(snapshotdir=NULL) {
   
   if(is.null(snapshotdir)) {
     fc <- file(".Rprofile")
-    on.exit(close(fc))
+    withr::defer(close(fc))
     writeLines(c('if(file.exists("~/.Rprofile")) source("~/.Rprofile")'),
                fc)
   } else {
     fc <- file(".Rprofile")
-    on.exit(close(fc))
+    withr::defer(close(fc))
     writeLines(c('if(file.exists("~/.Rprofile")) source("~/.Rprofile")',
                  paste0('.libPaths(',deparse(snapshotdir),')'),
                  paste0('print("Setting libPaths to ',snapshotdir,'")')),

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -227,11 +227,11 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
 
   Sys.setlocale(locale="C")
   maindir <- getwd()
-  on.exit(setwd(maindir))
+  withr::defer(setwd(maindir))
 
   if(lock_model) {
     lock_id <- gms::model_lock(timeout1=1)
-    on.exit(gms::model_unlock(lock_id), add=TRUE)
+    withr::defer(gms::model_unlock(lock_id))
   }
 
   # Apply scenario settings ans check configuration file for consistency
@@ -481,7 +481,7 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
   gms::singleGAMSfile(mainfile=cfg$model, output=file.path(cfg$results_folder, "full.gms"))
   if(lock_model) {
     gms::model_unlock(lock_id)
-    on.exit(setwd(maindir))
+    withr::defer(setwd(maindir))
   }
 
   setwd(cfg$results_folder)


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- replace `on.exit` with `withr::defer`
on.exit can break `withr` functionality or other `on.exit` calls by always overwriting the function that is executed on exit unless `add=TRUE` is passed, so `withr::defer` is much safer.
This might be the reason why models were not unlocked - the unlock was supposed to happen in an on.exit that was overwritten.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
