### PR TITLE
modify standby runs to include partition information

### DIFF
--- a/scripts/run_submit/submit_standby.sh
+++ b/scripts/run_submit/submit_standby.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #SBATCH --qos=standby
+#SBATCH --partition=priority
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
 #SBATCH --mail-type=END,FAIL

--- a/scripts/run_submit/submit_standby_dayMax.sh
+++ b/scripts/run_submit/submit_standby_dayMax.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #SBATCH --qos=standby
+#SBATCH --partition=priority
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
 #SBATCH --mail-type=END,FAIL

--- a/scripts/run_submit/submit_standby_maxMem.sh
+++ b/scripts/run_submit/submit_standby_maxMem.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #SBATCH --qos=standby
+#SBATCH --partition=priority
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
 #SBATCH --mail-type=END,FAIL

--- a/scripts/run_submit/submit_standby_maxMem_dayMax.sh
+++ b/scripts/run_submit/submit_standby_maxMem_dayMax.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #SBATCH --qos=standby
+#SBATCH --partition=priority
 #SBATCH --job-name=mag-run
 #SBATCH --output=slurm.log
 #SBATCH --mail-type=END,FAIL

--- a/scripts/slurmOutput.yml
+++ b/scripts/slurmOutput.yml
@@ -1,5 +1,5 @@
 slurmjobs:
-  SLURM standby: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=standby --time=24:00:00"
-  SLURM standby maxMem: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=standby --time=24:00:00 --mem-per-cpu=0 --cpus-per-task=16"
+  SLURM standby: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=standby --partition=priority --time=24:00:00"
+  SLURM standby maxMem: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=standby --partition=priority --time=24:00:00 --mem-per-cpu=0 --cpus-per-task=16"
   SLURM priority: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=priority --partition=priority"
   SLURM priority maxMem: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --time=200 --mem-per-cpu=8000 --wrap=\"Rscript %SCRIPT\" --qos=priority --partition=priority --mem-per-cpu=0 --cpus-per-task=16"

--- a/scripts/slurmStart.yml
+++ b/scripts/slurmStart.yml
@@ -1,4 +1,4 @@
 slurmjobs:
   SLURM priority: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --qos=priority --partition=priority --cpus-per-task=3"
-  SLURM standby: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --qos=standby --cpus-per-task=3"
+  SLURM standby: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --qos=standby --partition=priority --cpus-per-task=3"
   SLURM medium: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --qos=medium --cpus-per-task=3"


### PR DESCRIPTION
## :bird: Description of this PR :bird:

The standby qos has been moved to the priority partition:

```
scontrol show partition


PartitionName=standard
   AllowGroups=ALL AllowAccounts=ALL AllowQos=short,medium,long
   AllocNodes=ALL Default=YES QoS=N/A
   DefaultTime=NONE DisableRootJobs=NO ExclusiveUser=NO GraceTime=0 Hidden=NO
   MaxNodes=UNLIMITED MaxTime=UNLIMITED MinNodes=0 LLN=NO MaxCPUsPerNode=UNLIMITED
   Nodes=csl14c[177-180],csm14c[181-240],csn14c[121-176],cso14c[61-120]
   PriorityJobFactor=1 PriorityTier=1 RootOnly=NO ReqResv=NO OverSubscribe=NO
   OverTimeLimit=NONE PreemptMode=OFF
   State=UP TotalCPUs=23040 TotalNodes=180 SelectTypeParameters=NONE
   JobDefaults=(null)
   DefMemPerNode=UNLIMITED MaxMemPerNode=UNLIMITED
   TRES=cpu=23040,mem=121320000M,node=180,billing=23040

PartitionName=priority
   AllowGroups=ALL AllowAccounts=ALL AllowQos=priority,standby,standby_cancel
   AllocNodes=ALL Default=NO QoS=N/A
   DefaultTime=NONE DisableRootJobs=NO ExclusiveUser=NO GraceTime=0 Hidden=NO
   MaxNodes=UNLIMITED MaxTime=UNLIMITED MinNodes=0 LLN=NO MaxCPUsPerNode=UNLIMITED
   Nodes=csp14c[01-60]
   PriorityJobFactor=1 PriorityTier=1 RootOnly=NO ReqResv=NO OverSubscribe=NO
   OverTimeLimit=NONE PreemptMode=OFF
   State=UP TotalCPUs=7680 TotalNodes=60 SelectTypeParameters=NONE
   JobDefaults=(null)
   DefMemPerNode=UNLIMITED MaxMemPerNode=UNLIMITED
   TRES=cpu=7680,mem=40440000M,node=60,billing=7680

```

added 
```
--partition=priority
```
to the standby start and output runs.

- Briefly explain the purpose of this pull request

## :wrench: Checklist for PR creator :wrench:

- [ ] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [ ] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
