### PR TITLE
calibration and coupled NPI fixes in MitiConsv start script

### DIFF
--- a/scripts/start/projects/paper_MitiConsv.R
+++ b/scripts/start/projects/paper_MitiConsv.R
@@ -9,7 +9,7 @@
 # description: Land-based mitigation and habitat conservation
 # -------------------------------------------------------------
 
-rev <- "rev9"
+rev <- "rev14"
 
 cres <- "c200"
 
@@ -35,16 +35,11 @@ cfg$title <- "calib_run"
 cfg$output <- c("rds_report", "validation_short")
 cfg$force_replace <- TRUE
 
-cfg$recalibrate <- TRUE
-cfg$recalibrate_landconversion_cost <- TRUE
-
 cfg$best_calib <- TRUE
 cfg$best_calib_landconversion_cost <- FALSE
 
-cfg$gms$s14_use_yield_calib <- 1
-
 # cc is new default
-cfg <- setScenario(cfg, c("nocc_hist", "NPI", "ForestryExo"))
+cfg <- setScenario(cfg, c("SSP2","nocc_hist", "NPI", "ForestryExo"))
 cfg <- setScenario(cfg, c("MitiConsv"), scenario_config = "config/projects/scenario_config_miti_consv.csv")
 
 # sticky
@@ -98,9 +93,6 @@ for (scen in scenarios) {
   cfg <- setScenario(cfg, c(ssp, "nocc_hist", "NPI", "ForestryExo"))
   cfg <- setScenario(cfg, c("MitiConsv"), scenario_config = "config/projects/scenario_config_miti_consv.csv")
 
-  # Set path to coupled output
-  pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_Dec24/remind/output/C_rev5_MitiConsv_SSP2-NPi2025-rem-12/REMIND_generic_C_rev5_MitiConsv_SSP2-NPi2025-rem-12.mif"
-
   # sticky
   cfg$gms$factor_costs <- "sticky_feb18"
 
@@ -120,12 +112,22 @@ for (scen in scenarios) {
     cfg <- setScenario(cfg, "NDC")
     # Update path to coupled output
     pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_Dec24/remind/output/C_rev5_MitiConsv_SSP2-PkBudg650-rem-12/REMIND_generic_C_rev5_MitiConsv_SSP2-PkBudg650-rem-12.mif"
+    # Settings taken from coupled runs
+    cfg$gms$c56_pollutant_prices <- "coupling"
+    cfg$gms$c60_2ndgen_biodem <- "coupling"
+    cfg$path_to_report_ghgprices <- pathToCoupledOutput
+    cfg$path_to_report_bioenergy <- pathToCoupledOutput
   }
 
   if ("PB1000" %in% scen) {
     cfg <- setScenario(cfg, "NDC")
     # Update path to coupled output
     pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_Dec24/remind/output/C_rev5_MitiConsv_SSP2-PkBudg1000-rem-12/REMIND_generic_C_rev5_MitiConsv_SSP2-PkBudg1000-rem-12.mif"
+    # Settings taken from coupled runs
+    cfg$gms$c56_pollutant_prices <- "coupling"
+    cfg$gms$c60_2ndgen_biodem <- "coupling"
+    cfg$path_to_report_ghgprices <- pathToCoupledOutput
+    cfg$path_to_report_bioenergy <- pathToCoupledOutput
   }
 
   if ("30by30" %in% scen) {
@@ -135,12 +137,6 @@ for (scen in scenarios) {
   if ("BH" %in% scen) {
     cfg$gms$c22_protect_scenario <- "BH"
   }
-
-  # Settings taken from coupled runs
-  cfg$gms$c56_pollutant_prices <- "coupling"
-  cfg$gms$c60_2ndgen_biodem <- "coupling"
-  cfg$path_to_report_ghgprices <- pathToCoupledOutput
-  cfg$path_to_report_bioenergy <- pathToCoupledOutput
 
   cfg$title <- paste0(prefix, "_", paste(scen, collapse = "-"))
   start_run(cfg = cfg, codeCheck = FALSE)


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- There appeared to be an unexpected cropland trajectory due to issues in the NPI scenario in coupled runs. Also, the yield calibration led to strange behaviour. This PR takes care of this in the start script.

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
