### PR TITLE
New output script for reporting land use to SEALS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **41_area_equipped_for_irrigation** new AEI data (Mehta2022) replacing old Siebert data
 
 ### added
+- **scripts** New output script for reporting disaggregated land use patterns to the SEALS (Spatial Economic Allocation Landscape Simulator) downscaling model
 - **scenario_config.csv** added a scenario for the NGFS project
 - **config** new area equipped for irrigation (AEI) data in preprocessing (4.87)
 - **31_past** added `cc`, `nocc` and `nocc_hist` options for `c31_past_suit_scen` and `c31_grassl_yld_scenario`

--- a/scripts/output/extra/reportMAgPIE2SEALS.R
+++ b/scripts/output/extra/reportMAgPIE2SEALS.R
@@ -1,0 +1,40 @@
+# |  (C) 2008-2023 Potsdam Institute for Climate Impact Research (PIK)
+# |  authors, and contributors see CITATION.cff file. This file is part
+# |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
+# |  AGPL-3.0, you are granted additional permissions described in the
+# |  MAgPIE License Exception, version 1.0 (see LICENSE file).
+# |  Contact: magpie@pik-potsdam.de
+
+# --------------------------------------------------------------
+# description: Modifies gridded MAgPIE land use patterns so that they can be read in by the Spatial Economic Allocation Landscape Simulator (SEALS)
+# comparison script: FALSE
+# ---------------------------------------------------------------
+
+# Version 1.00 - Patrick v. Jeetze
+# 1.00: first working version
+
+library(gms)
+library(magpie4)
+
+message("Starting to report gridded MAgPIE land use for SEALS")
+
+############################# BASIC CONFIGURATION #######################################
+if (!exists("source_include")) {
+  title <- NULL
+  outputdir <- NULL
+
+  # Define arguments that can be read from command line
+  readArgs("outputdir", "title")
+}
+#########################################################################################
+
+message("Script started for output directory: ", outputdir)
+cfg <- gms::loadConfig(file.path(outputdir, "config.yml"))
+title <- cfg$title
+
+# Restructure data to conform to SEALS
+reportLandUseForSEALS(
+  magCellLand = "cell.land_0.5_share.nc",
+  outFile = paste0("cell.land_0.5_SEALS_", title, ".nc"),
+  dir = outputdir, selectyears = c(2015, 2050)
+)


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- Output script for reporting gridded land use patterns to the Spatial Economic Allocation Landscape Simulator (SEALS).

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
