### PR TITLE
Added SNV20 constraint to SEALS coupling script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **15_food** tax recycling for income effect in elastic food demand
 - **scenario_config.csv** `cfg$gms$s56_minimum_cprice` no longer used for `NCD`
-- **config.cfg** default for `cfg$gms$cropland` changed from "simple_apr24" to "detail_apr24" 
+- **config.cfg** default for `cfg$gms$cropland` changed from "simple_apr24" to "detail_apr24"
 - **config.cfg** default for `cfg$gms$s29_treecover_max` changed from 0.4 to 1
 - **config.cfg** default for `cfg$gms$s29_fallow_max ` changed from 0.4 to 0
 - **config.cfg** default for `cfg$gms$s35_forest_damage ` changed from 2 to 0
 - **scripts** land conversion cost calibration for cropland - FAO as target data set instead of MAgPIEown
 - **default.cfg** settings for  land conversion cost calibration updated
 - **60_bioenergy** renamed `c60_bioenergy_subsidy` to `s60_bioenergy_1st_subsidy` to more clearly reflect its use and changed its unit to USD17MER per GJ. Adjusted `q60_bioenergy_incentive` accordingly
-- **60_bioenergy** renamed `s60_bioenergy_gj_price_1st` to `s60_bioenergy_1st_price` and `s60_bioenergy_price_2nd` to `s60_bioenergy_2nd_price` 
+- **60_bioenergy** renamed `s60_bioenergy_gj_price_1st` to `s60_bioenergy_1st_price` and `s60_bioenergy_price_2nd` to `s60_bioenergy_2nd_price`
 - **default.cfg** default for `s60_bioenergy_1st_subsidy` (formerly `c60_bioenergy_subsidy`) changed from 246 USD17MER per ton to 6.5 USD17MER per GJ based on mean GJ per ton of 1st generation bioenergy products.
 - **default.cfg** default for `cfg$gms$bioenergy` change from `1stgen_priced_dec18` to `1st2ndgen_priced_feb24`
 
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scenario_config.csv** added scenario `VLLO` based on `SDP-MC`
 - **default.cfg** added selection of low and middle-income countries `isoCountriesLowMiddleIncome`
 - **scripts** start script for ScenarioMIP MAgPIE standalone runs
+- **scripts** The constraint to maintain 20% semi-natural vegetation at the 1x1km scale is passed on to SEALS, if the setting is changed from the `default.cfg`
 
 ### removed
 - **modules/15_food/anthropometrics_jan18** removed as outdated

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -25,7 +25,7 @@ cfg$model <- "main.gms"   #def = "main.gms"
 cfg$input <- c(regional    = "rev4.116_h12_magpie.tgz",
                cellular    = "rev4.116_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.116_h12_validation.tgz",
-               additional  = "additional_data_rev4.60.tgz",
+               additional  = "additional_data_rev4.62.tgz",
                calibration = "calibration_H12_FAO30_03Feb25.tgz")
 
 # NOTE: It is recommended to recalibrate the model when changing cellular input data
@@ -109,7 +109,7 @@ cfg$cost_calib_min_landconversion_cost <- 0.2            # def= 0.2
 # If FALSE, calibration factors from the last iteration are used.
 # If TRUE, calibration factors from the iteration with the lowest divergence are used.
 cfg$best_calib_landconversion_cost <- FALSE     # def = FALSE
-# Target data set that will be used for cropland calibration at regional level 
+# Target data set that will be used for cropland calibration at regional level
 # * "MAgPIEown": same data set as used for initialization of cropland
 # * "FAO": Data from FAOSTAT on cropland area
 cfg$cost_calib_hist_data <- "FAO"            # def = "FAO"
@@ -184,7 +184,7 @@ isoCountriesEUR <- "ALB,AUT,BEL,BGR,CYP,CZE,DEU,DNK,ESP,EST,FIN,FRA,FRO,
                 NLD,POL,PRT,ROU,SVK,SVN,SWE"
 
 
-isoCountriesLowMiddleIncome <- 
+isoCountriesLowMiddleIncome <-
                      "ABW,AFG,AGO,AIA,ALA,AND,ARE,ARG,ARM,ASM,ATA,
                       ATF,ATG,AZE,BDI,BEN,BES,BFA,BGD,BHR,BHS,BLM,
                       BLR,BLZ,BMU,BOL,BRA,BRB,BRN,BTN,BVT,BWA,CAF,
@@ -1954,12 +1954,12 @@ cfg$gms$s60_bioenergy_1st_subsidy <- 6.5          # def = 6.5
 
 # * GJ-based bioenergy subsidy (USD17MER per GJ), only used in 1st2ndgen_priced_feb24
 # * Target prices for 1st and 2nd gen bioenergy
-# * These are used for bioenergy price sensitivy experiments. 
+# * These are used for bioenergy price sensitivy experiments.
 # * Caution: Prices above production cost likely create feedback loops with endogenous 13_tc, switch to exogenous to avoid.
 cfg$gms$s60_bioenergy_1st_price <- 0 # def = 0
 cfg$gms$s60_bioenergy_2nd_price <- 0 # def = 0
 
-# * Shape of price curve towards defined target price, reached in 2100. For years where the 1st generation price is 
+# * Shape of price curve towards defined target price, reached in 2100. For years where the 1st generation price is
 # * below s60_bioenergy_1st_subsidy, s60_bioenergy_1st_subsidy is used instead.
 # * Options: const, exp, lin
 # * (const): constant price equal to target price

--- a/scripts/output/extra/runSEALSallocation.R
+++ b/scripts/output/extra/runSEALSallocation.R
@@ -1,4 +1,4 @@
-# |  (C) 2008-2024 Potsdam Institute for Climate Impact Research (PIK)
+# |  (C) 2008-2025 Potsdam Institute for Climate Impact Research (PIK)
 # |  authors, and contributors see CITATION.cff file. This file is part
 # |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
 # |  AGPL-3.0, you are granted additional permissions described in the

--- a/scripts/output/extra/runSEALSallocation.R
+++ b/scripts/output/extra/runSEALSallocation.R
@@ -1,4 +1,4 @@
-# |  (C) 2008-2025 Potsdam Institute for Climate Impact Research (PIK)
+# |  (C) 2008-2024 Potsdam Institute for Climate Impact Research (PIK)
 # |  authors, and contributors see CITATION.cff file. This file is part
 # |  of MAgPIE and licensed under AGPL-3.0-or-later. Under Section 7 of
 # |  AGPL-3.0, you are granted additional permissions described in the
@@ -161,6 +161,15 @@ Sys.chmod(iniLock, mode = "0664")
     sealsCoeff[consvRow, "data_location"] <- sub(
       "WDPA", consv, sealsCoeff[consvRow, "data_location"]
     )
+
+    if (cfg$gms$s29_snv_shr == 0.2){
+      # snv policy reallocation incentive
+      snvRow1 <- which(sealsCoeff[, "spatial_regressor_name"] == "snv20_realloc")
+      sealsCoeff[snvRow1, c("forest", "othernat")] <- -100
+      # snv policy expansion constraint
+      snvRow2 <- which(sealsCoeff[, "spatial_regressor_name"] == "snv20_expan")
+      sealsCoeff[snvRow2, "cropland"] <- 0
+    }
 
     peatArea <- PeatlandArea(file.path(dir, "fulldata.gdx"))[, as.numeric(sealsYears), ]
     rewetSwitch <- dimSums(peatArea[, , "rewet"], dim = 1) / dimSums(peatArea, dim = c(1, 3)) > 0.01

--- a/scripts/output/extra/runSEALSallocation.R
+++ b/scripts/output/extra/runSEALSallocation.R
@@ -162,13 +162,17 @@ Sys.chmod(iniLock, mode = "0664")
       "WDPA", consv, sealsCoeff[consvRow, "data_location"]
     )
 
-    if (cfg$gms$s29_snv_shr == 0.2){
-      # snv policy reallocation incentive
-      snvRow1 <- which(sealsCoeff[, "spatial_regressor_name"] == "snv20_realloc")
-      sealsCoeff[snvRow1, c("forest", "othernat")] <- -100
-      # snv policy expansion constraint
-      snvRow2 <- which(sealsCoeff[, "spatial_regressor_name"] == "snv20_expan")
-      sealsCoeff[snvRow2, "cropland"] <- 0
+    if (cfg$gms$s29_snv_shr != 0) {
+      if (cfg$gms$s29_snv_shr == 0.2) {
+        # snv policy reallocation incentive
+        snvRow1 <- which(sealsCoeff[, "spatial_regressor_name"] == "snv20_realloc")
+        sealsCoeff[snvRow1, c("forest", "othernat")] <- -100
+        # snv policy expansion constraint
+        snvRow2 <- which(sealsCoeff[, "spatial_regressor_name"] == "snv20_expan")
+        sealsCoeff[snvRow2, "cropland"] <- 0
+      } else {
+        warning("Only if s29_snv_shr is 0.2 can it be explicitly considered at the 1x1km scale during the SEALS allocation.")
+      }
     }
 
     peatArea <- PeatlandArea(file.path(dir, "fulldata.gdx"))[, as.numeric(sealsYears), ]


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- The constraint to maintain 20% semi-natural vegetation at the 1x1km scale is passed on to SEALS

## :wrench: Checklist for PR creator :wrench:

- [ ] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [ ] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [ ] RSE review done (at least 1)
