### PR TITLE
Bugfix forestry prices and trade cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **73_timber** revised timber demand calculations 
 - **32_forestry** revised plantation establishment assumptions
 - **35_natveg** revised wood harvest assumptions
+- **32_forestry** timber plantation harvest is no longer enforced at rotation age to avoid conflicts with `q21_trade_reg_up`, which can result in huge costs and negative prices for wood
+- **21_trade** Cost for additional imports to maintain feasibility reduced from 12300 to 1500 USD17MER per tDM to avoid implausibly high costs and prices for wood and woodfuel
 
 ### added
 - **scripts** output script for testing elastic demand
@@ -45,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **32_forestry** added contraint `q32_ndc_aff_limit` to make sure that NPI/NDC re/afforestation does not happen at the cost of forests and other natural vegetation.
 - **35_natveg** added interface `vm_natforest_reduction`
 - **56_ghg_policy** bugfixes for regional GHG policy fader
+- **core/macro** wrong use of `vm_supply` corrected in macro `m21_baseline_production`
 
 
 ## [4.9.1] - 2025-01-28

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     m4fsdp,
     madrat,
     magclass (>= 6.14.0),
-    magpie4 (>= 2.17.0),
+    magpie4 (>= 2.18.2),
     MagpieNCGains,
     magpiesets (>= 0.46.1),
     mip,

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -608,7 +608,7 @@ cfg$gms$trade <- "selfsuff_reduced"             # def = selfsuff_reduced
 # * Commodities that can have additional imports to maintain feasibility
 cfg$gms$k_import21 <- "wood, woodfuel"
 # * Cost for additional imports to maintain feasibility in USD17MER per tDM
-cfg$gms$s21_cost_import <- 12300               # def = 10000 * 1.23
+cfg$gms$s21_cost_import <- 1500               # def = 1500
 
 # * trade balance reduction scenario
 # * (l909090r808080):   10 percent trade liberalisation for secondary and

--- a/core/macros.gms
+++ b/core/macros.gms
@@ -115,5 +115,5 @@ $macro m58_LandMerge(land,landForestry,set) \
 $macro m21_baseline_production(supply, excess_prod, self_suff) \
     ((sum(supreg(h2,i2),supply(i2,k_trade)) + excess_prod(h2,k_trade)) \
      $((sum(ct,self_suff(ct,h2,k_trade)) >= 1)) \
-     + (sum(supreg(h2,i2),vm_supply(i2,k_trade)) * sum(ct,self_suff(ct,h2,k_trade))) \
+     + (sum(supreg(h2,i2),supply(i2,k_trade)) * sum(ct,self_suff(ct,h2,k_trade))) \
        $((sum(ct,self_suff(ct,h2,k_trade)) < 1)))

--- a/modules/21_trade/selfsuff_reduced/input.gms
+++ b/modules/21_trade/selfsuff_reduced/input.gms
@@ -15,7 +15,7 @@ sets
 
 scalars
   s21_trade_tariff Trade tariff switch (1=on 0=off)  (1)                   / 1 /
-  s21_cost_import Cost for additional imports to maintain feasibility (USD17MER per tDM) / 12300 /
+  s21_cost_import Cost for additional imports to maintain feasibility (USD17MER per tDM) / 1500 /
   s21_min_trade_margin_forestry Minimum trade margin for forestry products (USD17MER per tDM) / 62 /
 ;
 

--- a/modules/21_trade/selfsuff_reduced_bilateral22/input.gms
+++ b/modules/21_trade/selfsuff_reduced_bilateral22/input.gms
@@ -18,7 +18,7 @@ scalars
   s21_trade_tariff_fadeout fadeout scenario setting for trade tariffs              / 0 / 
   s21_trade_tariff_startyear year to start fading out trade tariffs                / 2025 /
   s21_trade_tariff_targetyear year to finish fading out trade tariffs              / 2050 /
-  s21_cost_import Cost for additional imports to maintain feasibility (USD17MER per tDM) / 12300 /
+  s21_cost_import Cost for additional imports to maintain feasibility (USD17MER per tDM) / 1500 /
   s21_min_trade_margin_forestry Minimum trade margin for forestry products (USD17MER per tDM) / 62 /
 ;
 

--- a/modules/32_forestry/dynamic_may24/input.gms
+++ b/modules/32_forestry/dynamic_may24/input.gms
@@ -27,7 +27,7 @@ scalars
   s32_est_cost_plant              Establishment cost for plantations (USD17MER per ha) / 2460 /
   s32_est_cost_natveg             Establishment cost for natural vegetation (USD17MER per ha) / 2460 /
   s32_recurring_cost              Recurring costs (USD17MER per ha) / 615 /
-  s32_harvesting_cost             Harvesting cost (USD17MER per ha) / 2460 /
+  s32_harvesting_cost             Harvesting cost (USD17MER per ha) / 1230 /
   s32_planning_horizon             Afforestation planing horizon (years)            / 50 /
   s32_rotation_extension          Rotation extension factor 1=original rotations 2=100 percent increase in rotations etc (1) / 1 /
   s32_faustmann_rotation          Switch to activate faustmann rotations (1=on 0=off) / 0 /

--- a/modules/32_forestry/dynamic_may24/presolve.gms
+++ b/modules/32_forestry/dynamic_may24/presolve.gms
@@ -104,8 +104,8 @@ elseif s32_hvarea = 2,
 ** Fix timber plantations until the end of the rotation. "ac.off" identical to "ord(ac)-1".
 ** The offset is needed because the first element of ac is ac0, which is not included in p32_rotation_cellular_harvesting.
   v32_land.fx(j,"plant",ac)$(ac.off < p32_rotation_cellular_harvesting(t,j)) = pc32_land(j,"plant",ac);
-** After the rotation period, all plantations are harvested.
-  v32_land.fx(j,"plant",ac)$(ac.off >= p32_rotation_cellular_harvesting(t,j)) = 0;
+** After the rotation period, all plantations can be harvested.
+  v32_land.lo(j,"plant",ac)$(ac.off >= p32_rotation_cellular_harvesting(t,j)) = 0;
   s32_establishment_static = 0;
   s32_establishment_dynamic = 1;
 );

--- a/scripts/start/projects/project_ScenarioMIP.R
+++ b/scripts/start/projects/project_ScenarioMIP.R
@@ -21,7 +21,7 @@ source("scripts/start_functions.R")
 source("config/default.cfg")
 
 # create additional information to describe the runs
-cfg$info$flag <- "SMIP46"
+cfg$info$flag <- "SMIP47"
 
 cfg$results_folder <- "output/:title:"
 cfg$force_replace <- TRUE


### PR DESCRIPTION
## :bird: Description of this PR :bird:

In the current develop, we observe huge negative prices for wood in CHA in 2070, and huge costs for trade in 2070 in other regions. The reason for this is that we enfore harvest of timber plantations at rotation age. In the specific case above, this creates a conflict with equation `q21_trade_reg_up`. Put simply, enforced wood production from timber plantations is higher than allowed by `q21_trade_reg_up`, which results in negative prices. 
This PR resolves this issues by allowing for more flexibility in harvest from timber plantations. Timber plantation harvest is no longer enforced at rotation age to avoid conflicts with `q21_trade_reg_up.
In addition, cost for additional imports to maintain feasibility are reduced from 12300 to 1500 USD17MER per tDM to avoid implausibly high costs and prices for wood and woodfuel

Changelog: 
- **32_forestry** timber plantation harvest is no longer enforced at rotation age to avoid conflicts with `q21_trade_reg_up`, which can result in huge costs and negative prices for wood. To ensure that harvest from timber plantations is prioritized over harvest from natural forest, `s32_harvesting_cost` is set to 50% of `s35_timber_harvest_cost_secdforest`.
- **21_trade** Cost for additional imports to maintain feasibility reduced from 12300 to 1500 USD17MER per tDM to avoid implausibly high costs and prices for wood and woodfuel
- **core/macro** wrong use of `vm_supply` corrected in macro `m21_baseline_production`

![Prices_Industrial_roundwood](https://github.com/user-attachments/assets/7a345416-71cb-4680-aa91-95d3a8b96fb7)
![Costs_Trade](https://github.com/user-attachments/assets/e2c0db54-0f4f-47f7-8730-6a9171d0d75d)

![Resources_Land_Cover_Cropland-140](https://github.com/user-attachments/assets/9184c871-3e01-4eab-be9f-655f22b0c584)
![Productivity_Landuse_Intensity_Indicator_Tau-112](https://github.com/user-attachments/assets/8c7d74b7-f987-4ac9-9278-41a995fda89c)
![Emissions_CO2_Land_Land_use_Change-127](https://github.com/user-attachments/assets/ea6d8060-b450-465a-a9d6-6558703f4238)

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : 28 mins
  - This PR's default :  31 mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
