### PR TITLE
 Bugfix: in the non-default realization of 30_crop, rotation_apr22, the fallow land term was on the wrong side of the equation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### changed
-- **30_crop** in the module realization rotation_apr22 there was a bug, fallow land was on the wrong side of the equation q30_cropland
 - **scripts** start_functions.R can now handle clusters per region flexibly
 - **scripts** the REMIND-MAgPIE coupling now uses renv
 - **41_area_equipped_for_irrigation** new AEI data (Mehta2022) replacing old Siebert data
@@ -23,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -
 
 ### fixed
+- **30_crop** corrected q30_cropland in module realization rotation_apr22, where fallow land was on the wrong side of the equation
 - **config** updated scenario configs to newest preprocessing (4.87)
 - **config** corrected wrong names of parameters for peatland costs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### changed
+- **30_crop** in the module realization rotation_apr22 there was a bug, fallow land was on the wrong side of the equation q30_cropland
 - **scripts** start_functions.R can now handle clusters per region flexibly
 - **scripts** the REMIND-MAgPIE coupling now uses renv
 - **41_area_equipped_for_irrigation** new AEI data (Mehta2022) replacing old Siebert data

--- a/modules/30_crop/penalty_apr22/equations.gms
+++ b/modules/30_crop/penalty_apr22/equations.gms
@@ -9,7 +9,7 @@
 *' The total land requirements for cropland are calculated as
 *' the sum of crop and water supply type specific land requirements.
 *' Fallow is no explicit landuse type, but the difference between
-*' land and harvested vm_area
+*' the land area for crops vm_land and the croparea vm_area
 
  q30_cropland(j2)  ..
    sum((kcr,w), vm_area(j2,kcr,w)) + vm_fallow(j2) =e= vm_land(j2,"crop");

--- a/modules/30_crop/penalty_apr22/equations.gms
+++ b/modules/30_crop/penalty_apr22/equations.gms
@@ -14,7 +14,6 @@
  q30_cropland(j2)  ..
    sum((kcr,w), vm_area(j2,kcr,w)) + vm_fallow(j2) =e= vm_land(j2,"crop");
 
-
 *' We assume that crop production can only take place on suitable cropland area.
 *' We use a suitability index (SI) map from @zabel_global_2014 to exclude areas
 *' from cropland production that have a low suitability, e.g. due to steep slopes,

--- a/modules/30_crop/rotation_apr22/equations.gms
+++ b/modules/30_crop/rotation_apr22/equations.gms
@@ -8,9 +8,11 @@
 *' @equations
 *' The total land requirements for cropland are calculated as
 *' the sum of crop and water supply type specific land requirements:
+*' Fallow is no explicit landuse type, but the difference between
+*' land and harvested vm_area
 
  q30_cropland(j2)  ..
-   sum((kcr,w), vm_area(j2,kcr,w)) =e= vm_land(j2,"crop") + vm_fallow(j2);
+   sum((kcr,w), vm_area(j2,kcr,w)) + vm_fallow(j2) =e= vm_land(j2,"crop");
 
 *' We assume that crop production can only take place on suitable cropland area.
 *' We use a suitability index (SI) map from @zabel_global_2014 to exclude areas

--- a/modules/30_crop/rotation_apr22/equations.gms
+++ b/modules/30_crop/rotation_apr22/equations.gms
@@ -9,7 +9,7 @@
 *' The total land requirements for cropland are calculated as
 *' the sum of crop and water supply type specific land requirements:
 *' Fallow is no explicit landuse type, but the difference between
-*' land and harvested vm_area
+*' the land area for crops vm_land and the croparea vm_area
 
  q30_cropland(j2)  ..
    sum((kcr,w), vm_area(j2,kcr,w)) + vm_fallow(j2) =e= vm_land(j2,"crop");


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- Bugfix: in the non-default realization of 30_crop, rotation_apr22, the fallow land term was on the wrong side of the equation.

## :wrench: Checklist for PR creator :wrench:

- [x ] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [ x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [ ] RSE review done (at least 1)
