### PR TITLE
Change the logic used to decide whether bioenergy demand and ghg prices are read from a REMIND report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### changed
 - **21_trade** refactor equations for enhanced readablility and improve documentation
 - **script** rewrite of merge_report.R based on rds files and rbind, which allows for more flexibility when merging reports. Avoid inconsistent use of "GLO" instead of "World" in report.rds files.
+- **script** scripts/start_functions.R decide individually for demand and price whether they are read from a REMIND report.
 
 ### added
 - **scripts** added output report `EU_report.R` that uses `EU_report.Rmd`

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -300,12 +300,11 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE)
     message("done.")
   }
 
-  # If reports for both bioenergy and GHG prices are available convert them
-  # to MAgPIE input, save to the respective input folders, and use it as input
-  if (!is.na(cfg$path_to_report_bioenergy) & !is.na(cfg$path_to_report_ghgprices)) {
-    getReportData(cfg$path_to_report_bioenergy, cfg$path_to_report_ghgprices)
-    cfg <- gms::setScenario(cfg,"coupling")
-  }
+  # If available (i.e. paths are set) extract bioenergy and/or GHG prices 
+  # from REMIND report and save them to the respective input folders
+  # Please note: For them to be used by the model, either the 'coupling' scenario
+  # must be selected or the corresponding switches must be set individually.
+  getReportData(cfg$path_to_report_bioenergy, cfg$path_to_report_ghgprices)
 
   # update all parameters which contain the levels and marginals
   # of all variables and equations
@@ -594,17 +593,21 @@ getReportData <- function(path_to_report_bioenergy, path_to_report_ghgprices = N
     return(mag)
   }
 
-  # read REMIND report
-  message("Reading bioenergy_demand from ", path_to_report_bioenergy)
-  mag <- .readAndPrepare(path_to_report_bioenergy)
-
-  .bioenergyDemand(mag)
-
-  # write emission files, if specified use path_to_report_ghgprices instead of the bioenergy report
-  if (is.na(path_to_report_ghgprices)) {
-    message("Reading ghg prices from the same file (", path_to_report_bioenergy, ")")
-    .emissionPrices(mag)
-  } else {
+  # if paths are provided, read bioenergy demand and ghg prices from REMIND reports 
+  if (!is.na(path_to_report_bioenergy)) {
+    message("Reading bioenergy_demand from ", path_to_report_bioenergy)
+    mag <- .readAndPrepare(path_to_report_bioenergy)
+    .bioenergyDemand(mag)
+  
+    if (path_to_report_ghgprices %in% path_to_report_bioenergy) {
+      message("Reading ghg prices from the same file (", path_to_report_bioenergy, ")")
+      .emissionPrices(mag)
+    }
+  }
+  
+  # read ghg prices from another REMIND report because path_to_report_bioenergy
+  # is different from path_to_report_ghgprices (including NA)
+  if (!is.na(path_to_report_ghgprices) && ! path_to_report_ghgprices %in% path_to_report_bioenergy) {
     message("Reading ghg prices from ", path_to_report_ghgprices)
     ghgmag <- .readAndPrepare(path_to_report_ghgprices)
     .emissionPrices(ghgmag)


### PR DESCRIPTION
## :bird: Description of this PR :bird:

Decide individually for demand and price whether they are read from a REMIND report. Meaning: if a path to a REMIND report is specified for one of the two, read it, regardless of whether a report is also given for the other. Previously, *both* were only read if a path was given for both, or if a path was only given for bioenergy. The new way allows setting demand and price individually, which is required for some standalone scenarios. In the REMIND coupling demand and price will always be read from the same report.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [x] RSE review done (at least 1)
