### PR TITLE
Bugfix warning disaggregation

### DIFF
--- a/scripts/output/extra/disaggregation.R
+++ b/scripts/output/extra/disaggregation.R
@@ -444,7 +444,7 @@ message("Disaggregating BII values")
 land_ini_hr <- read.magpie(land_hr_file)[, "y1995", ]
 side_layers_hr <- read.magpie(luh_side_layers)
 landArea <- dimSums(land_ini_hr, dim = 3)
-side_layers_lr <- toolAggregate(x = side_layers_hr, rel = map_file, weight = landArea, from = "cell", to = "cluster", zeroWeight = "allow")
+side_layers_lr <- toolAggregate(x = side_layers_hr, rel = map_file, weight = landArea, from = "cell", to = "cluster")
 
 # Convert land types for BII disaggregation
 land_ini_hr <- mbind(

--- a/scripts/output/extra/disaggregation.R
+++ b/scripts/output/extra/disaggregation.R
@@ -161,7 +161,7 @@ if (length(map_file) > 1) {
   # for grassland and natural vegetation
   natveg <- c("primforest", "secdforest", "other")
   consv_sum_lr <- mbind(
-    dimSums(land_consv_lr[, , "past"], 3.2),
+    dimSums(land_consv_lr[, , "past"], 3),
     setNames(dimSums(land_consv_lr[, , natveg], dim = 3), "natveg")
   )
   consv_sum_hr_agg <- mbind(

--- a/scripts/output/extra/disaggregation.R
+++ b/scripts/output/extra/disaggregation.R
@@ -444,7 +444,7 @@ message("Disaggregating BII values")
 land_ini_hr <- read.magpie(land_hr_file)[, "y1995", ]
 side_layers_hr <- read.magpie(luh_side_layers)
 landArea <- dimSums(land_ini_hr, dim = 3)
-side_layers_lr <- toolAggregate(x = side_layers_hr, rel = map_file, weight = landArea, from = "cell", to = "cluster")
+side_layers_lr <- toolAggregate(x = side_layers_hr, rel = map_file, weight = landArea, from = "cell", to = "cluster", zeroWeight = "allow")
 
 # Convert land types for BII disaggregation
 land_ini_hr <- mbind(

--- a/scripts/output/extra/disaggregation.R
+++ b/scripts/output/extra/disaggregation.R
@@ -161,7 +161,7 @@ if (length(map_file) > 1) {
   # for grassland and natural vegetation
   natveg <- c("primforest", "secdforest", "other")
   consv_sum_lr <- mbind(
-    dimSums(land_consv_lr[, , "past"], 3),
+    land_consv_lr[, , "past"],
     setNames(dimSums(land_consv_lr[, , natveg], dim = 3), "natveg")
   )
   consv_sum_hr_agg <- mbind(


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- Bugfix warning disaggregation

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
