### PR TITLE
Shift to sticky as default realization in the 38_factor_costs module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### changed
+- **config** The default realization for the 38_factor_costs module was switched to `sticky_feb18`. In this realization, capital stocks and their depreciation are tracked, giving some inertia to random relocation of production, improving high resolution outputs.
 - **21_trade** refactor equations for enhanced readablility and improve documentation
 - **scripts** rewrite of merge_report.R based on rds files and rbind, which allows for more flexibility when merging reports. Avoid inconsistent use of "GLO" instead of "World" in report.rds files.
 - **15_food** revision of MP/SCP implementation for milk and meat alternatives. Added demand for fat and sugar as ingredients for MP-based milk alternatives. Added optional demand for fat as ingredient for MP-based meat alternatives.

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -1135,7 +1135,7 @@ cfg$gms$c37_labor_uncertainty <- "ensmean"  # default = "ensmean"
 # NOTE: It is recommended to recalibrate the model when changing this setting!
 # NOTE: In case the maximum number of iterations is reached without convergence
 #       in the calibration, please consider to use the best_calib setting for the calibration run
-cfg$gms$factor_costs <- "per_ton_fao_may22"        # default = per_ton_fao_may22
+cfg$gms$factor_costs <- "sticky_feb18"        # default = "sticky_feb18"
 
 # * Regional (reg) or global (glo) factor requirements (applicable for per_ton_fao_may22,
 # * sticky_feb18, sticky_labor). The regional version keeps factor requirements constant


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- In this PR the default realization for the 38_factor_costs module was switched to `sticky_feb18`. Regional dynamics are similar to the per_ton_fao_may22 (previous default realization). However, sticky_feb18's land-use high-resolution outputs better fit historical and initialization values.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    -
![Untitled](https://github.com/user-attachments/assets/50227d61-f285-4957-8198-0278e4d1d6a1)
![Untitled-1](https://github.com/user-attachments/assets/6be31a89-966f-4eec-aa75-368ae476d7bd)
![Untitled](https://github.com/user-attachments/assets/c523f26f-913e-4226-bc2e-dbf106898c9c)
![Untitled-1](https://github.com/user-attachments/assets/30638be3-b263-4847-ad83-b56cc78865b8)
![Untitled](https://github.com/user-attachments/assets/e0921664-a4fa-421a-9408-05ee137af161)
![Untitled-1](https://github.com/user-attachments/assets/869e40d1-4401-45d4-be6c-43b0dc24000a)
![Untitled](https://github.com/user-attachments/assets/bd71e99d-8e5a-4f7f-bd75-9e7330b0c40d)


### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : 15 mins
  - This PR's default :  23 mins

Both in the new cluster.
## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [ ] RSE review done (at least 1)
