### PR TITLE
bugfix carbon stock and growing stock natveg and forestry

### DIFF
--- a/modules/14_yields/managementcalib_aug19/presolve.gms
+++ b/modules/14_yields/managementcalib_aug19/presolve.gms
@@ -22,7 +22,7 @@
 *` @code
 p14_growing_stock(t,j,ac,"forestry","plantations") =
     (
-      pm_carbon_density_ac_forestry(t,j,ac,"vegc")
+      pm_carbon_density_ac_forestry(t,j,ac,"vegc") * sum(cell(i,j),pm_gs_forestry_scaling_reg(i))
       / s14_carbon_fraction
       * f14_aboveground_fraction("forestry")
       / sum(clcl, pm_climate_class(j,clcl) * f14_ipcc_bce(clcl,"plantations"))
@@ -31,7 +31,7 @@ p14_growing_stock(t,j,ac,"forestry","plantations") =
 
 p14_growing_stock(t,j,ac,land_natveg,"natveg") =
     (
-     pm_carbon_density_ac(t,j,ac,"vegc")
+     pm_carbon_density_ac(t,j,ac,"vegc") * sum(cell(i,j),pm_gs_natveg_scaling_reg(i))
      / s14_carbon_fraction
      * f14_aboveground_fraction(land_natveg)
      / sum(clcl, pm_climate_class(j,clcl) * f14_ipcc_bce(clcl,"natveg"))

--- a/modules/32_forestry/dynamic_feb21/declarations.gms
+++ b/modules/32_forestry/dynamic_feb21/declarations.gms
@@ -49,7 +49,7 @@ parameters
  p32_aff_bgp(j,ac)                                  Biophysical impact of afforestation (tCeq per ha)
  p32_tcre_glo(j)                                    Global mean Transient Climate Response to cumulative Emissions (degree C per tC per ha)
  p32_observed_gs_reg(i)                             Observed growing stock (tDM per ha)
- p32_gs_scaling_reg(i)                              Calibration factor for scaling up the relative growing stock (1)
+ pm_gs_forestry_scaling_reg(i)                              Calibration factor for scaling up the relative growing stock (1)
  p32_rotation_dist(j,ac)                            Poulter distribution within celular rotation lengths (1)
  p32_updated_gs_reg(t,i)                            Updated growing stock information after calibration (m3 per ha)
  p32_plantation_contribution(t_ext,i)               Share of roundwood production coming from timber plantations (percent)
@@ -57,7 +57,6 @@ parameters
  p32_ac_dist(j,ac)                                  Actual share of age-class distribution (1)
  p32_avg_increment(t_all,j,ac)                      Mean annual increment (tC per ha per year)
  p32_bii_coeff(type32,bii_class_secd,potnatveg)     bii coeff (1)
- p32_c_density_ac_fast_forestry(t_all,j,ac)         Carbon densities in plantations based on Braakhekke et al (tC per ha)
  p32_disturbance_loss_ftype32(t,j,type32,ac)        Loss due to disturbances in all plantation type forests (mio. ha)
  pcm_land_forestry(j,type32)                        Forestry land pools (mio. ha)
 ;

--- a/modules/32_forestry/dynamic_feb21/preloop.gms
+++ b/modules/32_forestry/dynamic_feb21/preloop.gms
@@ -274,18 +274,11 @@ p32_observed_gs_reg(i)$(f32_gs_relativetarget(i)>0 AND sum((cell(i,j),ac),p32_la
 
 ** Initialze calibration factor for growing stocks as 1
 ** we dont set it to 0 as we don't want to modify carbon densities by multiplication with 0 later
-p32_gs_scaling_reg(i) = 1;
+pm_gs_forestry_scaling_reg(i) = 1;
 ** Calculate the ratio between target growing stock (reported by FAO) and observed growing stock (value at initialization in MAgPIE)
-p32_gs_scaling_reg(i)$(f32_gs_relativetarget(i)>0 AND f32_plantedforest(i)>0) = f32_gs_relativetarget(i) / p32_observed_gs_reg(i);
+pm_gs_forestry_scaling_reg(i)$(f32_gs_relativetarget(i)>0 AND f32_plantedforest(i)>0) = f32_gs_relativetarget(i) / p32_observed_gs_reg(i);
 ** Calibration factors lower than 1 are set to 1
-p32_gs_scaling_reg(i)$(p32_gs_scaling_reg(i) < 1) = 1;
-
-** Save pm_carbon_density_ac_forestry in a parameter before upscaling to FAO growing stocks.
-** This allows to use plantation growth curves for CO2 price driven afforestation.
-p32_c_density_ac_fast_forestry(t_all,j,ac) = pm_carbon_density_ac_forestry(t_all,j,ac,"vegc");
-
-** Update c-density for timber plantations based on calibration factor to match FAO growing stocks
-pm_carbon_density_ac_forestry(t_all,j,ac,"vegc") = pm_carbon_density_ac_forestry(t_all,j,ac,"vegc") * sum(cell(i,j),p32_gs_scaling_reg(i));
+pm_gs_forestry_scaling_reg(i)$(pm_gs_forestry_scaling_reg(i) < 1) = 1;
 
 ** set bii coefficients
 p32_bii_coeff(type32,bii_class_secd,potnatveg) = 0;

--- a/modules/32_forestry/dynamic_feb21/presolve.gms
+++ b/modules/32_forestry/dynamic_feb21/presolve.gms
@@ -36,7 +36,7 @@ v32_land_reduction.fx(j,type32,ac_est) = 0;
 if(s32_aff_plantation = 0,
  p32_carbon_density_ac(t,j,"aff",ac,ag_pools) = pm_carbon_density_ac(t,j,ac,ag_pools);
 elseif s32_aff_plantation = 1,
- p32_carbon_density_ac(t,j,"aff",ac,ag_pools) = p32_c_density_ac_fast_forestry(t,j,ac);
+ p32_carbon_density_ac(t,j,"aff",ac,ag_pools) = pm_carbon_density_ac_forestry(t,j,ac,ag_pools);
 );
 
 *' Timber plantations carbon densities:

--- a/modules/35_natveg/dynamic_feb21/declarations.gms
+++ b/modules/35_natveg/dynamic_feb21/declarations.gms
@@ -30,7 +30,7 @@ parameters
  p35_updated_gs_natfor(t,i)                       Updated growing stock in natural forests after calibration (m3 per ha)
  p35_land_start_ac(j,ac,land_natveg)              Initial Natural vegetation area (mio. ha)
  p35_observed_gs_reg(i)                           Observed growing stock in natural forests before calibration (m3 per ha)
- p35_gs_scaling_reg(i)                            Regional calibration factors for natural vegetation yields (1)
+ pm_gs_natveg_scaling_reg(i)                            Regional calibration factors for natural vegetation yields (1)
  p35_protection_dist(j,ac)                        Distribution of secondary forest protection (1)
  p35_land_restoration(j,land_natveg)              Actual secondary forest and other land restoration area (mio. ha)
 ;

--- a/modules/35_natveg/dynamic_feb21/preloop.gms
+++ b/modules/35_natveg/dynamic_feb21/preloop.gms
@@ -69,12 +69,9 @@ p35_observed_gs_reg(i)$(f35_gs_relativetarget(i)>0 AND sum((cell(i,j),ac,land_na
 
 ** Initialze calibration factor for growing stocks as 1
 ** we dont set it to 0 as we don't want to modify carbon densities by multiplication with 0 later
-p35_gs_scaling_reg(i) = 1;
+pm_gs_natveg_scaling_reg(i) = 1;
 ** Calculate the ratio between target growing stock (reported by FAO) and observed growing stock (value at initialization in MAgPIE)
-p35_gs_scaling_reg(i)$(f35_gs_relativetarget(i)>0 AND p35_observed_gs_reg(i)>0) = f35_gs_relativetarget(i) / p35_observed_gs_reg(i);
-
-** Update c-densitiy based on calibration factor for growing stocks
-pm_carbon_density_ac(t_all,j,ac,"vegc") = pm_carbon_density_ac(t_all,j,ac,"vegc") * sum(cell(i,j),p35_gs_scaling_reg(i));
+pm_gs_natveg_scaling_reg(i)$(f35_gs_relativetarget(i)>0 AND p35_observed_gs_reg(i)>0) = f35_gs_relativetarget(i) / p35_observed_gs_reg(i);
 
 * -----------------------------
 * Set forest damage trajectory

--- a/modules/52_carbon/normal_dec17/start.gms
+++ b/modules/52_carbon/normal_dec17/start.gms
@@ -21,7 +21,7 @@ pm_carbon_density_ac_forestry(t_all,j,ac,"litc") = m_growth_litc_soilc(pc52_carb
 *** Natveg
 
 *calculate vegetation age-class carbon density in current time step with chapman richards equation
-pm_carbon_density_ac(t,j,ac,"vegc") = m_growth_vegc(pc52_carbon_density_start(t,j,"vegc"),fm_carbon_density(t,j,"other","vegc"),sum(clcl,pm_climate_class(j,clcl)*f52_growth_par(clcl,"k","natveg")),sum(clcl,pm_climate_class(j,clcl)*f52_growth_par(clcl,"m","natveg")),(ord(ac)-1));
+pm_carbon_density_ac(t_all,j,ac,"vegc") = m_growth_vegc(pc52_carbon_density_start(t_all,j,"vegc"),fm_carbon_density(t_all,j,"other","vegc"),sum(clcl,pm_climate_class(j,clcl)*f52_growth_par(clcl,"k","natveg")),sum(clcl,pm_climate_class(j,clcl)*f52_growth_par(clcl,"m","natveg")),(ord(ac)-1));
 
 *calculate litter carbon density based on linear growth funktion: carbon_density(ac) = intercept + slope*ac (20 year time horizon taken from IPCC)
-pm_carbon_density_ac(t,j,ac,"litc") = m_growth_litc_soilc(pc52_carbon_density_start(t,j,"litc"),fm_carbon_density(t,j,"other","litc"),(ord(ac)-1));
+pm_carbon_density_ac(t_all,j,ac,"litc") = m_growth_litc_soilc(pc52_carbon_density_start(t_all,j,"litc"),fm_carbon_density(t_all,j,"other","litc"),(ord(ac)-1));


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- Issue in current develop branch: pm_carbon_density_ac and pm_carbon_density_ac_forestry provided by the carbon module are scaled in the preloop of the forestry and natveg modules to match observed growing stocks. This is done because pm_carbon_density_ac and pm_carbon_density_ac_forestry are used to derive timber yields in the presolve of the yields module. The problem is that pm_carbon_density_ac and pm_carbon_density_ac_forestry no longer reflect the growth dynamics of natveg and timber plantations. This has implicaitons for a) re/afforestation dynamics and b) estimating the land carbon sink in the magpie4 R library.
- Suggested solution in this PR: Introduction of a new interfaces between natveg/forestry and yields module: pm_gs_forestry_scaling_reg and pm_gs_natveg_scaling_reg. This allows to do the necessary scaling directly in the timber yield calculations, while leaving pm_carbon_density_ac and pm_carbon_density_ac_forestry untouched and thus retaining the carbon dynamcis over time.
Note: the 2 interfaces could be merged in a single interface but this interface would need to be defined in the yields module, which content-wise does not fit so well. 

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
