### PR TITLE
changed SEALS reporting and underlying function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scenario_config.csv** settings for cfg$gms$s35_secdf_distribution in `ForestryEndo` and `ForestryExo` changed from `2` to `0`
 - **scenario_config.csv** removed erroneous setting `cc` from column `input`
 - **default.cfg** update default `cfg$gms$c56_pollutant_prices` and `cfg$gms$c60_2ndgen_biodem` to `R32M46-SSP2EU-NPi`
-- **default.cfg** update input data to rev 4.96 
+- **default.cfg** update input data to rev 4.96
 - **default.cfg** changed default for `cfg$gms$s56_buffer_aff` from 0.2 to 0.5
 - **default.cfg** changed default for `cfg$gms$s32_aff_prot` from 0 to 1
 - **21_trade** s21_trade_bal_damper for roundwood changed from 0.75 to 0.65
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **58_peatland** removed realization "on"
 
 ### fixed
+- **scripts** Fixed writing of NetCDF files in output/reportMAgPIE2SEALS.R
 - **scripts** Fixed disaggregation.R and disaggregation_LUH2.R to be used with 67k
 - **scripts** bugfix highres.R for bioenergy demand and GHG prices in coupled runs
 - **35_natveg** bugfixes ac_est

--- a/scripts/output/extra/reportMAgPIE2SEALS.R
+++ b/scripts/output/extra/reportMAgPIE2SEALS.R
@@ -34,7 +34,7 @@ title <- cfg$title
 
 # Restructure data to conform to SEALS
 reportLandUseForSEALS(
-  magCellLand = "cell.land_0.5_share.nc",
+  magCellLand = "cell.land_0.5_share.mz",
   outFile = paste0("cell.land_0.5_SEALS_", title, ".nc"),
-  dir = outputdir, selectyears = c(2015, 2020, 2025, 2030, 2035, 2040, 2045, 2050)
+  dir = outputdir, selectyears = c(2020, 2030, 2040, 2050)
 )


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- Due to a change in `magclass::write.magpie` that affected the writing of NetCDF files, some fixes were necessary regarding the reporting of NetCDF files for SEALS
- 
## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
