### PR TITLE
update highres parallel opmization tc 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **config** initial treecover on cropland starts from zero
 - **config** additional data update additional_data_rev4.53.tgz
 - **29_cropland** added option for linear and sigmoidal faders
+- **scripts** output/extra/highres.R use default 13_tc realization
 
 
 ### added

--- a/scripts/output/extra/highres.R
+++ b/scripts/output/extra/highres.R
@@ -37,7 +37,10 @@ resultsarchive <- "/p/projects/rd3mod/models/results/magpie"
 # Load start_run(cfg) function which is needed to start MAgPIE runs
 source("scripts/start_functions.R")
 
-highres <- function(cfg) {
+# Plausible values for "res" (high resolution): "c1000" and "c2000"
+# Options for "tc" (13_tc realization): NULL (no change), "exo" and "endo_jan22"
+
+highres <- function(cfg = cfg, res = "c2000", tc = NULL) {
   #lock the model folder
   lockId <- gms::model_lock(timeout1 = 24)
   withr::defer(gms::model_unlock(lockId))
@@ -45,9 +48,6 @@ highres <- function(cfg) {
   if(any(!(modelstat(gdx) %in% c(2,7)))) stop("Modelstat different from 2 or 7 detected")
 
   cfg$output <- cfg$output[cfg$output!="extra/highres"]
-
-  # set high resolution, available options are c1000 and c2000
-  res <- "c1000"
 
   # search for matching high resolution file in repositories
   # pattern: "rev4.65_h12_*_cellularmagpie_c2000_MRI-ESM2-0-ssp370_lpjml-3eb70376.tgz"
@@ -139,10 +139,12 @@ highres <- function(cfg) {
   f21_trade_balance <- toolAggregate(ov_prod_reg - (ov_supply + import_for_feasibility), supreg)
   write.magpie(f21_trade_balance, paste0("modules/21_trade/input/f21_trade_balance.cs3"))
 
-  #get tau from low resolution run with c200
-  ov_tau <- readGDX(gdx, "ov_tau",select=list(type="level"))
-  write.magpie(ov_tau,"modules/13_tc/input/f13_tau_scenario.csv")
-  cfg$gms$tc <- "exo"
+  if(!is.null(tc)) {
+    #get tau from low resolution run with c200
+    ov_tau <- readGDX(gdx, "ov_tau",select=list(type="level"))
+    write.magpie(ov_tau,"modules/13_tc/input/f13_tau_scenario.csv")
+    cfg$gms$tc <- tc
+  }
 
   #use exo trade and parallel optimization
   cfg$gms$trade <- "exo"

--- a/scripts/output/extra/highres.R
+++ b/scripts/output/extra/highres.R
@@ -40,7 +40,7 @@ source("scripts/start_functions.R")
 # Plausible values for "res" (high resolution): "c1000" and "c2000"
 # Options for "tc" (13_tc realization): NULL (no change), "exo" and "endo_jan22"
 
-highres <- function(cfg = cfg, res = "c2000", tc = NULL) {
+highres <- function(cfg = cfg, res = "c1000", tc = NULL) {
   #lock the model folder
   lockId <- gms::model_lock(timeout1 = 24)
   withr::defer(gms::model_unlock(lockId))


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- **scripts** output/extra/highres.R use default 13_tc realization

With "exo", the previous default in output/extra/highres.R, spikes in costs and prices occur in single time steps. 
With "endo_jan22" (model default), this does not happen.
Run time for c1000 parallel is the same for both, tc exo and tc endo_jan22: 18 mins with H16.

For context, some more run times:
c1000-SSP2-T400-CO2,978.5 = 16 h (c1000 global optimization)
c400-SSP2-T400-CO2,113.1
HRc1000_c400-SSP2-T400-CO2,18.8
HRc2000_c1000-SSP2-T400-CO2,48.1
TCendo_HRc1000_c400-SSP2-T400-CO2,18.4
TCendo_HRc2000_c400-SSP2-T400-CO2,72.2

## :wrench: Checklist for PR creator :wrench:

- [ ] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [ ] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
