### PR TITLE
show renv snapshot errors

### DIFF
--- a/output.R
+++ b/output.R
@@ -197,8 +197,8 @@ runOutputs <- function(comp=NULL, output=NULL, outputdir=NULL, submit=NULL) {
     freshLockfile <- withr::local_tempfile()
 
     message("Generating lockfile... ", appendLF = FALSE)
-    utils::capture.output({
-      errorMessage <- utils::capture.output({
+    errorMessage1 <- utils::capture.output({
+      errorMessage2 <- utils::capture.output({
         snapshotSuccess <- tryCatch({
           renv::snapshot(lockfile = freshLockfile, prompt = FALSE)
           TRUE
@@ -206,7 +206,7 @@ runOutputs <- function(comp=NULL, output=NULL, outputdir=NULL, submit=NULL) {
       }, type = "message")
     })
     if (!snapshotSuccess) {
-      stop(paste(errorMessage, collapse = "\n"))
+      stop(paste(errorMessage1, collapse = "\n"), paste(errorMessage2, collapse = "\n"))
     }
     message("done.")
 

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -280,8 +280,8 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
       # the main renv is loaded
       message("Generating lockfile in '", cfg$results_folder, "'... ", appendLF = FALSE)
       # suppress output of renv::snapshot
-      utils::capture.output({
-        errorMessage <- utils::capture.output({
+      errorMessage1 <- utils::capture.output({
+        errorMessage2 <- utils::capture.output({
           snapshotSuccess <- tryCatch({
             # snapshot current main renv into run folder
             renv::snapshot(lockfile = file.path(cfg$results_folder, "_renv.lock"), prompt = FALSE)
@@ -290,7 +290,7 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
         }, type = "message")
       })
       if (!snapshotSuccess) {
-        stop(paste(errorMessage, collapse = "\n"))
+        stop(paste(errorMessage1, collapse = "\n"), paste(errorMessage2, collapse = "\n"))
       }
       message("done.")
     } else {


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- an error during renv::snapshot was not shown, this PR should fix that

## :wrench: Checklist for PR creator :wrench:

- [ ] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
