### PR TITLE
check variable + unit format in rds_report

### DIFF
--- a/scripts/output/rds_report.R
+++ b/scripts/output/rds_report.R
@@ -22,7 +22,7 @@ library(piamutils)
 options("magclass.verbosity" = 1)
 
 ############################# BASIC CONFIGURATION #############################
-if(!exists("source_include")) {
+if (!exists("source_include")) {
   outputdir <- "/p/projects/landuse/users/miodrag/projects/tests/flexreg/output/H12_setup1_2016-11-23_12.38.56/"
   readArgs("outputdir")
 }
@@ -57,20 +57,22 @@ for (mapping in c("AR6", "NAVIGATE", "SHAPE", "AR6_MAgPIE")) {
 
 write.report(report, file = mif)
 
-q <- as.quitte(report)
+qu <- as.quitte(report)
 # as.quitte converts "World" into "GLO". But we want to keep "World" and therefore undo these changes
-q <- droplevels(q)
-levels(q$region)[levels(q$region) == "GLO"] <- "World"
-q$region <- factor(q$region,levels = sort(levels(q$region)))
+qu <- droplevels(qu)
+levels(qu$region)[levels(qu$region) == "GLO"] <- "World"
+qu$region <- factor(qu$region,levels = sort(levels(qu$region)))
 
-if(all(is.na(q$value))) stop("No values in reporting!")
+if (all(is.na(qu$value))) {
+  stop("No values in reporting!")
+}
 
-saveRDS(q, file = rds, version = 2)
+saveRDS(qu, file = rds, version = 2)
 
-if(file.exists(runstatistics) & dir.exists(resultsarchive)) {
+if (file.exists(runstatistics) && dir.exists(resultsarchive)) {
   stats <- list()
   load(runstatistics)
-  if(is.null(stats$id)) {
+  if (is.null(stats$id)) {
     # create an id if it does not exist (which means that statistics have not
     # been saved to the archive before) and save statistics to the archive
     message("No id found in runstatistics.rda. Calling lucode2::runstatistics() to create one.")
@@ -82,9 +84,8 @@ if(file.exists(runstatistics) & dir.exists(resultsarchive)) {
   }
 
   # Save report to results archive
-  saveRDS(q, file = paste0(resultsarchive, "/", stats$id, ".rds"), version = 2)
-  cwd <- getwd()
-  setwd(resultsarchive)
-  system("find -type f -name '1*.rds' -printf '%f\n' | sort > fileListForShinyresults")
-  setwd(cwd)
+  saveRDS(qu, file = paste0(resultsarchive, "/", stats$id, ".rds"), version = 2)
+  withr::with_dir(resultsarchive, {
+    system("find -type f -name '1*.rds' -printf '%f\n' | sort > fileListForShinyresults")
+  })
 }

--- a/scripts/output/rds_report.R
+++ b/scripts/output/rds_report.R
@@ -37,6 +37,11 @@ resultsarchive <- "/p/projects/rd3mod/models/results/magpie"
 
 
 report <- getReport(gdx, scenario = cfg$title, dir = outputdir)
+if (!all(grepl(" \\(([^\\()]*)\\)($|\\.)", getNames(report, fulldim = TRUE)$variable))) {
+  warning("Variables should be in the format 'name (unit)', but the following are not:\n",
+          paste(grep(" \\(([^\\()]*)\\)($|\\.)", getNames(report, fulldim = TRUE)$variable,
+                     invert = TRUE, value = TRUE), collapse = "\n"))
+}
 
 for (mapping in c("AR6", "NAVIGATE", "SHAPE", "AR6_MAgPIE")) {
   missingVariables <- sort(setdiff(unique(deletePlus(getMappingVariables(mapping, "M"))), unique(deletePlus(getNames(report, dim = "variable")))))
@@ -48,7 +53,6 @@ for (mapping in c("AR6", "NAVIGATE", "SHAPE", "AR6_MAgPIE")) {
 }
 
 write.report(report, file = mif)
-report <- read.report(file = mif, as.list = FALSE)
 
 q <- as.quitte(report)
 # as.quitte converts "World" into "GLO". But we want to keep "World" and therefore undo these changes

--- a/scripts/output/rds_report.R
+++ b/scripts/output/rds_report.R
@@ -38,16 +38,19 @@ resultsarchive <- "/p/projects/rd3mod/models/results/magpie"
 
 report <- getReport(gdx, scenario = cfg$title, dir = outputdir)
 if (!all(grepl(" \\(([^\\()]*)\\)($|\\.)", getNames(report, fulldim = TRUE)$variable))) {
-  warning("Variables should be in the format 'name (unit)', but the following are not:\n",
+  warning("Variables should be in the format 'name (unit)' (the space between name and unit is important), ",
+          "but the following are not:\n",
           paste(grep(" \\(([^\\()]*)\\)($|\\.)", getNames(report, fulldim = TRUE)$variable,
                      invert = TRUE, value = TRUE), collapse = "\n"))
 }
 
 for (mapping in c("AR6", "NAVIGATE", "SHAPE", "AR6_MAgPIE")) {
-  missingVariables <- sort(setdiff(unique(deletePlus(getMappingVariables(mapping, "M"))), unique(deletePlus(getNames(report, dim = "variable")))))
+  missingVariables <- sort(setdiff(unique(deletePlus(getMappingVariables(mapping, "M"))),
+                                   unique(deletePlus(getNames(report, dim = "variable")))))
   if (length(missingVariables) > 0) {
     warning("# The following ", length(missingVariables), " variables are expected in the piamInterfaces package ",
-            "for mapping ", mapping, ", but cannot be found in the MAgPIE report.\nPlease either fix in magpie4 or adjust the mapping in piamInterfaces.\n- ",
+            "for mapping ", mapping, ", but cannot be found in the MAgPIE report.\n",
+            "Please either fix in magpie4 or adjust the mapping in piamInterfaces.\n- ",
             paste(missingVariables, collapse = ",\n- "), "\n")
   }
 }


### PR DESCRIPTION
## :bird: Description of this PR :bird:

With this PR we get a warning if the regex used in as.quitte does not match a variable. This should prevent the shiny missing unit issue in the future.

## :wrench: Checklist for PR creator :wrench:

- [ ] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [ ] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
