### PR TITLE
re-introduced solprint when solverstat is 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### changed
+- **80_optimization** printing of solprint when solver status is 7 re-activated 
 - **scripts** start_functions.R can now handle clusters per region flexibly
 - **scripts** the REMIND-MAgPIE coupling now uses renv
 - **41_area_equipped_for_irrigation** new AEI data (Mehta2022) replacing old Siebert data

--- a/modules/80_optimization/lp_nlp_apr17/solve.gms
+++ b/modules/80_optimization/lp_nlp_apr17/solve.gms
@@ -72,7 +72,7 @@ $batinclude "./modules/include.gms" nl_fix
 *' of the previous optimization as upper bound and minimizing the land
 *' differences.
 
-    if((magpie.modelstat=1 or magpie.modelstat = 7),
+    if ((magpie.modelstat=1 or magpie.modelstat = 7),
       vm_cost_glo.up = vm_cost_glo.l;
       solve magpie USING nlp MINIMIZING vm_landdiff;
       vm_cost_glo.up = Inf;
@@ -148,7 +148,7 @@ $batinclude "./modules/include.gms" nl_relax
     );
 
 * if solve stopped with an error, try it again with conopt3
-  if((magpie.modelstat = 13),
+  if ((magpie.modelstat = 13),
     display "WARNING: Modelstat 13 | retry with CONOPT3!";
     option nlp = conopt;
     solve magpie USING nlp MINIMIZING vm_cost_glo;
@@ -198,7 +198,7 @@ if ((p80_modelstat(t) < 3),
   put_utility 'shell' / 'mv -f magpie_p.gdx magpie_' t.tl:0'.gdx';
 );
 
-if ((p80_modelstat(t) > 2),
+if ((p80_modelstat(t) > 2 and p80_modelstat(t) ne 7),
   Execute_Unload "fulldata.gdx";
   abort "no feasible solution found!";
 );

--- a/modules/80_optimization/lp_nlp_apr17/solve.gms
+++ b/modules/80_optimization/lp_nlp_apr17/solve.gms
@@ -165,7 +165,7 @@ $batinclude "./modules/include.gms" nl_relax
 
 
 * write extended run information in list file in the case that the final solution is infeasible
-  if((s80_counter >= s80_maxiter and p80_modelstat(t) > 2 and p80_modelstat(t) ne 7),
+  if ((s80_counter >= s80_maxiter and p80_modelstat(t) > 2 and p80_modelstat(t)),
     magpie.solprint = 1
   );
 
@@ -198,7 +198,7 @@ if ((p80_modelstat(t) < 3),
   put_utility 'shell' / 'mv -f magpie_p.gdx magpie_' t.tl:0'.gdx';
 );
 
-if ((p80_modelstat(t) > 2 and p80_modelstat(t) ne 7),
+if ((p80_modelstat(t) > 2 and p80_modelstat(t)),
   Execute_Unload "fulldata.gdx";
   abort "no feasible solution found!";
 );

--- a/modules/80_optimization/lp_nlp_apr17/solve.gms
+++ b/modules/80_optimization/lp_nlp_apr17/solve.gms
@@ -165,7 +165,7 @@ $batinclude "./modules/include.gms" nl_relax
 
 
 * write extended run information in list file in the case that the final solution is infeasible
-  if ((s80_counter >= s80_maxiter and p80_modelstat(t) > 2 and p80_modelstat(t)),
+  if ((s80_counter >= s80_maxiter and p80_modelstat(t) > 2),
     magpie.solprint = 1
   );
 

--- a/modules/80_optimization/lp_nlp_apr17/solve.gms
+++ b/modules/80_optimization/lp_nlp_apr17/solve.gms
@@ -198,7 +198,7 @@ if ((p80_modelstat(t) < 3),
   put_utility 'shell' / 'mv -f magpie_p.gdx magpie_' t.tl:0'.gdx';
 );
 
-if ((p80_modelstat(t) > 2 and p80_modelstat(t)),
+if ((p80_modelstat(t) > 2),
   Execute_Unload "fulldata.gdx";
   abort "no feasible solution found!";
 );

--- a/modules/80_optimization/nlp_apr17/solve.gms
+++ b/modules/80_optimization/nlp_apr17/solve.gms
@@ -91,7 +91,7 @@ if ((p80_modelstat(t) <= 2),
   put_utility 'shell' / 'mv -f magpie_p.gdx magpie_' t.tl:0'.gdx';
 );
 
-if ((p80_modelstat(t) > 2 and p80_modelstat(t)),
+if ((p80_modelstat(t) > 2),
   Execute_Unload "fulldata.gdx";
   abort "no feasible solution found!";
 );

--- a/modules/80_optimization/nlp_apr17/solve.gms
+++ b/modules/80_optimization/nlp_apr17/solve.gms
@@ -73,7 +73,7 @@ if(magpie.modelstat > 2 OR magpie.numNOpt > s80_num_nonopt_allowed,
   display vm_cost_glo.l;
 
 * write extended run information in list file in the case that the final solution is infeasible
-  if((s80_counter >= (s80_maxiter-1) and magpie.modelstat > 2 and magpie.modelstat),
+  if((s80_counter >= (s80_maxiter-1) and magpie.modelstat > 2),
     magpie.solprint = 1
   );
 

--- a/modules/80_optimization/nlp_apr17/solve.gms
+++ b/modules/80_optimization/nlp_apr17/solve.gms
@@ -49,7 +49,7 @@ if (magpie.modelstat > 2 OR magpie.numNOpt > s80_num_nonopt_allowed,
   repeat(
     s80_counter = s80_counter + 1 ;
 
-  if(magpie.modelstat ne s80_modelstat_previter,
+  if (magpie.modelstat ne s80_modelstat_previter,
     display "Modelstat > 2 | Retry solve with CONOPT4 default setting";
     solve magpie USING nlp MINIMIZING vm_cost_glo ;
   elseif magpie.modelstat = s80_modelstat_previter,
@@ -73,7 +73,7 @@ if (magpie.modelstat > 2 OR magpie.numNOpt > s80_num_nonopt_allowed,
   display vm_cost_glo.l;
 
 * write extended run information in list file in the case that the final solution is infeasible
-  if((s80_counter >= (s80_maxiter-1) and magpie.modelstat > 2),
+  if ((s80_counter >= (s80_maxiter-1) and magpie.modelstat > 2),
     magpie.solprint = 1
   );
 
@@ -91,7 +91,7 @@ if ((p80_modelstat(t) <= 2),
   put_utility 'shell' / 'mv -f magpie_p.gdx magpie_' t.tl:0'.gdx';
 );
 
-if ((p80_modelstat(t) > 2 and p80_modelstat(t) ne 7)
+if ((p80_modelstat(t) > 2 and p80_modelstat(t) ne 7),
   Execute_Unload "fulldata.gdx";
   abort "no feasible solution found!";
 );

--- a/modules/80_optimization/nlp_apr17/solve.gms
+++ b/modules/80_optimization/nlp_apr17/solve.gms
@@ -45,7 +45,7 @@ display vm_cost_glo.l;
 display magpie.modelstat;
 
 * in case of problems try different solvers and optfile settings
-if(magpie.modelstat > 2 OR magpie.numNOpt > s80_num_nonopt_allowed,
+if (magpie.modelstat > 2 OR magpie.numNOpt > s80_num_nonopt_allowed,
   repeat(
     s80_counter = s80_counter + 1 ;
 
@@ -91,7 +91,7 @@ if ((p80_modelstat(t) <= 2),
   put_utility 'shell' / 'mv -f magpie_p.gdx magpie_' t.tl:0'.gdx';
 );
 
-if ((p80_modelstat(t) > 2),
+if ((p80_modelstat(t) > 2 and p80_modelstat(t) ne 7)
   Execute_Unload "fulldata.gdx";
   abort "no feasible solution found!";
 );

--- a/modules/80_optimization/nlp_apr17/solve.gms
+++ b/modules/80_optimization/nlp_apr17/solve.gms
@@ -73,7 +73,7 @@ if(magpie.modelstat > 2 OR magpie.numNOpt > s80_num_nonopt_allowed,
   display vm_cost_glo.l;
 
 * write extended run information in list file in the case that the final solution is infeasible
-  if((s80_counter >= (s80_maxiter-1) and magpie.modelstat > 2 and magpie.modelstat ne 7),
+  if((s80_counter >= (s80_maxiter-1) and magpie.modelstat > 2 and magpie.modelstat),
     magpie.solprint = 1
   );
 
@@ -91,7 +91,7 @@ if ((p80_modelstat(t) <= 2),
   put_utility 'shell' / 'mv -f magpie_p.gdx magpie_' t.tl:0'.gdx';
 );
 
-if ((p80_modelstat(t) > 2 and p80_modelstat(t) ne 7),
+if ((p80_modelstat(t) > 2 and p80_modelstat(t)),
   Execute_Unload "fulldata.gdx";
   abort "no feasible solution found!";
 );

--- a/modules/80_optimization/nlp_par/solve.gms
+++ b/modules/80_optimization/nlp_par/solve.gms
@@ -69,7 +69,7 @@ repeat
         display s80_counter;
         display magpie.modelStat;
 
-      if((p80_counter(h) >= s80_maxiter AND p80_modelstat(t,h) > 2 AND p80_modelstat(t,h)),
+      if((p80_counter(h) >= s80_maxiter AND p80_modelstat(t,h) > 2),
           display "No feasible solution found. Writing LST file.";
           option AsyncSolLst=1;
           display$handlecollect(p80_handle(h)) 're-collect';

--- a/modules/80_optimization/nlp_par/solve.gms
+++ b/modules/80_optimization/nlp_par/solve.gms
@@ -117,7 +117,7 @@ repeat
   display$readyCollect(p80_handle,INF) 'Problem waiting for next instance to complete';
 until card(p80_handle) = 0 OR smax(h, p80_counter(h)) >= s80_maxiter;
 
-if (smax(h,p80_modelstat(t,h)) > 2),
+if (smax(h,p80_modelstat(t,h)) > 2,
     Execute_Unload "fulldata.gdx";
     abort "No feasible solution found!";
 );

--- a/modules/80_optimization/nlp_par/solve.gms
+++ b/modules/80_optimization/nlp_par/solve.gms
@@ -69,7 +69,7 @@ repeat
         display s80_counter;
         display magpie.modelStat;
 
-      if((p80_counter(h) >= s80_maxiter AND p80_modelstat(t,h) > 2 AND p80_modelstat(t,h) ne 7),
+      if((p80_counter(h) >= s80_maxiter AND p80_modelstat(t,h) > 2 AND p80_modelstat(t,h)),
           display "No feasible solution found. Writing LST file.";
           option AsyncSolLst=1;
           display$handlecollect(p80_handle(h)) 're-collect';
@@ -117,7 +117,7 @@ repeat
   display$readyCollect(p80_handle,INF) 'Problem waiting for next instance to complete';
 until card(p80_handle) = 0 OR smax(h, p80_counter(h)) >= s80_maxiter;
 
-if (smax(h,p80_modelstat(t,h)) > 2 and smax(h,p80_modelstat(t,h)) ne 7,
+if (smax(h,p80_modelstat(t,h)) > 2 and smax(h,p80_modelstat(t,h)),
     Execute_Unload "fulldata.gdx";
     abort "No feasible solution found!";
 );

--- a/modules/80_optimization/nlp_par/solve.gms
+++ b/modules/80_optimization/nlp_par/solve.gms
@@ -117,7 +117,7 @@ repeat
   display$readyCollect(p80_handle,INF) 'Problem waiting for next instance to complete';
 until card(p80_handle) = 0 OR smax(h, p80_counter(h)) >= s80_maxiter;
 
-if (smax(h,p80_modelstat(t,h)) > 2 and smax(h,p80_modelstat(t,h)),
+if (smax(h,p80_modelstat(t,h)) > 2),
     Execute_Unload "fulldata.gdx";
     abort "No feasible solution found!";
 );

--- a/modules/80_optimization/nlp_par/solve.gms
+++ b/modules/80_optimization/nlp_par/solve.gms
@@ -69,7 +69,7 @@ repeat
         display s80_counter;
         display magpie.modelStat;
 
-      if((p80_counter(h) >= s80_maxiter AND p80_modelstat(t,h) > 2),
+      if ((p80_counter(h) >= s80_maxiter AND p80_modelstat(t,h) > 2),
           display "No feasible solution found. Writing LST file.";
           option AsyncSolLst=1;
           display$handlecollect(p80_handle(h)) 're-collect';
@@ -79,15 +79,15 @@ repeat
 
       display$handledelete(p80_handle(h)) 'trouble deleting handles' ;
 
-    if(p80_modelstat(t,h) <= 2 AND magpie.numNOpt <= s80_num_nonopt_allowed,
+    if (p80_modelstat(t,h) <= 2 AND magpie.numNOpt <= s80_num_nonopt_allowed,
         display "Model status <= 2. Handle cleared.";
         s80_resolve = 0;
         p80_handle(h) = 0;
       );
 
-    if(s80_resolve = 1,
+    if (s80_resolve = 1,
       display "Resolve"
-      if(p80_modelstat(t,h) ne s80_modelstat_previter,
+      if (p80_modelstat(t,h) ne s80_modelstat_previter,
               display "Modelstat > 2 | Retry solve with CONOPT4 default setting";
           solve magpie USING nlp MINIMIZING vm_cost_glo ;
         elseif p80_modelstat(t,h) = s80_modelstat_previter,
@@ -117,7 +117,7 @@ repeat
   display$readyCollect(p80_handle,INF) 'Problem waiting for next instance to complete';
 until card(p80_handle) = 0 OR smax(h, p80_counter(h)) >= s80_maxiter;
 
-if (smax(h,p80_modelstat(t,h)) > 2,
+if (smax(h,p80_modelstat(t,h)) > 2 and smax(h,p80_modelstat(t,h)) ne 7,
     Execute_Unload "fulldata.gdx";
     abort "No feasible solution found!";
 );


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- modelstat 7 means "Solver terminated early and model was feasible but not yet optimal". In this case, the solprint should be activated to be able to find in which equation the infeasibility occurred
- at modelstat 7, the full solprint is printed now

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
 
### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [ ] RSE review done (at least 1)
