### PR TITLE
Update land conversion cost calibration for cropland - FAO as target data set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **config.cfg** default for `cfg$gms$s29_treecover_max` changed from 0.4 to 1
 - **config.cfg** default for `cfg$gms$s29_fallow_max ` changed from 0.4 to 0
 - **config.cfg** default for `cfg$gms$s35_forest_damage ` changed from 2 to 0
+- **scripts** land conversion cost calibration for cropland - FAO as target data set instead of MAgPIEown
 
 ### added
 - **scenario_config.csv** added column `NPI-revert`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **config.cfg** default for `cfg$gms$s29_fallow_max ` changed from 0.4 to 0
 - **config.cfg** default for `cfg$gms$s35_forest_damage ` changed from 2 to 0
 - **scripts** land conversion cost calibration for cropland - FAO as target data set instead of MAgPIEown
+- **default.cfg** settings for  land conversion cost calibration updated
 
 ### added
 - **scenario_config.csv** added column `NPI-revert`

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports:
     gms (>= 0.24.0),
     here,
     iamc,
-    lucode2 (>= 0.36.0),
+    lucode2 (>= 0.51.1),
     luplot,
     luscale (>= 2.27.9),
     lusweave,

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ model source code via the R package goxygen
 package and run the main function (goxygen) in the main folder of the model.
 The resulting documentation can be found in the folder "doc".
 
-Please find a set of tutorials here https://magpiemodel.github.io/tutorials/.
+Please find a set of tutorials here https://magpiemodel.github.io/tutorials.
 This guide will give you a brief technical introduction in how to install, run and use the model
 and how to analyse the model output.
 

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -95,7 +95,7 @@ cfg$recalibrate_landconversion_cost <- "ifneeded" #def "ifneeded"
 # Up to which accuracy shall be recalibrated?
 cfg$calib_accuracy_landconversion_cost <- 0.01         # def = 0.01
 # What is the maximum number of iterations if the precision goal is not reached?
-cfg$calib_maxiter_landconversion_cost <- 40           # def = 40
+cfg$calib_maxiter_landconversion_cost <- 20           # def = 20
 # Restart from existing calibration factors (TRUE or FALSE)
 cfg$restart_landconversion_cost <- FALSE           # def = FALSE
 # Number of lowpass filter iterations applied on calibration factors
@@ -104,11 +104,15 @@ cfg$lowpass_filter_landconversion_cost <- 1        # def= 1
 # Set upper limit for cropland calibration factor
 cfg$cost_calib_max_landconversion_cost <- 3         # def= 3
 # Set lower limit for cropland calibration factor
-cfg$cost_calib_min_landconversion_cost <- 0.05            # def= 0.05
+cfg$cost_calib_min_landconversion_cost <- 0.2            # def= 0.2
 # Selection type of calibration factors.
 # If FALSE, calibration factors from the last iteration are used.
 # If TRUE, calibration factors from the iteration with the lowest divergence are used.
 cfg$best_calib_landconversion_cost <- FALSE     # def = FALSE
+# Target data set that will be used for cropland calibration at regional level 
+# * "MAgPIEown": same data set as used for initialization of cropland
+# * "FAO": Data from FAOSTAT on cropland area
+cfg$cost_calib_hist_data <- "FAO"            # def = "FAO"
 
 # Settings for NPI/NDC recalculation
 # * (TRUE): NPI/NDC recalculation will be performed

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -102,7 +102,7 @@ cfg$restart_landconversion_cost <- FALSE           # def = FALSE
 # for time steps 1995-2015
 cfg$lowpass_filter_landconversion_cost <- 1        # def= 1
 # Set upper limit for cropland calibration factor
-cfg$cost_calib_max_landconversion_cost <- 3         # def= 3
+cfg$cost_calib_max_landconversion_cost <- 2.5         # def= 2.5
 # Set lower limit for cropland calibration factor
 cfg$cost_calib_min_landconversion_cost <- 0.2            # def= 0.2
 # Selection type of calibration factors.

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -26,7 +26,7 @@ cfg$input <- c(regional    = "rev4.116_h12_magpie.tgz",
                cellular    = "rev4.116_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.116_h12_validation.tgz",
                additional  = "additional_data_rev4.60.tgz",
-               calibration = "calibration_H12_27Sep24.tgz")
+               calibration = "calibration_H12_FAO30_03Feb25.tgz")
 
 # NOTE: It is recommended to recalibrate the model when changing cellular input data
 #       as well as for any other setting that would affect initial values in the model,
@@ -100,7 +100,7 @@ cfg$calib_maxiter_landconversion_cost <- 20           # def = 20
 cfg$restart_landconversion_cost <- FALSE           # def = FALSE
 # Number of lowpass filter iterations applied on calibration factors
 # for time steps 1995-2015
-cfg$lowpass_filter_landconversion_cost <- 1        # def= 1
+cfg$lowpass_filter_landconversion_cost <- 0        # def= 0
 # Set upper limit for cropland calibration factor
 cfg$cost_calib_max_landconversion_cost <- 2.5         # def= 2.5
 # Set lower limit for cropland calibration factor

--- a/config/projects/scenario_config_fsec.csv
+++ b/config/projects/scenario_config_fsec.csv
@@ -79,6 +79,5 @@ gms$c73_build_demand;;;;;;;;;;;;;;;;;;;;;;;;50pc;;;;;;;;;;;;;;;;;;;;;;;;;;;
 input['cellular'];rev4.116_FSEC_3c888fa5_cellularmagpie_c200_MRI-ESM2-0-ssp460_lpjml-8e6c5eb1.tgz;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;rev4.116_FSEC_0bd54110_cellularmagpie_c200_MRI-ESM2-0-ssp119_lpjml-8e6c5eb1.tgz;rev4.116_FSEC_6819938d_cellularmagpie_c200_MRI-ESM2-0-ssp126_lpjml-8e6c5eb1.tgz;;rev4.116_FSEC_1b5c3817_cellularmagpie_c200_MRI-ESM2-0-ssp245_lpjml-8e6c5eb1.tgz;rev4.116_FSEC_3c888fa5_cellularmagpie_c200_MRI-ESM2-0-ssp460_lpjml-8e6c5eb1.tgz;rev4.116_FSEC_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz;rev4.116_FSEC_09a63995_cellularmagpie_c200_MRI-ESM2-0-ssp585_lpjml-8e6c5eb1.tgz;;;
 input['regional'];rev4.116_FSEC_magpie.tgz;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 input['validation'];rev4.116_FSEC_validation.tgz;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-input['additional'];additional_data_rev4.59.tgz;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-input['calibration'];calibration_FSEC_19Nov24.tgz;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+input['calibration'];calibration_FSEC_FAO_03Feb25.tgz;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 magicc_emis_scen;bjoernAR6_C_SSP2-NDC.mif;;;bjoernAR6_C_SSP2-PkBudg900.mif;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;bjoernAR6_C_SSP1-NDC.mif;;;;;;;;;;;;bjoernAR6_C_RemSDP-900-MagSSP1.mif;;

--- a/main.gms
+++ b/main.gms
@@ -160,13 +160,13 @@ $title magpie
 * md5sum: NA
 * Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
-* Used data set: additional_data_rev4.59.tgz
+* Used data set: additional_data_rev4.60.tgz
 * md5sum: NA
 * Repository: https://rse.pik-potsdam.de/data/magpie/public
 * 
-* Used data set: calibration_H12_27Sep24.tgz
-* md5sum: NA
-* Repository: https://rse.pik-potsdam.de/data/magpie/public
+* Used data set: calibration_H12_FAO30_03Feb25.tgz
+* md5sum: aba0b877f383fefabc558d79180fc43f
+* Repository: /Users/flo/Development/input_data/
 * 
 * Low resolution: c200
 * High resolution: 0.5
@@ -179,11 +179,11 @@ $title magpie
 * 
 * Regionscode: 62eff8f7
 * 
-* Regions data revision: 4.114
+* Regions data revision: 4.116
 * 
 * lpj2magpie settings:
 * * LPJmL data: MRI-ESM2-0:ssp370
-* * Revision: 4.114
+* * Revision: 4.116
 * 
 * aggregation settings:
 * * Input resolution: 0.5
@@ -195,7 +195,7 @@ $title magpie
 * * Call: withCallingHandlers(expr, message = messageHandler, warning = warningHandler,     error = errorHandler)
 * 
 * 
-* Last modification (input data): Sun Oct 27 00:37:36 2024
+* Last modification (input data): Thu Feb  6 14:08:31 2025
 * 
 *###################### R SECTION END (VERSION INFO) ###########################
 

--- a/scripts/calibration/landconversion_cost.R
+++ b/scripts/calibration/landconversion_cost.R
@@ -94,7 +94,7 @@ time_series_cost <- function(calib_factor) {
 
 time_series_reward <- function(calib_factor) {
   out2 <- new.magpie(getRegions(calib_factor), years = c(seq(1995, 2015, by = 5), seq(2050, 2150, by = 5)), fill = 0)
-  out2[, seq(2000, 2015, by = 5), ] <- calib_factor
+  out2[, getYears(calib_factor), ] <- calib_factor
   out2 <- time_interpolate(out2, seq(2020, 2050, by = 5), integrate_interpolated_years = T)
   return(out2)
 }
@@ -125,6 +125,7 @@ update_calib <- function(gdx_file, calib_accuracy = 0.01, lowpass_filter = 1, ca
 
   calib_factor_cost <- setNames(old_calib[, , "cost"], NULL) * calib_correction_cost
   calib_factor_reward <- setNames(old_calib[, , "reward"], NULL) * calib_correction_reward
+  calib_factor_reward[,1995,] <- 0
   calib_factor_reward[calib_factor_reward < 0] <- 0
   
   if (!start_flag) {
@@ -159,6 +160,10 @@ update_calib <- function(gdx_file, calib_accuracy = 0.01, lowpass_filter = 1, ca
     above_limit <- (calib_factor_cost >= cost_max)
     calib_factor_cost[above_limit] <- cost_max
     calib_divergence_cost[getRegions(calib_factor_cost), , ][above_limit] <- 0
+    
+    above_limit <- (calib_factor_reward >= cost_max)
+    calib_factor_reward[above_limit] <- cost_max
+    calib_divergence_reward[getRegions(calib_factor_reward), , ][above_limit] <- 0
   }
 
   if (!is.null(cost_min)) {

--- a/scripts/calibration/landconversion_cost.R
+++ b/scripts/calibration/landconversion_cost.R
@@ -150,8 +150,8 @@ update_calib <- function(gdx_file, calib_accuracy = 0.01, lowpass_filter = 1, ca
 
   if (!is.null(cost_max)) {
     # if reward exists, set cost calibration to cost_max
-    reward_exists <- (calib_factor_reward > 0)
-    calib_factor_cost[reward_exists] <- cost_max
+    # reward_exists <- (calib_factor_reward > 0)
+    # calib_factor_cost[reward_exists] <- cost_max
     
     # set value for India to cost_max for better convergence
     if ("IND" %in% getRegions(calib_factor_cost)) {

--- a/scripts/calibration/landconversion_cost.R
+++ b/scripts/calibration/landconversion_cost.R
@@ -35,7 +35,7 @@ calibration_run <- function(putfolder, calib_magpie_name, logoption = 3, s_use_g
 
 # get ratio between modelled area and reference area
 
-getCalibFactor <- function(gdx_file, mode = "cost", calib_accuracy = 0.05, lowpass_filter = 1, histData = "FAO") {
+getCalibFactor <- function(gdx_file, mode = "cost", calib_accuracy = 0.05, lowpass_filter = 1, histData = "FAO", cost_min = 0.2) {
   require(magclass)
   require(magpie4)
   require(gdx2)
@@ -65,7 +65,7 @@ getCalibFactor <- function(gdx_file, mode = "cost", calib_accuracy = 0.05, lowpa
     out[is.na(out)] <- 1
     getNames(out) <- NULL
     out[out < 0] <- 1
-    out[,1,] <- 0
+    out[,1,] <- cost_min
   } else if (mode == "reward") {
     shrLostProj <- new.magpie(getRegions(magpie), getYears(magpie), fill = 0)
     shrLostHist <- new.magpie(getRegions(magpie), getYears(magpie), fill = 0)

--- a/scripts/calibration/landconversion_cost.R
+++ b/scripts/calibration/landconversion_cost.R
@@ -40,7 +40,6 @@ getCalibFactor <- function(gdx_file, mode = "cost", calib_accuracy = 0.05, lowpa
   require(magpie4)
   require(gdx2)
   y <- readGDX(gdx_file,"t")
-  y <- seq(1995,2015,by=5)
   magpie <- land(gdx_file)[, y, "crop"]
   if (histData == "MAgPIEown") {
     hist <- dimSums(readGDX(gdx_file, "f10_land")[, , "crop"], dim = 1.2)
@@ -107,7 +106,7 @@ time_series_reward <- function(calib_factor) {
 }
 
 # Calculate the correction factor and save it
-update_calib <- function(gdx_file, calib_accuracy = 0.01, lowpass_filter = 1, calib_file, cost_max = 3, cost_min = 0.2, calibration_step = "", n_maxcalib = 20, best_calib = FALSE, histData = "FAO") {
+update_calib <- function(gdx_file, calib_accuracy = 0.01, lowpass_filter = 1, calib_file, cost_max = 2.5, cost_min = 0.2, calibration_step = "", n_maxcalib = 20, best_calib = FALSE, histData = "FAO") {
   require(magclass)
   require(magpie4)
   require(gdx2)
@@ -149,10 +148,7 @@ update_calib <- function(gdx_file, calib_accuracy = 0.01, lowpass_filter = 1, ca
   }
 
   if (!is.null(cost_max)) {
-    # if reward exists, set cost calibration to cost_max
-    # reward_exists <- (calib_factor_reward > 0)
-    # calib_factor_cost[reward_exists] <- cost_max
-    
+
     # set value for India to cost_max for better convergence
     if ("IND" %in% getRegions(calib_factor_cost)) {
       calib_factor_cost["IND", -1 , ] <- cost_max
@@ -169,9 +165,6 @@ update_calib <- function(gdx_file, calib_accuracy = 0.01, lowpass_filter = 1, ca
     calib_factor_cost[above_limit] <- cost_max
     calib_divergence_cost[getRegions(calib_factor_cost), , ][above_limit] <- 0
     
-    # above_limit <- (calib_factor_reward >= cost_max)
-    # calib_factor_reward[above_limit] <- cost_max
-    # calib_divergence_reward[getRegions(calib_factor_reward), , ][above_limit] <- 0
   }
 
   if (!is.null(cost_min)) {
@@ -268,7 +261,7 @@ update_calib <- function(gdx_file, calib_accuracy = 0.01, lowpass_filter = 1, ca
 calibrate_magpie <- function(n_maxcalib = 20,
                              restart = FALSE,
                              calib_accuracy = 0.01,
-                             cost_max = 3,
+                             cost_max = 2.5,
                              cost_min = 0.2,
                              calib_magpie_name = "magpie_calib",
                              lowpass_filter = 1,

--- a/scripts/calibration/landconversion_cost.R
+++ b/scripts/calibration/landconversion_cost.R
@@ -35,15 +35,27 @@ calibration_run <- function(putfolder, calib_magpie_name, logoption = 3, s_use_g
 
 # get ratio between modelled area and reference area
 
-getCalibFactor <- function(gdx_file, mode = "cost", calib_accuracy = 0.05, lowpass_filter = 1) {
+getCalibFactor <- function(gdx_file, mode = "cost", calib_accuracy = 0.05, lowpass_filter = 1, histData = "FAO") {
   require(magclass)
   require(magpie4)
   require(gdx2)
   y <- readGDX(gdx_file,"t")
   magpie <- land(gdx_file)[, y, "crop"]
-  hist <- dimSums(readGDX(gdx_file, "f10_land")[, , "crop"], dim = 1.2)
-  data <- hist[, y, "crop"]
-  shrLost <- (setYears(hist[getRegions(magpie), 2015, ], NULL) - setYears(hist[getRegions(magpie), 1995, ], NULL)) / setYears(hist[getRegions(magpie), 1995, ], NULL)
+  if (histData == "MAgPIEown") {
+    hist <- dimSums(readGDX(gdx_file, "f10_land")[, , "crop"], dim = 1.2)
+    data <- hist[, y, "crop"]
+  } else if (histData == "FAO") {
+    if(file.exists("calib_data.rds")) {
+      val <- readRDS("calib_data.rds")
+    } else {
+      val <- read.report("input/validation.mif", as.list = FALSE)
+      val <- val[getRegions(magpie),getYears(magpie),"historical.FAO_crop_past.Resources|Land Cover|+|Cropland (million ha)"]
+      names(dimnames(val)) <- names(dimnames(magpie))
+      getNames(val) <- "crop"
+      saveRDS(val, file = "calib_data.rds")
+    }
+    data <- val
+  }
   if (nregions(magpie) != nregions(data) | !all(getRegions(magpie) %in% getRegions(data))) {
     stop("Regions in MAgPIE do not agree with regions in reference calibration area data set!")
   }
@@ -54,16 +66,19 @@ getCalibFactor <- function(gdx_file, mode = "cost", calib_accuracy = 0.05, lowpa
     getNames(out) <- NULL
 
     out[which(out < 0, arr.ind = T)] <- 1
+    out <- lowpass(out,i = lowpass_filter)
   } else if (mode == "reward") {
-    out <- magpie / data - 1
+    shrLostProj <- (setYears(magpie[, 2015, ], NULL) - setYears(magpie[, 1995, ], NULL)) / setYears(magpie[, 1995, ], NULL)
+    shrLostHist <- (setYears(data[getRegions(magpie), 2015, ], NULL) - setYears(data[getRegions(magpie), 1995, ], NULL)) / setYears(data[getRegions(magpie), 1995, ], NULL)
+    out <- shrLostHist/shrLostProj
     out[is.na(out)] <- 0
+    out[is.infinite(out)] <- 0
     getNames(out) <- NULL
-
+    
     # only reward if share of cropland lost between 1995 and 2015 exceeds a certain threshold. Otherwise set to 0.
-    out[rownames(which(shrLost > -calib_accuracy, arr.ind = T)),,] <- 0
+    out[rownames(which(shrLostHist > -calib_accuracy, arr.ind = T)),,] <- 0
     out[which(out < 0, arr.ind = T)] <- 0
   }
-  out <- lowpass(out,i = lowpass_filter)
   return(magpiesort(out))
 }
 
@@ -79,19 +94,13 @@ time_series_cost <- function(calib_factor) {
 
 time_series_reward <- function(calib_factor) {
   out2 <- new.magpie(getRegions(calib_factor), years = c(seq(1995, 2015, by = 5), seq(2050, 2150, by = 5)), fill = 0)
-  out2[, getYears(calib_factor), ] <- calib_factor
+  out2[, seq(2000, 2015, by = 5), ] <- calib_factor
   out2 <- time_interpolate(out2, seq(2020, 2050, by = 5), integrate_interpolated_years = T)
   return(out2)
 }
 
-getHistCrop <- function() {
-  rep <- read.report("input/validation.mif", as.list = FALSE)
-  crop <- collapseNames(rep[, , "historical.FAO_crop_past.Resources|Land Cover|+|Cropland (million ha)"])
-  return(crop)
-}
-
 # Calculate the correction factor and save it
-update_calib <- function(gdx_file, calib_accuracy = 0.05, lowpass_filter = 1, calib_file, cost_max = 3, cost_min = 0.05, calibration_step = "", n_maxcalib = 40, best_calib = FALSE) {
+update_calib <- function(gdx_file, calib_accuracy = 0.01, lowpass_filter = 1, calib_file, cost_max = 3, cost_min = 0.2, calibration_step = "", n_maxcalib = 20, best_calib = FALSE, histData = "FAO") {
   require(magclass)
   require(magpie4)
   require(gdx2)
@@ -103,7 +112,7 @@ update_calib <- function(gdx_file, calib_accuracy = 0.05, lowpass_filter = 1, ca
   calib_divergence_cost <- abs(calib_correction_cost - 1)
 
   calib_correction_reward <- getCalibFactor(gdx_file, mode = "reward", calib_accuracy = calib_accuracy, lowpass_filter = lowpass_filter)
-  calib_divergence_reward <- abs(calib_correction_reward)
+  calib_divergence_reward <- abs(calib_correction_reward - 1)
   
   ### -> in case it is the first step, it forces the initial factors to be equal to 1
   if (file.exists(calib_file)) {
@@ -111,12 +120,11 @@ update_calib <- function(gdx_file, calib_accuracy = 0.05, lowpass_filter = 1, ca
     start_flag <- FALSE
   } else {
     old_calib <- new.magpie(cells_and_regions = getCells(calib_divergence_cost), years = y, names = c("cost", "reward"), fill = 1)
-    old_calib[,,"reward"] <- 0
     start_flag <- TRUE
   }
 
   calib_factor_cost <- setNames(old_calib[, , "cost"], NULL) * calib_correction_cost
-  calib_factor_reward <- setNames(old_calib[, , "reward"], NULL) + calib_correction_reward
+  calib_factor_reward <- setNames(old_calib[, , "reward"], NULL) * calib_correction_reward
   calib_factor_reward[calib_factor_reward < 0] <- 0
   
   if (!start_flag) {
@@ -124,9 +132,11 @@ update_calib <- function(gdx_file, calib_accuracy = 0.05, lowpass_filter = 1, ca
     # use stricter divergence threshold in first 5 calibration_step steps
     cost_acc_reached <- calib_divergence_cost <= ifelse(calibration_step < 6, 0.01, calib_accuracy)
     calib_factor_cost[cost_acc_reached] <- setNames(old_calib[, , "cost"], NULL)[cost_acc_reached]
-
+    calib_correction_cost[cost_acc_reached] <- 1
+    
     reward_acc_reached <- calib_divergence_reward <= ifelse(calibration_step < 6, 0.01, calib_accuracy)
     calib_factor_reward[reward_acc_reached] <- setNames(old_calib[, , "reward"], NULL)[reward_acc_reached]
+    calib_correction_reward[reward_acc_reached] <- 0
   }
 
   if (!is.null(cost_max)) {
@@ -139,9 +149,11 @@ update_calib <- function(gdx_file, calib_accuracy = 0.05, lowpass_filter = 1, ca
       calib_factor_cost["IND", , ] <- cost_max
     }
     
-    # set value for CAZ to cost_max for better convergence
-    if ("CAZ" %in% getRegions(calib_factor_cost)) {
-      calib_factor_cost["CAZ", , ] <- cost_max
+    # set value for CAZ to cost_max for better convergence; only needed for LUH2 due to mismatch between LUH2 and FAO historical data for cropland.
+    if (histData == "MAgPIEown") {
+      if ("CAZ" %in% getRegions(calib_factor_cost)) {
+        calib_factor_cost["CAZ", , ] <- cost_max
+      }
     }
     
     above_limit <- (calib_factor_cost >= cost_max)
@@ -201,6 +213,7 @@ update_calib <- function(gdx_file, calib_accuracy = 0.05, lowpass_filter = 1, ca
         " unit: -",
         paste0(" note: Best calibration factor from the run"),
         " origin: scripts/calibration/landconversion_cost.R (path relative to model main directory)",
+        paste(" Calibration settings:",  "calib_accuracy=", calib_accuracy, "lowpass_filter=", lowpass_filter, "cost_max=", cost_max, "cost_min=", cost_min, "n_maxcalib=",n_maxcalib, "best_calib=",best_calib, "histData=",histData),
         paste0(" creation date: ", date())
       )
       write.magpie(round(calib_best_full, 3), calib_file, comment = comment)
@@ -227,6 +240,7 @@ update_calib <- function(gdx_file, calib_accuracy = 0.05, lowpass_filter = 1, ca
       " unit: -",
       paste0(" note: Calibration step ", calibration_step),
       " origin: scripts/calibration/landconversion_cost.R (path relative to model main directory)",
+      paste(" Calibration settings:",  "calib_accuracy=", calib_accuracy, "lowpass_filter=", lowpass_filter, "cost_max=", cost_max, "cost_min=", cost_min, "n_maxcalib=",n_maxcalib, "best_calib=",best_calib, "histData=",histData),
       paste0(" creation date: ", date())
     )
 
@@ -238,11 +252,11 @@ update_calib <- function(gdx_file, calib_accuracy = 0.05, lowpass_filter = 1, ca
 
 
 
-calibrate_magpie <- function(n_maxcalib = 40,
-                             restart = TRUE,
-                             calib_accuracy = 0.05,
+calibrate_magpie <- function(n_maxcalib = 20,
+                             restart = FALSE,
+                             calib_accuracy = 0.01,
                              cost_max = 3,
-                             cost_min = 0.05,
+                             cost_min = 0.2,
                              calib_magpie_name = "magpie_calib",
                              lowpass_filter = 1,
                              calib_file = "modules/39_landconversion/input/f39_calib.csv",
@@ -250,7 +264,8 @@ calibrate_magpie <- function(n_maxcalib = 40,
                              data_workspace = NULL,
                              logoption = 3,
                              debug = FALSE,
-                             best_calib = FALSE) {
+                             best_calib = FALSE,
+                             histData = "FAO") {
   require(magclass)
 
   if (!restart) {
@@ -280,6 +295,7 @@ calibrate_magpie <- function(n_maxcalib = 40,
   # delete calib_magpie_gms in the main folder
   unlink(paste0(calib_magpie_name, ".*"))
   unlink("fulldata.gdx")
+  unlink("calib_data.rds")
 
   cat("\nLand conversion cost calibration finished\n")
 }

--- a/scripts/calibration/landconversion_cost.R
+++ b/scripts/calibration/landconversion_cost.R
@@ -67,10 +67,8 @@ getCalibFactor <- function(gdx_file, mode = "cost", calib_accuracy = 0.05, lowpa
     out[out < 0] <- 1
     out <- lowpass(out,i = lowpass_filter)
   } else if (mode == "reward") {
-    shrLostProj <- new.magpie(getRegions(magpie), getYears(magpie), fill = 0)
     shrLostHist <- new.magpie(getRegions(magpie), getYears(magpie), fill = 0)
     for (i in 2:length(y)) {
-      shrLostProj[ , y[i], ] <- (setYears(magpie[, y[i], ], NULL) - setYears(magpie[, y[i-1], ], NULL)) / setYears(magpie[, y[i-1], ], NULL)
       shrLostHist[ , y[i], ] <- (setYears(data[, y[i], ], NULL) - setYears(data[, y[i-1], ], NULL)) / setYears(data[, y[i-1], ], NULL)
     }
     

--- a/scripts/start/extra/recalibrateH16.R
+++ b/scripts/start/extra/recalibrateH16.R
@@ -19,7 +19,7 @@ source("scripts/start_functions.R")
 source("config/default.cfg")
 cfg$input['regional'] <- "rev4.116_36f73207_magpie.tgz"
 cfg$input['validation'] <- "rev4.116_36f73207_validation.tgz"
-cfg$input['calibration'] <- "calibration_H16_27Sep24.tgz"
+cfg$input['calibration'] <- "calibration_H16_FAO_03Feb25.tgz"
 cfg$input['cellular'] <- "rev4.116_36f73207_44a213b6_cellularmagpie_c400_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1_clusterweight-ba4466a8.tgz"
 
 cfg$results_folder <- "output/:title:"

--- a/scripts/start/extra/recalibrateH16.R
+++ b/scripts/start/extra/recalibrateH16.R
@@ -30,4 +30,4 @@ cfg$output <- c("rds_report")
 cfg$force_replace <- TRUE
 cfg$qos <- "priority"
 start_run(cfg,codeCheck=FALSE)
-magpie4::submitCalibration("H16")
+magpie4::submitCalibration("H16_FAO")

--- a/scripts/start/extra/recalibrate_FSEC.R
+++ b/scripts/start/extra/recalibrate_FSEC.R
@@ -25,9 +25,8 @@ cfg$results_folder                  <- "output/:title:"
 cfg$recalibrate                     <- TRUE # required when penality_apr22 activated
 cfg$best_calib                      <- TRUE
 cfg$recalibrate_landconversion_cost <- TRUE
-cfg$best_calib_landconversion_cost  <- TRUE
 cfg$output                          <- c("rds_report")
 cfg$force_replace                   <- TRUE
 cfg$qos <- "priority"
 start_run(cfg, codeCheck = FALSE)
-magpie4::submitCalibration("FSEC")
+magpie4::submitCalibration("FSEC_FAO")

--- a/scripts/start/extra/recalibrate_default.R
+++ b/scripts/start/extra/recalibrate_default.R
@@ -25,4 +25,4 @@ cfg$output <- c("rds_report")
 cfg$force_replace <- TRUE
 cfg$qos <- "priority"
 start_run(cfg,codeCheck=FALSE)
-magpie4::submitCalibration("H12")
+magpie4::submitCalibration("H12_FAO")

--- a/scripts/start/projects/project_ABCDR.R
+++ b/scripts/start/projects/project_ABCDR.R
@@ -33,7 +33,7 @@ cfg$qos <- "standby_dayMax"
 
 cfg$input['regional'] <- "rev4.116_36f73207_magpie.tgz"
 cfg$input['validation'] <- "rev4.116_36f73207_validation.tgz"
-cfg$input['calibration'] <- "calibration_H16_27Sep24.tgz"
+cfg$input['calibration'] <- "calibration_H16_FAO_03Feb25.tgz"
 cfg$input['cellular'] <- "rev4.116_36f73207_bd86374e_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1_clusterweight-ba4466a8.tgz"
 
 ssp <- "SSP2"

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -476,7 +476,8 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE,
                      data_workspace = cfg$val_workspace,
                      logoption = 3,
                      debug = cfg$debug,
-                     best_calib = cfg$best_calib_landconversion_cost)
+                     best_calib = cfg$best_calib_landconversion_cost,
+                     histData = cfg$cost_calib_hist_data)
     cat("Land conversion cost calibration factor calculated!\n")
   }
 


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- **scripts** land conversion cost calibration for cropland - FAO as target data set instead of MAgPIEown
- **default.cfg** settings for  land conversion cost calibration updated

The file `f39_calib.csv` now includes meta information on the settings used for generating the calibration factors:
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/4eedbb82-0c24-4bfc-8ca4-a27cfe5a51cb" />

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

![Resources_Land_Cover_Cropland-133](https://github.com/user-attachments/assets/6e40d7da-6983-416f-9b82-1f42283d1609)
![Resources_Land_Cover_Cropland-134](https://github.com/user-attachments/assets/229d163e-8a54-4751-b2ad-fbc1ef7051eb)
![Productivity_Landuse_Intensity_Indicator_Tau-110](https://github.com/user-attachments/assets/72f62032-eece-44f1-87c5-5bcc3bb3b363)
![Emissions_CO2_Land_Land_use_Change-121](https://github.com/user-attachments/assets/817448a2-8a43-407d-bda9-4599d2f9ce58)


### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : 28.8 mins
  - This PR's default :  26.5 mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
