### PR TITLE
Made NPI and NDC calculatiosn ready for 67k cells and removed reference to semantic versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$model <- "main.gms"   #def = "main.gms"
 cfg$input <- c(regional    = "rev4.84_h12_magpie.tgz",
                cellular    = "rev4.84_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.84_h12_validation.tgz",
-               additional  = "additional_data_rev4.39.tgz",
+               additional  = "additional_data_rev4.43.tgz",
                calibration = "calibration_H12_per_ton_fao_may22_glo_23Mar23.tgz")
 
 # NOTE: It is recommended to recalibrate the model when changing cellular input data

--- a/scripts/npi_ndc/start_npi_ndc.R
+++ b/scripts/npi_ndc/start_npi_ndc.R
@@ -56,6 +56,7 @@ calc_NPI_NDC <- function(policyregions = "iso",
       map_file <- grep("67420", map_file, value = TRUE, invert = TRUE)
     }
   }
+  stopfinot(lenght(map_file) == 1)
 
   forest_stock <- dimSums(land_stock[,,c("primforest","secdforest","forestry")], dim=3)
   getNames(forest_stock) <- "forest"

--- a/scripts/npi_ndc/start_npi_ndc.R
+++ b/scripts/npi_ndc/start_npi_ndc.R
@@ -32,7 +32,9 @@ calc_NPI_NDC <- function(policyregions = "iso",
   #read in cellular land cover (stock) from landuse initialization
   land_stock <- read.magpie(land_stock_file)
   
-  # update spatial names
+  # use pol_mapping to update spatial mapping of cells to regions
+  # so that not only countries can be used for policies but also smaller
+  # units such as provinces 
   if(dim(land_stock)[1] == 59199) { # 59199 cells
     if(dim(pol_mapping)[1] > 59199) {
       pol_mapping <- pol_mapping[order(pol_mapping$cell),]

--- a/scripts/npi_ndc/start_npi_ndc.R
+++ b/scripts/npi_ndc/start_npi_ndc.R
@@ -301,13 +301,14 @@ calc_policy <- function(policy, stock, pol_type="aff", pol_mapping=pol_mapping,
   }
 
   #calculate the reduction target in absolute numbers
-  rel <- data.frame(from=pol_mapping$policyregions,to=paste(pol_mapping$iso,1:dim(pol_mapping)[1],sep="."), stringsAsFactors = FALSE)
   if(dim(pol_mapping)[1] == 59199) {
-    rel <- data.frame(from=pol_mapping$policyregions,to=paste(pol_mapping$iso,1:59199,sep="."), stringsAsFactors = FALSE)
+    rel <- data.frame(from=pol_mapping$policyregions,to=paste(pol_mapping$policyregions,1:59199,sep="."), stringsAsFactors = FALSE)
+    countryCell <- paste(pol_mapping$iso,1:59199,sep=".")
   } else {
     lon <- sub(".", "p", pol_mapping$lon, fixed = TRUE)
     lat <- sub(".", "p", pol_mapping$lat, fixed = TRUE)
-    rel <- data.frame(from=pol_mapping$policyregions,to=paste(lon, lat, pol_mapping$iso,sep="."), stringsAsFactors = FALSE)
+    rel <- data.frame(from=pol_mapping$policyregions,to=paste(lon, lat, pol_mapping$policyregions,sep="."), stringsAsFactors = FALSE)
+    countryCell <- paste(lon, lat, pol_mapping$iso,sep=".")
   }
   if(pol_type=="aff") {
     magpie_policy <- madrat::toolAggregate(x=magpie_policy, rel=rel, weight=weight)
@@ -318,6 +319,7 @@ calc_policy <- function(policy, stock, pol_type="aff", pol_mapping=pol_mapping,
   }
 
   map <- readRDS(map_file)
+  getItems(magpie_policy, dim = 1, raw = TRUE) <- map$cell
   magpie_policy <- madrat::toolAggregate(magpie_policy,map)
 
   return(magpie_policy)

--- a/scripts/npi_ndc/start_npi_ndc.R
+++ b/scripts/npi_ndc/start_npi_ndc.R
@@ -35,7 +35,8 @@ calc_NPI_NDC <- function(policyregions = "iso",
   # update spatial names
   if(dim(land_stock)[1] == 59199) { # 59199 cells
     if(dim(pol_mapping)[1] > 59199) {
-      pol_mapping <- pol_mapping[order(pol_mapping$cell),][!is.na(pol_mapping$cell),]
+      pol_mapping <- pol_mapping[order(pol_mapping$cell),]
+      pol_mapping <- pol_mapping[!is.na(pol_mapping$cell),]
     }
     getItems(land_stock, dim = 1, raw = TRUE) <- paste(pol_mapping$policyregions,1:59199,sep=".")
   } else {

--- a/scripts/npi_ndc/start_npi_ndc.R
+++ b/scripts/npi_ndc/start_npi_ndc.R
@@ -44,6 +44,15 @@ calc_NPI_NDC <- function(policyregions = "iso",
    m <- merge(coords, pol_mapping, sort =FALSE)
    getItems(land_stock, dim = "iso") <- m$policyregions
   }
+  
+  # select map_file if more than one has been found
+  if(length(map_file) > 1) {
+    if(dim(land_stock)[1] == 67420) {
+      map_file <- grep("67420", map_file, value = TRUE)
+    } else {
+      map_file <- grep("67420", map_file, value = TRUE, invert = TRUE)
+    }
+  }
 
   forest_stock <- dimSums(land_stock[,,c("primforest","secdforest","forestry")], dim=3)
   getNames(forest_stock) <- "forest"


### PR DESCRIPTION

## :bird: Description of this PR :bird:

This PR contains two components:

1. small fix in CHANGELOG description as we do not follow all rules required to call it semantic versioning, what we are doing.
2. update of the NPI/NDC script so that it can handle now 59k and 67k cells inputs (for that a newer revision of additional_data is required in addition to the changes in the script)

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
The changes do not affect the runtime as the computed NPI/NDC policy files `npi_ndc_aff_pol.cs3 
`  and  `npi_ndc_ad_aolc_pol.cs3` remain unchanged (verified in a test run).

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [x] RSE review done (at least 1)
