### PR TITLE
Use 'find' instead of 'ls' to create the list of reportings available for shinyresults

### DIFF
--- a/scripts/output/rds_report.R
+++ b/scripts/output/rds_report.R
@@ -77,6 +77,6 @@ if(file.exists(runstatistics) & dir.exists(resultsarchive)) {
   saveRDS(q, file = paste0(resultsarchive, "/", stats$id, ".rds"), version = 2)
   cwd <- getwd()
   setwd(resultsarchive)
-  system("ls 1*.rds > files")
+  system("find -type f -name '1*.rds' -printf '%f\n' | sort > fileListForShinyresults")
   setwd(cwd)
 }


### PR DESCRIPTION
## :bird: Description of this PR :bird:

Use 'find' instead of 'ls' to create the list of reportings available in the results archive for shinyresults.

Explanation https://www.baeldung.com/linux/argument-list-too-long-error

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
