### PR TITLE
added switch to turn off yield calib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### changed
+- **14_yields_and_config** The new default is to not use yield calibration factors from the preprocessing. The switch s14_use_yield_calib can optionally reenable the use of yield calibration factors.
 - **inputdata** There was another bug (terra default na.rm changed) in the inputdata that was fixed with rev4.93
 - **inputdata** There was a major bug (related to proj/terra) in the rev4.91 inputdata that was fixed with rev4.92
 - **scripts** LUH2_disaggregation output script was modified. Specifically, flooded area was made compatible with the LUH definition, cropland and grazing land were added to the states.nc file, and specific naming/details (datatype,  zname, xname, and yname) were added when creating the .nc files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### changed
-- **14_yields_and_config** The new default is to not use yield calibration factors from the preprocessing. The switch s14_use_yield_calib can optionally reenable the use of yield calibration factors.
+- **14_yields_and_config** The new default is to not use yield calibration factors from a calibration run. The switch s14_use_yield_calib can optionally reenable the use of yield calibration factors.
 - **inputdata** There was another bug (terra default na.rm changed) in the inputdata that was fixed with rev4.93
 - **inputdata** There was a major bug (related to proj/terra) in the rev4.91 inputdata that was fixed with rev4.92
 - **scripts** LUH2_disaggregation output script was modified. Specifically, flooded area was made compatible with the LUH definition, cropland and grazing land were added to the states.nc file, and specific naming/details (datatype,  zname, xname, and yname) were added when creating the .nc files.

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -57,10 +57,11 @@ cfg$force_replace <- FALSE
 
 # Settings for the yield calibration
 # For this yield calibration (that uses results from a special MAgPIE calibration run 
-# triggered by the recalibrate switch) to function the switch s14_use_yield_calib needs 
+# triggered by the recalibrate switch) to be activated the switch s14_use_yield_calib needs 
 # to be turned on. (Default is off)
 # This switch should only be activated for penalty_apr22 crop realization.
 # For other realizations, it is recommended not to use this yield calibration.
+#
 # Switch to turn on/off recalibration of yields.
 # * (TRUE): Yield calibration will be performed
 # * (ifneeded): Yield calibration will only be executed if input data is

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -56,8 +56,9 @@ cfg$force_download <- FALSE
 cfg$force_replace <- FALSE
 
 # Settings for the yield calibration
-# For this preprocessing yield calibration triggered by the recalibrate switch
-# to function the switch s14_use_yield_calib needs to be turned on. (Default is off)
+# For this yield calibration (that uses results from a special MAgPIE calibration run 
+# triggered by the recalibrate switch) to function the switch s14_use_yield_calib needs 
+# to be turned on. (Default is off)
 # This switch should only be activated for penalty_apr22 crop realization.
 # For other realizations, it is recommended not to use this yield calibration.
 # Switch to turn on/off recalibration of yields.
@@ -321,7 +322,7 @@ cfg$gms$s14_calib_ir2rf <- 1       # def = 1
 # *          0 (land degradation is switched off)
 cfg$gms$s14_degradation <- 0      # def = 0
 
-# Switch to toggle the use of yield calibration factors from the preprocessing in the model run.
+# Switch to toggle the use of yield calibration factors (that resulted from a calibration run).
 # If 0, no yield calibration factors are used, meaning all calibration factors are set to 1.
 # If 1, yield calibration factors are used. (For this option to function, either an existing calibration file 
 # must be supplied in the input directory, or yields must be recalibrated during preprocessing.)

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -65,7 +65,7 @@ cfg$force_replace <- FALSE
 # * (ifneeded): Yield calibration will only be executed if input data is
 # *             downloaded from repository
 # * (FALSE): Yield calibration will not be performed
-cfg$recalibrate <- "ifneeded"     # def = "ifneeded"
+cfg$recalibrate <- FALSE     # def = FALSE
 # Up to which accuracy shall be recalibrated?
 cfg$calib_accuracy <- 0.05         # def = 0.05
 # What is the maximum number of iterations if the precision goal is not reached?

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -56,6 +56,9 @@ cfg$force_download <- FALSE
 cfg$force_replace <- FALSE
 
 # Settings for the yield calibration
+# For this preprocessing yield calibration to function 
+# the switch s14_use_yield_calib needs to be turned on. (Default is off)
+# Switch to turn on/off recalibration of yields.
 # * (TRUE): Yield calibration will be performed
 # * (ifneeded): Yield calibration will only be executed if input data is
 # *             downloaded from repository
@@ -315,6 +318,12 @@ cfg$gms$s14_calib_ir2rf <- 1       # def = 1
 # * options: 1 (yields are reduced based on yield reduction coefficients)
 # *          0 (land degradation is switched off)
 cfg$gms$s14_degradation <- 0      # def = 0
+
+# Switch to toggle the use of yield calibration factors from the preprocessing in the model run.
+# If 0, no yield calibration factors are used, meaning all calibration factors are set to 1.
+# If 1, yield calibration factors are used. (For this option to function, either an existing calibration file 
+# must be supplied in the input directory, or yields must be recalibrated during preprocessing.)
+cfg$gms$s14_use_yield_calib <- 0    # def = 0
 
 # ***---------------------    15_food    ---------------------------------------
 # * (anthropometrics_jan18): estimates food using scenario dependent regression

--- a/config/scenario_fsec.csv
+++ b/config/scenario_fsec.csv
@@ -5,6 +5,7 @@ gms$c09_pal_scenario;;;;SSP1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 gms$s12_interest_lic;;;0.06;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 gms$s12_interest_hic;;;0.04;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 gms$food;anthro_iso_jun22;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+gms$s14_use_yield_calib;1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 gms$s15_exo_waste;;;;;;;;0;0;0;0;0;0;0;0;1;;;;;;;;;;;;;;;;;0;1;;;;;;;;;;;;;;;
 gms$s15_exo_diet;;;;;;;;1;1;1;1;1;1;1;1;0;;;;;;;;;;;;;;;;;1;1;;;;;;;;;;;;;;;
 gms$c15_kcal_scen;;;;;;;;no_underweight;half_overweight;endo;endo;endo;endo;endo;endo;endo;;;;;;;;;;;;;;;;;no_underweight_half_overweight;no_underweight_half_overweight;;;;;;;;;;;;;;;

--- a/modules/14_yields/managementcalib_aug19/input.gms
+++ b/modules/14_yields/managementcalib_aug19/input.gms
@@ -16,6 +16,8 @@ scalar s14_calib_ir2rf   Switch to calibrate rainfed to irrigated yield ratios (
 
 scalar s14_degradation   Switch to include yield impacts of land degradation(0=no degradation 1=with degradation) / 0 /;
 
+scalar s14_use_yield_calib  Switch for using or not using yield calibration factors from the preprocessing (1=use facs 0=not use facs) / 0 /;
+
 scalars
   s14_yld_past_switch  Spillover parameter for translating technological change in the crop sector into pasture yield increases  (1)     / 0.25 /
   s14_yld_reduction_soil_loss  Decline of land productivity in areas with severe soil loss (1)     / 0.08 /

--- a/modules/14_yields/managementcalib_aug19/preloop.gms
+++ b/modules/14_yields/managementcalib_aug19/preloop.gms
@@ -144,13 +144,14 @@ if ((s14_calib_ir2rf = 1),
 ***YIELD CALIBRATION***********************************************************************
 
 *' @code
-*' Calibrated yields are additionally adjusted by calibration factors 'f14_yld_calib'
+*' Calibrated yields can additionally be adjusted by calibration factors 'f14_yld_calib'
 *' determined in a calibration run. As MAgPIE optimizes yield patterns and FAO regional
-*' yields are outlier corrected, historical production and croparea can only be reproduced
-*' with this additional step of correction:
+*' yields are outlier corrected, historical production and croparea can in some cases 
+*' be better represented with this additional correction:
 
-* set default values in case of missing input file
-if(sum((i,ltype14),f14_yld_calib(i,ltype14)) = 0,
+* set yield calib factors to 1 in case of no use of yield calibration factors (s14_use_yield_calib = 0) 
+* or missing input file 
+if(s14_use_yield_calib = 0 OR sum((i,ltype14),f14_yld_calib(i,ltype14)) = 0,
   f14_yld_calib(i,ltype14) = 1;
 );
 

--- a/scripts/start/extra/recalibrate_FSEC.R
+++ b/scripts/start/extra/recalibrate_FSEC.R
@@ -22,7 +22,7 @@ source("scripts/projects/fsec.R")
 cfg       <- fsecScenario(scenario = "c_BAU")
 cfg$title <- "FSEC24Mar23"
 cfg$results_folder                  <- "output/:title:"
-cfg$recalibrate                     <- TRUE
+cfg$recalibrate                     <- TRUE # required when penality_apr22 activated
 cfg$best_calib                      <- TRUE
 cfg$recalibrate_landconversion_cost <- TRUE
 cfg$best_calib_landconversion_cost  <- FALSE


### PR DESCRIPTION
## :bird: Description of this PR :bird:
Add a switch to turn off the use of yield calibration factors


## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [x] RSE review done (at least 1)