### PR TITLE
bugfix warning in highres output script

### DIFF
--- a/scripts/output/extra/highres.R
+++ b/scripts/output/extra/highres.R
@@ -161,11 +161,11 @@ highres <- function(cfg = cfg, res = "c1000", tc = NULL) {
   a <- readGDX(gdx,"f60_bioenergy_dem_emulator", react = "silent")
   if(!is.null(a)) write.magpie(a,"modules/60_bioenergy/input/glo.2ndgen_bioenergy_demand.csv")
 
-  #get regional afforestation patterns from low resolution run with c200
+  #get regional afforestation/reforestation (AR) patterns from low resolution run with c200
   aff <- dimSums(landForestry(gdx)[,,c("aff","ndc")],dim=3)
-  #Take away initial NDC area for consistency with global afforestation limit
+  #Take away initial NDC area for consistency with global AR limit
   aff <- aff-setYears(aff[,1,],NULL)
-  #calculate maximum regional afforestation over time
+  #calculate maximum regional AR over time
   aff_max <- setYears(aff[,1,],NULL)
   for (r in getRegions(aff)) {
     aff_max[r,,] <- max(aff[r,,])
@@ -173,10 +173,10 @@ highres <- function(cfg = cfg, res = "c1000", tc = NULL) {
   aff_max[aff_max < 0] <- 0
   write.magpie(aff_max,"modules/32_forestry/input/f32_max_aff_area.cs4")
   cfg$gms$s32_max_aff_area_glo <- 0
-  #check
+  #check if regional AR exceeds global AR limit
   if(cfg$gms$s32_max_aff_area < Inf) {
-    indicator <- abs(sum(aff_max)-cfg$gms$s32_max_aff_area)
-    if(indicator > 1e-06) warning(paste("Global and regional afforestation limit differ by",indicator,"Mha"))
+    indicator <- sum(aff_max)-cfg$gms$s32_max_aff_area
+    if(indicator > 1e-06) warning(paste("Regional AR exceeds global AR limit by",indicator,"Mha"))
   }
 
   Sys.sleep(2)


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- improved check if regional AR exceeds global AR limit

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [ ] RSE review done (at least 1)
