### PR TITLE
results folder for highres runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **config** new area equipped for irrigation (AEI) data in preprocessing (4.87)
 - **31_past** added `cc`, `nocc` and `nocc_hist` options for `c31_past_suit_scen` and `c31_grassl_yld_scenario`
 - **32_carbon** added `nocc` and `nocc_hist` option for `c52_land_carbon_sink_rcp`
+- **config** added `cfg$results_folder_highres` which allows to modify the output folder used in the `highres.R` output script
 
 ### removed
 -

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -1876,6 +1876,12 @@ cfg$output <- c("output_check", "extra/disaggregation", "rds_report")
 # :title: is a placeholder for the current run title (cfg$title)
 cfg$results_folder <- "output/:title::date:"
 
+# Results folder used by the "highres.R" output script
+# If NULL, the default set in "highres.R" is used (currently a subfolder in "output")
+# To place highres runs directly in the "output" folder, change to "output"
+# To place highres runs in a specific subfolder change to "output/HR"
+cfg$results_folder_highres <- NULL
+
 # Which files should be copied into the output folder?
 cfg$files2export <- list()
 # Files that should be copied before MAgPIE is started

--- a/scripts/output/extra/highres.R
+++ b/scripts/output/extra/highres.R
@@ -120,7 +120,11 @@ highres <- function(cfg) {
   tmp[1]    <- paste0(tmp[1], paste0("HR", res))
   cfg$title <- paste(tmp, collapse = "_")
 
-  cfg$results_folder <- paste0("output/HR", res, "/:title:")
+  if(!is.null(cfg$results_folder_highres)) {
+    cfg$results_folder <- file.path(cfg$results_folder_highres,":title:")
+  } else {
+    cfg$results_folder <- paste0("output/HR", res, "/:title:")
+  }
   cfg$force_replace  <- TRUE
   cfg$recalc_npi_ndc <- TRUE
 

--- a/scripts/start/test_runs.R
+++ b/scripts/start/test_runs.R
@@ -28,6 +28,7 @@ cfg$info$flag <- "weeklyTests"
 
 cfg$output <- c("rds_report") # Only run rds_report after model run
 cfg$results_folder <- "output/:title:"
+cfg$results_folder_highres <- "output"
 cfg$force_replace <- TRUE
 
 # support function to create standardized title

--- a/scripts/start/test_runs.R
+++ b/scripts/start/test_runs.R
@@ -28,7 +28,6 @@ cfg$info$flag <- "weeklyTests"
 
 cfg$output <- c("rds_report") # Only run rds_report after model run
 cfg$results_folder <- "output/:title:"
-cfg$results_folder_highres <- "output"
 cfg$force_replace <- TRUE
 
 # support function to create standardized title
@@ -78,9 +77,11 @@ codeCheck <- FALSE
 
 ### Business-as-usual
 cfg <- fsecScenario(scenario = "c_BAU")
+cfg$results_folder_highres <- "output"
 start_run(cfg = cfg, codeCheck = codeCheck)
 
 ### FSDP Scenario
 cfg <- fsecScenario(scenario = "e_FSDP")
+cfg$results_folder_highres <- "output"
 start_run(cfg = cfg, codeCheck = codeCheck)
 


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- **config** added `cfg$results_folder_highres` which allows to modify the output folder used in the `highres.R` output script

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
