### PR TITLE
add mail-type FAIL

### DIFF
--- a/scripts/run_submit/submit_medium.sh
+++ b/scripts/run_submit/submit_medium.sh
@@ -3,7 +3,7 @@
 #SBATCH --qos=medium
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
-#SBATCH --mail-type=END
+#SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=3
 
 Rscript submit.R

--- a/scripts/run_submit/submit_priority.sh
+++ b/scripts/run_submit/submit_priority.sh
@@ -3,7 +3,7 @@
 #SBATCH --qos=priority
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
-#SBATCH --mail-type=END
+#SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=3
 
 Rscript submit.R

--- a/scripts/run_submit/submit_priority_maxMem.sh
+++ b/scripts/run_submit/submit_priority_maxMem.sh
@@ -3,7 +3,7 @@
 #SBATCH --qos=priority
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
-#SBATCH --mail-type=END
+#SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=16
 #SBATCH --mem-per-cpu=0
 

--- a/scripts/run_submit/submit_short.sh
+++ b/scripts/run_submit/submit_short.sh
@@ -3,7 +3,7 @@
 #SBATCH --qos=short
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
-#SBATCH --mail-type=END
+#SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=3
 
 Rscript submit.R

--- a/scripts/run_submit/submit_short_maxMem.sh
+++ b/scripts/run_submit/submit_short_maxMem.sh
@@ -3,7 +3,7 @@
 #SBATCH --qos=short
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
-#SBATCH --mail-type=END
+#SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=16
 #SBATCH --mem-per-cpu=0
 

--- a/scripts/run_submit/submit_standby.sh
+++ b/scripts/run_submit/submit_standby.sh
@@ -3,7 +3,7 @@
 #SBATCH --qos=standby
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
-#SBATCH --mail-type=END
+#SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=3
 
 Rscript submit.R

--- a/scripts/run_submit/submit_standby_dayMax.sh
+++ b/scripts/run_submit/submit_standby_dayMax.sh
@@ -3,7 +3,7 @@
 #SBATCH --qos=standby
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
-#SBATCH --mail-type=END
+#SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=3
 #SBATCH --time=24:00:00
 

--- a/scripts/run_submit/submit_standby_maxMem.sh
+++ b/scripts/run_submit/submit_standby_maxMem.sh
@@ -3,7 +3,7 @@
 #SBATCH --qos=standby
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
-#SBATCH --mail-type=END
+#SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=16
 #SBATCH --mem-per-cpu=0
 

--- a/scripts/run_submit/submit_standby_maxMem_dayMax.sh
+++ b/scripts/run_submit/submit_standby_maxMem_dayMax.sh
@@ -3,7 +3,7 @@
 #SBATCH --qos=standby
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
-#SBATCH --mail-type=END
+#SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=16
 #SBATCH --mem-per-cpu=0
 #SBATCH --time=24:00:00

--- a/scripts/slurmOutput.yml
+++ b/scripts/slurmOutput.yml
@@ -1,5 +1,5 @@
 slurmjobs:
-  SLURM standby: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=standby --time=24:00:00"
-  SLURM standby maxMem: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=standby --time=24:00:00 --mem-per-cpu=0 --cpus-per-task=16"
-  SLURM priority: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=priority"
-  SLURM priority maxMem: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=priority --mem-per-cpu=0 --cpus-per-task=16"
+  SLURM standby: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=standby --time=24:00:00"
+  SLURM standby maxMem: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=standby --time=24:00:00 --mem-per-cpu=0 --cpus-per-task=16"
+  SLURM priority: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=priority"
+  SLURM priority maxMem: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=priority --mem-per-cpu=0 --cpus-per-task=16"

--- a/scripts/slurmStart.yml
+++ b/scripts/slurmStart.yml
@@ -1,4 +1,4 @@
 slurmjobs:
-  SLURM priority: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END --wrap=\"Rscript %SCRIPT\" --qos=priority --cpus-per-task=3"
-  SLURM standby: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END --wrap=\"Rscript %SCRIPT\" --qos=standby --cpus-per-task=3"
-  SLURM medium: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END --wrap=\"Rscript %SCRIPT\" --qos=medium --cpus-per-task=3"
+  SLURM priority: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --qos=priority --cpus-per-task=3"
+  SLURM standby: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --qos=standby --cpus-per-task=3"
+  SLURM medium: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --qos=medium --cpus-per-task=3"


### PR DESCRIPTION
## :bird: Description of this PR :bird:
As @dklein-pik pointed out to me: on our new hpc mail-type FAIL needs to be specified to also get a notification mails for failed runs. Providing the additional argument "FAIL" also works on the old cluster. The same was added in remind with https://github.com/remindmodel/remind/pull/1740

## :wrench: Checklist for PR creator :wrench:

- [ ] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [ ] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
