### PR TITLE
bugfixed inputdata rev4.92

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -90,7 +90,7 @@
       "affiliation": "Potsdam Institute for Climate Impact Research"
     },
     {
-      "name": "Führlich, Pascal",
+      "name": "Sauer, Pascal",
       "affiliation": "Potsdam Institute for Climate Impact Research",
       "orcid": "0000-0002-6856-8239"
     },

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -106,11 +106,11 @@ authors:
     given-names: Anne
     affiliation: "Potsdam Institute for Climate Impact Research"
 
-  - family-names: Führlich
+  - family-names: Sauer
     given-names: Pascal
     orcid: https://orcid.org/0000-0002-6856-8239
     affiliation: "Potsdam Institute for Climate Impact Research"
-    email: pascal.fuehrlich@pik-potsdam.de
+    email: pascal.sauer@pik-potsdam.de
 
   - family-names: Lotze-Campen
     given-names: Hermann

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,12 +22,11 @@ cfg$model <- "main.gms"   #def = "main.gms"
 #### input settings ####
 
 # which input data sets should be used?
-cfg$input <- c(regional    = "rev4.91_h12_magpie.tgz",
-               cellular    = "rev4.91_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
-               validation  = "rev4.91_h12_validation.tgz",
+cfg$input <- c(regional    = "rev4.91_2023-10-18_67k_piam1.25_h12_magpie.tgz",
+               cellular    = "rev4.91_2023-10-18_67k_piam1.25_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
+               validation  = "rev4.91_2023-10-18_67k_piam1.25_h12_validation.tgz",
                additional  = "additional_data_rev4.46.tgz",
                calibration = "calibration_H12_per_ton_fao_may22_glo_08Aug23.tgz")
-
 # NOTE: It is recommended to recalibrate the model when changing cellular input data
 #       as well as for any other setting that would affect initial values in the model,
 #       e.g. changes in costs structure, NPI policies, etc.

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -22,11 +22,12 @@ cfg$model <- "main.gms"   #def = "main.gms"
 #### input settings ####
 
 # which input data sets should be used?
-cfg$input <- c(regional    = "rev4.91_2023-10-18_67k_piam1.25_h12_magpie.tgz",
-               cellular    = "rev4.91_2023-10-18_67k_piam1.25_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
-               validation  = "rev4.91_2023-10-18_67k_piam1.25_h12_validation.tgz",
+cfg$input <- c(regional    = "rev4.92_h12_magpie.tgz",
+               cellular    = "rev4.92_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
+               validation  = "rev4.92_h12_validation.tgz",
                additional  = "additional_data_rev4.46.tgz",
                calibration = "calibration_H12_per_ton_fao_may22_glo_08Aug23.tgz")
+
 # NOTE: It is recommended to recalibrate the model when changing cellular input data
 #       as well as for any other setting that would affect initial values in the model,
 #       e.g. changes in costs structure, NPI policies, etc.


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- We identified a critical bug in the rev4.91 inputdata related to proj/6.3.1, this PR switches to rev4.92 where the bug is no longer present

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
