### PR TITLE
replace speed_aggregate

### DIFF
--- a/scripts/output/extra/disaggregation_LUH2.R
+++ b/scripts/output/extra/disaggregation_LUH2.R
@@ -122,7 +122,7 @@ if(!dir.exists(paste0(out_dir,"/mappingLUH2MAgPIE/"))) dir.create(paste0(out_dir
 if(!file.exists(paste0(out_dir,"/mappingLUH2MAgPIE/LUH2MAgPIE.csv"))) write.csv(as.data.frame(mapping),file=paste0(out_dir,"/mappingLUH2MAgPIE/LUH2MAgPIE.csv"))
 countries<-intersect(getCells(mapping),unique(mapping_spatial$country))
 mapping_spatial<-subset(mapping_spatial,country %in% countries)
-map_LUHMAg_grid<-setYears(speed_aggregate(mapping[countries,,],rel=mapping_spatial,weight=NULL,from="country",to="cell",dim=1),NULL)
+map_LUHMAg_grid<-setYears(madrat::toolAggregate(mapping[countries,,],rel=mapping_spatial,weight=NULL,from="country",to="cell",dim=1),NULL)
 
 #### calculates grid cell area of the earths sphere
 land_hr <- read.magpie(land_hr_out_file)


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- replace the only occurance of speed_aggregate in non-deprecated script

## :wrench: Checklist for PR creator :wrench:

- [ ] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [ ] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
