### PR TITLE
switch to turn off future bioplastic demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **module_documentation** all references to USD05 changed to USD17
 
 ### added
--
+- **62_material** added switch to turn off future material demand for bioplastic
 
 ### removed
 -

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -1941,11 +1941,16 @@ cfg$gms$material <- "exo_flexreg_apr16"
 # * defined by the maximum demand for bioplastics s62_max_dem_bioplastics
 # * (in mio. tonnes) and the midpoint s62_midpoint_dem_bioplastics (i.e.
 # * where bioplastic demand is half of the maximum demand).
-# * If maximum demand is 0, biomass demand for bioplastic production is not included.
+# * If s62_include_bioplastic is set to 0, future biomass demand for bioplastic
+# * production is not included. Otherwise, bioplastic demand is either kept
+# * constant at the value of 2020 (if s62_max_dem_bioplastics is set to 0)
+# * or follows a logistic curve with the specified maximum demand and
+# * midpoint (s62_midpoint_dem_bioplastic).
 # * Projected total plastic use in the "Global Ambiton" scneario of the OECD is
 # * about 600 mio. tonnes in 2050 -> E.g. 200 mio. tonnes in 2050 could be a
 # * reasonable (but ambitious) bioplastic scenario. With midpoint 2050 this
 # * would mean s62_max_dem_bioplastic = 400.
+cfg$gms$s62_include_bioplastic      <- 1                 # def = 1
 cfg$gms$s62_max_dem_bioplastic      <- 0                 # def = 0
 cfg$gms$s62_midpoint_dem_bioplastic <- 2050              # def = 2050
 

--- a/modules/62_material/exo_flexreg_apr16/input.gms
+++ b/modules/62_material/exo_flexreg_apr16/input.gms
@@ -27,5 +27,6 @@ $offdelim
 /
 ;
 
+scalar s62_include_bioplastic switch whether future bioplastic demand should be included (0 or 1) / 0 /;
 scalar s62_max_dem_bioplastic maximum demand for bioplastics (mio. tDM per yr) / 0 /;
 scalar s62_midpoint_dem_bioplastic midpoint of logistic function for bioplastic demand (yr) / 2050 /;

--- a/modules/62_material/exo_flexreg_apr16/input.gms
+++ b/modules/62_material/exo_flexreg_apr16/input.gms
@@ -27,6 +27,6 @@ $offdelim
 /
 ;
 
-scalar s62_include_bioplastic switch whether future bioplastic demand should be included (0 or 1) / 0 /;
+scalar s62_include_bioplastic switch whether future bioplastic demand should be included (0 or 1) / 1 /;
 scalar s62_max_dem_bioplastic maximum demand for bioplastics (mio. tDM per yr) / 0 /;
 scalar s62_midpoint_dem_bioplastic midpoint of logistic function for bioplastic demand (yr) / 2050 /;

--- a/modules/62_material/exo_flexreg_apr16/preloop.gms
+++ b/modules/62_material/exo_flexreg_apr16/preloop.gms
@@ -9,9 +9,9 @@
  p62_dem_food_lastcalibyear(i) = 1;
  p62_dem_bioplastic(t,i) = 0;
 
-* Bioplastic demand is based on historic values up to 2020, and either kept constant for
-* future years, or following a logistic function with given midpoint and maximum if a 
-* bioplastic production target is exogenously set. 
+* Bioplastic demand is based on historic values up to 2020, and either set to zero for 
+* future years, kept constant at the value of 2020, or following a logistic function with 
+* given midpoint and maximum if a bioplastic production target is exogenously set. 
 * Global bioplastic demand is distributed to regions proportional to population due to lack of better data.
 
 p62_dem_bioplastic(t,i) = f62_hist_dem_bioplastic(t) * (im_pop(t,i) / sum(i2, im_pop(t,i2)));
@@ -20,6 +20,10 @@ p62_dem_bioplastic(t,i)$(m_year(t)>2020) = f62_hist_dem_bioplastic("y2020") * (i
 if (s62_max_dem_bioplastic <> 0,
   s62_growth_rate_bioplastic = log((s62_max_dem_bioplastic/f62_hist_dem_bioplastic("y2020")) - 1)/(s62_midpoint_dem_bioplastic-2020);
   p62_dem_bioplastic(t,i)$(m_year(t)>2020) = s62_max_dem_bioplastic / (1 + exp(-s62_growth_rate_bioplastic*(m_year(t)-s62_midpoint_dem_bioplastic))) * (im_pop(t,i) / sum(i2, im_pop(t,i2)));
+);
+
+if (s62_include_bioplastic = 0,
+  p62_dem_bioplastic(t,i)$(m_year(t)>2020) = 0;
 );
 
 * translate bioplastic demand to biomass demand using conversion factors between bioplastic and the different biomass sources

--- a/modules/62_material/exo_flexreg_apr16/presolve.gms
+++ b/modules/62_material/exo_flexreg_apr16/presolve.gms
@@ -30,5 +30,9 @@ if (sum(sameas(t_past,t),1) = 1,
   p62_bioplastic_substrate_double_counted(t,i,kall) = p62_bioplastic_substrate(t,i,kall);
   p62_bioplastic_substrate_lastcalibyear(i,kall) = p62_bioplastic_substrate(t,i,kall);
 else
-  p62_bioplastic_substrate_double_counted(t,i,kall) = p62_bioplastic_substrate_lastcalibyear(i,kall) * p62_scaling_factor(i);
+  if (s62_include_bioplastic = 0,
+    p62_bioplastic_substrate_double_counted(t,i,kall) = 0;
+  else
+    p62_bioplastic_substrate_double_counted(t,i,kall) = p62_bioplastic_substrate_lastcalibyear(i,kall) * p62_scaling_factor(i);
+  );
 );


### PR DESCRIPTION
## :bird: Description of this PR :bird:

This PR adds a switch to turn off future bioplastic demand (instead of keeping it constant at 2020 values or increasing demand to an exogenously set target). This option is necessary, as both `begr` and `betr` are used as biomass for bioplastics, which is in conflict with `c30_bioen_type` set to `begr` or `betr` only (fixing the production of the respective other to zero).

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

![image](https://github.com/user-attachments/assets/6322fb60-b139-4b51-8319-8ca383248bda)

With the new option, we get a spike in bioplastic demand in 2020. However, values are very low and the difference between keeping bioplastic demand constant or setting it to zero does not affect e.g. crop patterns.

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : 25:06 mins
  - This PR's default :  25:29 mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
