### PR TITLE
modified agmip output script to use piaminterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **35_natveg**  `vm_land(j2,"forestry")` included in NPI/NDC constraint `q35_min_forest`
 - **35_natveg** replaced the realisation `dynamic_feb21` with realisation `pot_forest_may24`. The new realisation provides additional information on the potential forest area, which is now used to constrain forest and forestry expansion and recovery. The remaining area for forest establishment is provided to the forestry module via the new interface parameter `pcm_max_forest_est`.
 - **52_carbon** Separate carbon densities for forest and other land. Before there was only a single carbon density for natural vegetation land.
+- **scripts** modified agmip_merge_report to use piamInterfaces
 
 ### added
 - **default.cfg** added cropland growth constraint `cfg$gms$s30_annual_max_growth`

--- a/scripts/output/projects/agmip_merge_report.R
+++ b/scripts/output/projects/agmip_merge_report.R
@@ -14,8 +14,9 @@ library(lucode2)
 library(magclass)
 library(quitte)
 library(madrat)
-library(iamc)
+library(piamInterfaces)
 library(gms)
+library(dplyr)
 
 options(error=function()traceback(2))
 
@@ -64,10 +65,32 @@ if (!is.null(missing)) {
 }
 
 if (file.exists("output/agmip_report_full.csv")) {
-  #saveRDS(read.quitte("output/agmip_report_full.csv"),file = "output/agmip_report_full.rds")
-  #agmip_report_full <- read.report(file="agmip_report_full.csv")
-  write.reportProject(mif = "output/agmip_report_full.csv",
-                      mapping = system.file("extdata", mapping = "variablemappingAgMIP.csv", package = "magpie4"),
-                      file = "output/agmip_report_subset.csv", format = "AgMIP")
-  #write.reportProject(mif="output/agmip_report_full.csv",mapping = "mapping_magpie_agmip.csv", file = "agmip_report_subset.csv",format="AgMIP")
+  submission <- generateIIASASubmission(
+    mifs = "output/agmip_report_full.csv",
+    mapping = "AgMIP",
+    model = "MAgPIE",
+    outputFilename = NULL,
+    timesteps = c(seq(1900, 2100, 1)),
+    naAction = "na.pass"
+  )
+  submission <- submission %>%
+    mutate(
+      "item" := gsub(".*\\.", "", variable),
+      "variable" := gsub("\\..*", "", variable)
+    ) %>%
+    select(
+      "Model" = "model",
+      "Scenario" = "scenario",
+      "Region" = "region",
+      "Item" = "item",
+      "Variable" = "variable",
+      "Year" = "period",
+      "Unit" = "unit",
+      "Value" = "value"
+    )
+  write.csv(submission,
+    quote = FALSE,
+    file = "output/agmip_submission_report.csv",
+    row.names = FALSE
+  )
 }

--- a/scripts/output/projects/agmip_merge_report.R
+++ b/scripts/output/projects/agmip_merge_report.R
@@ -70,7 +70,7 @@ if (file.exists("output/agmip_report_full.csv")) {
     mapping = "AgMIP",
     model = "MAgPIE",
     outputFilename = NULL,
-    timesteps = c(seq(1900, 2100, 1)),
+    timesteps = c(seq(1995, 2100, 1)),
     naAction = "na.pass"
   )
   submission <- submission %>%


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- This PR modifies the agmip output script to use the piamInterfaces mapping instead of the deprecated mapping write.reportProject from the iamc package. 

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
