### PR TITLE
update merge_report and rds_report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### changed
 - **21_trade** refactor equations for enhanced readablility and improve documentation
+- **script** rewrite of merge_report.R based on rds files and rbind, which allows for more flexibility when merging reports. Avoid inconsistent use of "GLO" instead of "World" in report.rds files.
 
 ### added
 - **scripts** added output report `EU_report.R` that uses `EU_report.Rmd`

--- a/scripts/output/merge_report.R
+++ b/scripts/output/merge_report.R
@@ -30,27 +30,24 @@ if(!exists("source_include")) {
 cat("\nStarting output generation\n")
 
 missing <- NULL
+out <- NULL
 
-if(file.exists("output/report_all.mif")) file.rename("output/report_all.mif","output/report_all.bak")
+if(file.exists("output/report_all.rds")) file.rename("output/report_all.rds","output/report_all_bak.rds")
+if(file.exists("output/report_all.mif")) file.rename("output/report_all.mif","output/report_all_bak.mif")
 
 for (i in 1:length(outputdir)) {
   print(paste("Processing",outputdir[i]))
-  #gdx file
-  rep<-file.path(outputdir[i],"report.mif")
+  rep<-file.path(outputdir[i],"report.rds")
   if(file.exists(rep)) {
-    #get scenario name
-    cfg <- gms::loadConfig(file.path(outputdir[i], "config.yml"))
-    scen <- cfg$title
-    #read-in reporting file
-    a <- read.report(rep,as.list = FALSE)
-    getNames(a,dim=1) <- scen
-    #add to reporting mif file
-    write.report(a,file="output/report_all.mif",append=TRUE,ndigit = 4,skipempty = FALSE)
+    a <- readRDS(rep)
+    out <- rbind(out,a)
   } else missing <- c(missing,outputdir[i])
 }
+
+saveRDS(out,file="output/report_all.rds")
+write.mif(out,"output/report_all.mif")
+
 if (!is.null(missing)) {
   cat("\nList of folders with missing report.mif\n")
   print(missing)
 }
-
-if(file.exists("output/report_all.mif")) saveRDS(read.quitte("output/report_all.mif"),file = "output/report_all.rds")

--- a/scripts/output/rds_report.R
+++ b/scripts/output/rds_report.R
@@ -48,8 +48,13 @@ for (mapping in c("AR6", "NAVIGATE", "SHAPE", "AR6_MAgPIE")) {
 }
 
 write.report(report, file = mif)
+
 q <- as.quitte(report)
+# as.quitte converts "World" into "GLO". But we want to keep "World" and therefore undo these changes
 q <- droplevels(q)
+levels(q$region)[levels(q$region) == "GLO"] <- "World"
+q$region <- factor(q$region,levels = sort(levels(q$region)))
+
 if(all(is.na(q$value))) stop("No values in reporting!")
 
 saveRDS(q, file = rds, version = 2)

--- a/scripts/output/rds_report_iso.R
+++ b/scripts/output/rds_report_iso.R
@@ -31,7 +31,13 @@ rds_iso <- paste0(outputdir, "/report_iso.rds")
 ###############################################################################
 
 report <- getReportIso(gdx, scenario = cfg$title, dir = outputdir)
+
 q <- as.quitte(report)
+# as.quitte converts "World" into "GLO". But we want to keep "World" and therefore undo these changes
+q <- droplevels(q)
+levels(q$region)[levels(q$region) == "GLO"] <- "World"
+q$region <- factor(q$region,levels = sort(levels(q$region)))
+
 if (all(is.na(q$value))) {
   stop("No values in reporting!")
 }


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- rewrite of merge_report.R based on rds files and rbind, which allows for more flexibility when merging reports
- Avoid inconsistent use of "GLO" instead of "World" in report.rds files.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
