### PR TITLE
bugfix v21_manna_from_heaven highres.R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **52_carbon** bugfix acx long-term carbon density
 - **32_forestry** keep c-density for timber plantations constant after rotation length to avoid unrealistic carbon sequestration in unharvested timber plantation
 - **32_forestry** bugfix unit p32_observed_gs_reg
+- **21_trade** v21_manna_from_heaven fixed to zero by default. Without fixing to zero, v21_manna_from_heaven was used unnecessarily in runs started with highres.R
 
 ## [4.7.0] - 2023-12-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **52_carbon** bugfix acx long-term carbon density
 - **32_forestry** keep c-density for timber plantations constant after rotation length to avoid unrealistic carbon sequestration in unharvested timber plantation
 - **32_forestry** bugfix unit p32_observed_gs_reg
-- **21_trade** v21_manna_from_heaven fixed to zero by default. Without fixing to zero, v21_manna_from_heaven was used unnecessarily in runs started with highres.R
+- **21_trade** introduced s21_manna_from_heaven for fixing v21_manna_from_heaven to zero. Without fixing to zero, v21_manna_from_heaven was used unnecessarily in runs started with highres.R
 
 ## [4.7.0] - 2023-12-11
 

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -557,7 +557,7 @@ cfg$gms$trade <- "selfsuff_reduced"             # def = selfsuff_reduced
 # * option for `exo` realization only: 
 # * fix `v21_manna_from_heaven` to zero (0) or not (1)
 # Note: Without fixing to zero, v21_manna_from_heaven might be used unnecessarily in runs started with highres.R
-cfg$gms$21_manna_from_heaven <- 0
+cfg$gms$s21_manna_from_heaven <- 0
 
 # * trade balance reduction scenario
 # * (l909090r808080):   10 percent trade liberalisation for secondary and

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -554,6 +554,11 @@ cfg$gms$c20_scp_type <- "sugar"                         # def = sugar
 # *                     to exports
 cfg$gms$trade <- "selfsuff_reduced"             # def = selfsuff_reduced
 
+# * option for `exo` realization only: 
+# * fix `v21_manna_from_heaven` to zero (0) or not (1)
+# Note: Without fixing to zero, v21_manna_from_heaven might be used unnecessarily in runs started with highres.R
+cfg$gms$21_manna_from_heaven <- 0
+
 # * trade balance reduction scenario
 # * (l909090r808080):   10 percent trade liberalisation for secondary and
 # *                     livestock products in 2030,2050,2100 and 20 percent for

--- a/modules/21_trade/exo/input.gms
+++ b/modules/21_trade/exo/input.gms
@@ -5,6 +5,10 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
+scalars
+ s21_manna_from_heaven  v21_manna_from_heaven fixed to zero (0) or available at high cost (1) (binary) / 0 /
+;
+
 table f21_trade_balance(t_all,h,kall) trade balance of positive exports and negative imports (mio. tDM per yr)
 $ondelim
 $include "./modules/21_trade/input/f21_trade_balance.cs3"

--- a/modules/21_trade/exo/preloop.gms
+++ b/modules/21_trade/exo/preloop.gms
@@ -8,3 +8,6 @@
 ** Save self sufficiency values as a interface parameter needed in forestry module
 pm_selfsuff_ext(t_ext,h,kforestry) = f21_self_suff("y2150",h,kforestry);
 pm_selfsuff_ext(t_all,h,kforestry) = f21_self_suff(t_all,h,kforestry);
+
+** fix to zero by default
+v21_manna_from_heaven.fx(h,kall)$(s21_manna_from_heaven = 0) = 0;


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- **21_trade** v21_manna_from_heaven fixed to zero by default. Without fixing to zero, v21_manna_from_heaven was used unnecessarily in runs started with highres.R in the first time steps, which caused price spikes in the results. 

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [x] RSE review done (at least 1)
