### PR TITLE
Adjust US$2005 -> 2017 for data read from REMIND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **inputdata** changed GDP base year from 2005USD to 2017USD
 - **config** changed default input data to use 2017USD
 - **module_documentation** all references to USD05 changed to USD17
+- **scripts** REMIND coupling reads data in US$2017, not US$2005
 
 ### added
 -

--- a/scripts/start/extra/emulator.R
+++ b/scripts/start/extra/emulator.R
@@ -59,9 +59,9 @@ write.ghgtax <- function(mifname, outfile) {
   tmp <- read.report(fname, as.list = FALSE)
 
   # Select variables from REMIND report
-  ghg_price_names <- c("Price|Carbon (US$2005/t CO2)",
-                       "Price|N2O (US$2005/t N2O)",
-                       "Price|CH4 (US$2005/t CH4)")
+  ghg_price_names <- c("Price|Carbon (US$2017/t CO2)",
+                       "Price|N2O (US$2017/t N2O)",
+                       "Price|CH4 (US$2017/t CH4)")
   tmp <- collapseNames(tmp[,,ghg_price_names])
   # remove global dimension
   tmp <- tmp["GLO",,,invert=TRUE]
@@ -72,11 +72,11 @@ write.ghgtax <- function(mifname, outfile) {
 
   ghgtax <- new.magpie(cells_and_regions = getRegions(tmp),years = time,fill = NA,sets = c("regions","years","gas"),names = c("n2o_n_direct","n2o_n_indirect","ch4","co2_c"))
 
-  # unit defined in modules/56_ghg_policy/input/f56_pollutant_prices.cs3: US$ 2005 per Mg N2O-N CH4 and CO2-C
-  ghgtax[,,"co2_c"]          <- tmp[,,"Price|Carbon (US$2005/t CO2)"] * 44/12  # US$2005/tCO2 -> US$2005/tC
-  ghgtax[,,"ch4"]            <- tmp[,,"Price|CH4 (US$2005/t CH4)"]
-  ghgtax[,,"n2o_n_direct"]   <- tmp[,,"Price|N2O (US$2005/t N2O)"] * 44/28     # US$2005/tN2O -> US$2005/tN
-  ghgtax[,,"n2o_n_indirect"] <- tmp[,,"Price|N2O (US$2005/t N2O)"] * 44/28     # US$2005/tN2O -> US$2005/tN
+  # unit defined in modules/56_ghg_policy/input/f56_pollutant_prices.cs3: US$ 2017 per Mg N2O-N CH4 and CO2-C
+  ghgtax[,,"co2_c"]          <- tmp[,,"Price|Carbon (US$2017/t CO2)"] * 44/12  # US$2017/tCO2 -> US$2017/tC
+  ghgtax[,,"ch4"]            <- tmp[,,"Price|CH4 (US$2017/t CH4)"]
+  ghgtax[,,"n2o_n_direct"]   <- tmp[,,"Price|N2O (US$2017/t N2O)"] * 44/28     # US$2017/tN2O -> US$2017/tN
+  ghgtax[,,"n2o_n_indirect"] <- tmp[,,"Price|N2O (US$2017/t N2O)"] * 44/28     # US$2017/tN2O -> US$2017/tN
 
   # set ghg prices before and in 2020 to zero
   ghgtax[,getYears(ghgtax)<="y2020",] <- 0
@@ -89,7 +89,7 @@ write.ghgtax <- function(mifname, outfile) {
   cat("CO2 price in 2025:",ghgtax[,2025,"co2_c"],"\n")
   for_plot <- ghgtax[1,,"co2_c"] * 12/44 # convert unit back just for plotting
   #for_plot <- for_plot[,c("y1995","y2110","y2130","y2150"),,invert=TRUE]
-  txtplot(as.numeric(gsub("y","",getYears(for_plot))),for_plot,ylab="US$2005/tCO2")
+  txtplot(as.numeric(gsub("y","",getYears(for_plot))),for_plot,ylab="US$2017/tCO2")
 
   cat("Writing GHG tax scenario",scenarios[scen,"ghgtax_name"],"\n\n")
   write.magpie(ghgtax, file_name = outfile)

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -555,16 +555,16 @@ getReportData <- function(path_to_report_bioenergy, path_to_report_ghgprices = N
   }
 
   .emissionPrices <- function(mag){
-    out_c <- mag[,,"Price|Carbon (US$2005/t CO2)"]*44/12 # US$2005/tCO2 -> US$2005/tC
+    out_c <- mag[,,"Price|Carbon (US$2017/t CO2)"]*44/12 # US$2017/tCO2 -> US$2017/tC
     dimnames(out_c)[[3]] <- "co2_c"
 
-    out_n2o_direct <- mag[,,"Price|N2O (US$2005/t N2O)"]*44/28 # US$2005/tN2O -> US$2005/tN
+    out_n2o_direct <- mag[,,"Price|N2O (US$2017/t N2O)"]*44/28 # US$2017/tN2O -> US$2017/tN
     dimnames(out_n2o_direct)[[3]] <- "n2o_n_direct"
 
-    out_n2o_indirect <- mag[,,"Price|N2O (US$2005/t N2O)"]*44/28 # US$2005/tN2O -> US$2005/tN
+    out_n2o_indirect <- mag[,,"Price|N2O (US$2017/t N2O)"]*44/28 # US$2017/tN2O -> US$2017/tN
     dimnames(out_n2o_indirect)[[3]] <- "n2o_n_indirect"
 
-    out_ch4 <- mag[,,"Price|CH4 (US$2005/t CH4)"]
+    out_ch4 <- mag[,,"Price|CH4 (US$2017/t CH4)"]
     dimnames(out_ch4)[[3]] <- "ch4"
 
     out <- mbind(out_n2o_direct,out_n2o_indirect,out_ch4,out_c)


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- REMIND reports in US$2017 now, so MAgPIE only finds those data if it searches for US$2017. That also fits to [these lines](https://github.com/magpiemodel/magpie/blob/8ef5c646587bbea38b48357a541a6bfa8f1c897f/modules/56_ghg_policy/price_aug22/input.gms#L108-L112) where the data is expected in `USD17MER per t`.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`. Warns that `File f31_pastr_suitability.cs2 seems to be missing!` which seems to be unrelated
    - run `make test-coupled` using REMIND develop

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
