### PR TITLE
bugfix tree cover on cropland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### fixed
 - **11_costs** changed equation to fix bug in total water cost calculation 
+- **29_cropland** treecover age-class growth was not working properly because ac_sub was erroneously not fixed 
 
 
 ## [4.8.2] - 2024-09-24

--- a/modules/29_cropland/detail_apr24/presolve.gms
+++ b/modules/29_cropland/detail_apr24/presolve.gms
@@ -64,11 +64,10 @@ if (s29_treecover_keep = 1,
  i29_treecover_target(t,j)$(i29_treecover_target(t,j) < pc29_treecover_share(j)) = pc29_treecover_share(j);
 );
 
-* Bounds for treecover. Only ac_est can increase in optimization. ac_sub can only decrease.
+* Bounds for treecover. Only ac_est can increase in optimization. ac_sub is fixed.
 v29_treecover.lo(j,ac_est) = 0;
 v29_treecover.up(j,ac_est) = Inf;
-v29_treecover.lo(j,ac_sub) = 0;
-v29_treecover.up(j,ac_sub) = pc29_treecover(j,ac_sub);
+v29_treecover.fx(j,ac_sub) = pc29_treecover(j,ac_sub);
 m_boundfix(v29_treecover,(j,ac_sub),l,1e-6);
 
 * set treecover penalty

--- a/scripts/start/projects/project_ABCDR.R
+++ b/scripts/start/projects/project_ABCDR.R
@@ -19,7 +19,7 @@ source("config/default.cfg")
 #download_and_update(cfg)
 
 # create additional information to describe the runs
-cfg$info$flag <- "ABCDR12"
+cfg$info$flag <- "ABCDR13"
 
 cfg$results_folder <- "output/:title:"
 cfg$force_replace <- TRUE


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- **29_cropland** treecover age-class growth was not working properly because ac_sub was erroneously not fixed 

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
