### PR TITLE
hotfix for rds_report.R output script: fix units in "report.rds" file

### DIFF
--- a/scripts/output/rds_report.R
+++ b/scripts/output/rds_report.R
@@ -48,6 +48,7 @@ for (mapping in c("AR6", "NAVIGATE", "SHAPE", "AR6_MAgPIE")) {
 }
 
 write.report(report, file = mif)
+report <- read.report(file = mif, as.list=F)
 
 q <- as.quitte(report)
 # as.quitte converts "World" into "GLO". But we want to keep "World" and therefore undo these changes

--- a/scripts/output/rds_report.R
+++ b/scripts/output/rds_report.R
@@ -39,7 +39,7 @@ resultsarchive <- "/p/projects/rd3mod/models/results/magpie"
 report <- getReport(gdx, scenario = cfg$title, dir = outputdir)
 
 for (mapping in c("AR6", "NAVIGATE", "SHAPE", "AR6_MAgPIE")) {
-  missingVariables <- sort(setdiff(unique(deletePlus(getMappingVariables(mapping,"M"))),unique(deletePlus(getNames(report,dim="variable")))))
+  missingVariables <- sort(setdiff(unique(deletePlus(getMappingVariables(mapping, "M"))), unique(deletePlus(getNames(report, dim = "variable")))))
   if (length(missingVariables) > 0) {
     warning("# The following ", length(missingVariables), " variables are expected in the piamInterfaces package ",
             "for mapping ", mapping, ", but cannot be found in the MAgPIE report.\nPlease either fix in magpie4 or adjust the mapping in piamInterfaces.\n- ",
@@ -48,7 +48,7 @@ for (mapping in c("AR6", "NAVIGATE", "SHAPE", "AR6_MAgPIE")) {
 }
 
 write.report(report, file = mif)
-report <- read.report(file = mif, as.list=F)
+report <- read.report(file = mif, as.list = FALSE)
 
 q <- as.quitte(report)
 # as.quitte converts "World" into "GLO". But we want to keep "World" and therefore undo these changes

--- a/scripts/output/rds_report_iso.R
+++ b/scripts/output/rds_report_iso.R
@@ -32,6 +32,10 @@ rds_iso <- paste0(outputdir, "/report_iso.rds")
 
 report <- getReportIso(gdx, scenario = cfg$title, dir = outputdir)
 
+mif <- sub(".rds",".mif",rds_iso)
+write.report(report, file = mif, scenario = cfg$title)
+report <- read.report(file = mif, as.list=F)
+
 q <- as.quitte(report)
 # as.quitte converts "World" into "GLO". But we want to keep "World" and therefore undo these changes
 q <- droplevels(q)

--- a/scripts/output/rds_report_iso.R
+++ b/scripts/output/rds_report_iso.R
@@ -34,7 +34,7 @@ report <- getReportIso(gdx, scenario = cfg$title, dir = outputdir)
 
 mif <- sub(".rds",".mif",rds_iso)
 write.report(report, file = mif, scenario = cfg$title)
-report <- read.report(file = mif, as.list=F)
+report <- read.report(file = mif, as.list = FALSE)
 
 q <- as.quitte(report)
 # as.quitte converts "World" into "GLO". But we want to keep "World" and therefore undo these changes


### PR DESCRIPTION
## :bird: Description of this PR :bird:

With the most up-to-date R packages, units in `report.rds` are missing. 
Therefore, results don't show up in `shinyresults::appResults()`
I guess the problem comes from `as.quitte(report)` and might be related to the use $ signs in our reporting.
The file `report.mif` seems fine. 
Reading this file again after writing solves the problem. 
I'm sure that there is a better solution than this hotfix but we need to be able to look at our results.
@pascal-sauer It would be great if you could have a look into this.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
