### PR TITLE
use magpie4::disaggregateLandConservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **script/start/test_runs.R** Test runs adjusted based on availability from coupled runs for R34M410. 
 - **scenario_config.csv** SSP2 food system assumptions for ScenarioMIP VLLO to avoid sudden jump of calorie intake after 2025
 - **scripts** request 24h for SLURM jobs (except for medium which still requests 7 days)
+- **scripts** disaggregation.R moved disaggregateLandConservation function to magpie4
 
 ### added
 - **default.cfg** added option to set Tol_Optimality (GAMS solver setting) to a certain value (GAMS-default 1e-7, new MAgPIE-default 1e-8)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     m4fsdp,
     madrat,
     magclass (>= 6.14.0),
-    magpie4 (>= 2.22.9),
+    magpie4 (>= 2.24.0),
     MagpieNCGains,
     magpiesets (>= 0.46.1),
     mip,

--- a/scripts/output/extra/disaggregation.R
+++ b/scripts/output/extra/disaggregation.R
@@ -87,99 +87,6 @@ if (length(map_file) > 1) {
   return(area_shr_hr)
 }
 
-.dissagLandConsv <- function(gdx, cfg, map_file, wdpa_hr_file, consv_prio_hr_file) {
-  land_consv_lr <- readGDX(gdx, "pm_land_conservation", react = "silent")
-  land_consv_lr <- dimSums(land_consv_lr, dim=3.2)
-  wdpa_hr <- read.magpie(wdpa_hr_file)
-  map <- readRDS(map_file)
-
-  # create full time series
-  land_consv_hr <- new.magpie(map[, "cell"], getYears(land_consv_lr), getItems(wdpa_hr, dim = 3.2),
-    fill = 0, sets = c("x.y.iso", "year", "data")
-  )
-
-  iso <- readGDX(gdx, "iso")
-  consv_iso <- readGDX(gdx, "policy_countries22")
-  consv_iso <- consv_iso[consv_iso %in% getItems(wdpa_hr, dim = 1.3)]
-  if (length(consv_iso) == 0) {
-    warning("No countries selected in land conservation disaggregation. Results may be erroneous")
-  }
-
-  base_protect_select <- cfg$gms$c22_base_protect
-  base_protect_noselect <- cfg$gms$c22_base_protect_noselect
-
-  if (!all(c(base_protect_select, base_protect_noselect) %in% "none")) {
-
-    if (base_protect_noselect != "none") {
-      land_consv_hr[, getYears(land_consv_hr), ] <- collapseDim(wdpa_hr[, nyears(wdpa_hr), base_protect_noselect], dim = 3.1)
-      land_consv_hr[, getYears(wdpa_hr), ] <- collapseDim(wdpa_hr[, , base_protect_noselect], dim = 3.1)
-    }
-    if (base_protect_select != "none") {
-      land_consv_hr[consv_iso, , ] <- collapseDim(wdpa_hr[consv_iso, nyears(wdpa_hr), base_protect_select], dim = 3.1)
-    } else {
-      land_consv_hr[consv_iso, , ] <- 0
-    }
-  }
-
-  consv_select <- cfg$gms$c22_protect_scenario
-  consv_noselect <- cfg$gms$c22_protect_scenario_noselect
-
-  if (!all(c(consv_select, consv_noselect) %in% "none")) {
-    if (file.exists(consv_prio_hr_file)) {
-      consv_prio_all <- read.magpie(consv_prio_hr_file)
-      consv_prio_hr <- new.magpie(
-        cells_and_regions = map[, "cell"],
-        names = getNames(consv_prio_all, dim = 2), fill = 0,
-        sets = c("x.y.iso", "year", "data")
-      )
-
-      if (consv_noselect != "none") {
-        consv_prio_hr <- collapseDim(consv_prio_all[, , consv_noselect], dim = 3.1)
-      }
-      if (consv_select != "none") {
-        consv_prio_hr[consv_iso, , ] <- collapseDim(consv_prio_all[consv_iso, , consv_select], dim = 3.1)
-      } else {
-        consv_prio_hr[consv_iso, , ] <- 0
-      }
-      # future conservation only pertains to natveg
-      consv_prio_hr[, , c("crop", "past", "forestry", "urban")] <- 0
-      consv_fader <- readGDX(gdx, "p22_conservation_fader", format = "first_found")
-      consv_prio_hr <- consv_prio_hr * consv_fader[, getYears(land_consv_hr), ]
-
-      # add conservation priority areas
-      land_consv_hr <- (land_consv_hr + consv_prio_hr)
-    } else {
-      warning(paste(
-        "Future land conservation used in MAgPIE run but high resolution",
-        "conservation priority data for disaggregation not found."
-      ))
-    }
-  }
-  # Due to internal constraints and compensation (e.g. NDC forest conservation)
-  # the actual land conservation can sometimes be smaller than the land
-  # conservation in the input data (this can especially happen also if
-  # land restoration is switched off). Therefore a scaling is applied here separately
-  # for grassland and natural vegetation
-  natveg <- c("primforest", "secdforest", "other")
-  consv_sum_lr <- mbind(
-    land_consv_lr[, , "past"],
-    setNames(dimSums(land_consv_lr[, , natveg], dim = 3), "natveg")
-  )
-  consv_sum_hr_agg <- mbind(
-    toolAggregate(land_consv_hr[, , "past"], map, from = "cell", to = "cluster"),
-    toolAggregate(setNames(dimSums(land_consv_hr[, , natveg], dim = 3), "natveg"),
-      map,
-      from = "cell", to = "cluster"
-    )
-  )
-  consv_scaling <- consv_sum_lr / consv_sum_hr_agg
-  consv_scaling[is.na(consv_scaling) | is.infinite(consv_scaling)] <- 1
-  consv_scaling <- toolAggregate(consv_scaling, map, from = "cluster", to = "cell")
-  land_consv_hr[, , "past"] <- consv_scaling[, , "past"] * land_consv_hr[, , "past"]
-  land_consv_hr[, , natveg] <- consv_scaling[, , "natveg"] * land_consv_hr[, , natveg]
-  return(land_consv_hr)
-}
-
 .dissagBII <- function(gdx, map_file, dir) {
   # Biodiversity intactness indicator (BII) at cluster level
   bii_lr <- BII(gdx,
@@ -292,8 +199,6 @@ if (file.exists(wdpa_hr_file)) {
                                                          mapping = readRDS(map_file),
                                                          wdpaHr = read.magpie(wdpa_hr_file),
                                                          conservationPrioHr = conservationPrioHr)
-  land_consv_hr2 <- .dissagLandConsv(gdx, cfg, map_file, wdpa_hr_file, consv_prio_hr_file)
-  stopifnot(identical(land_consv_hr, land_consv_hr2))
 
   # Write gridded conservation land
   .writeDisagg(land_consv_hr, land_consv_hr_out_file,

--- a/scripts/output/extra/disaggregation.R
+++ b/scripts/output/extra/disaggregation.R
@@ -281,7 +281,19 @@ message("Disaggregating conservation land")
 
 land_consv_hr <- NULL
 if (file.exists(wdpa_hr_file)) {
-  land_consv_hr <- .dissagLandConsv(gdx, cfg, map_file, wdpa_hr_file, consv_prio_hr_file)
+  if (file.exists(consv_prio_hr_file)) {
+    conservationPrioHr <- read.magpie(consv_prio_hr_file)
+  } else {
+    warning("Future land conservation used in MAgPIE run but high resolution ",
+            "conservation priority data for disaggregation not found.")
+    conservationPrioHr <- NULL
+  }
+  land_consv_hr <- magpie4::disaggregateLandConservation(gdx, cfg,
+                                                         mapping = readRDS(map_file),
+                                                         wdpaHr = read.magpie(wdpa_hr_file),
+                                                         conservationPrioHr = conservationPrioHr)
+  land_consv_hr2 <- .dissagLandConsv(gdx, cfg, map_file, wdpa_hr_file, consv_prio_hr_file)
+  stopifnot(identical(land_consv_hr, land_consv_hr2))
 
   # Write gridded conservation land
   .writeDisagg(land_consv_hr, land_consv_hr_out_file,


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- .dissagLandConsv was moved to magpie4::disaggregateLandConservation, see https://github.com/pik-piam/magpie4/pull/82

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
