### PR TITLE
optional temporal fader for start of C prive driven afforestation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -
 
 ### added
--
+- **56_ghg_policy** added optional temporal fader for start of C prive driven afforestation
 
 ### removed
 -
@@ -65,7 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **config.cfg** default for `cfg$gms$s35_forest_damage ` changed from 2 to 0
 - **default.cfg** default for `cfg$gms$bioenergy` change from `1stgen_priced_dec18` to `1st2ndgen_priced_feb24`
 - **default.cfg** default for `s60_bioenergy_1st_subsidy` (formerly `c60_bioenergy_subsidy`) changed from 246 USD17MER per ton to 6.5 USD17MER per GJ based on mean GJ per ton of 1st generation bioenergy products.
-- **default.cfg** default for module `44_biodiversity` changed from `bii_target_apr24` to `bii_target
+- **default.cfg** default for module `44_biodiversity` changed from `bii_target_apr24` to `bii_target`
 - **default.cfg** input data upgraded from rev4.116 to rev4.117
 - **default.cfg** Reactivated external scenario for damage from shifting agriculture (`cfg$gms$s35_forest_damage <- 2`)
 - **default.cfg** settings for  land conversion cost calibration updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### changed
--
+- **scenario_config** update of VLLO scenario to EAT-Lancet 2
 
 ### added
 - **56_ghg_policy** added optional temporal fader for start of C prive driven afforestation

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     m4fsdp,
     madrat,
     magclass (>= 6.14.0),
-    magpie4 (>= 2.24.0),
+    magpie4 (>= 2.27.2),
     MagpieNCGains,
     magpiesets (>= 0.46.1),
     mip,

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -1655,8 +1655,13 @@ cfg$gms$s56_minimum_cprice <- 3.67    # def = 3.67
 # * "emulator" is selected above.
 cfg$gms$policy_countries56  <- all_iso_countries   # def = all_iso_countries
 
-# * Switch for C price driven afforestation (1=on 0=off)
-cfg$gms$s56_c_price_induced_aff <- 1   # def = on
+# * Switch for C price driven afforestation (0=off 1=full effect)
+# *  Range of meaningful values: 0-1 
+cfg$gms$s56_c_price_induced_aff <- 1   # def = 1
+# * Start year of C price induced afforestation fade-in
+cfg$gms$s56_fader_cpriceaff_start <- 2030   # def = 2030
+# * End year of C price induced afforestation fade-in
+cfg$gms$s56_fader_cpriceaff_end <- 2030   # def = 2030
 
 # * C price used as incentive for afforestation
 # * Note: This setting should only be changed by experienced users

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -1655,12 +1655,13 @@ cfg$gms$s56_minimum_cprice <- 3.67    # def = 3.67
 # * "emulator" is selected above.
 cfg$gms$policy_countries56  <- all_iso_countries   # def = all_iso_countries
 
-# * Switch for C price driven afforestation (0=off 1=full effect)
-# *  Range of meaningful values: 0-1 
+# * Switch for C price driven re/afforestation (1=on 0=off)
 cfg$gms$s56_c_price_induced_aff <- 1   # def = 1
-# * Start year of C price induced afforestation fade-in
+# * Settings for optional temporal fade-in of C price driven re/afforestation between start and end year (linear interpolation)
+# * Note: The default setting mutes the signal until and including 2030
+# * Start year of C price induced re/afforestation fade-in
 cfg$gms$s56_fader_cpriceaff_start <- 2030   # def = 2030
-# * End year of C price induced afforestation fade-in
+# * End year of C price induced re/afforestation fade-in
 cfg$gms$s56_fader_cpriceaff_end <- 2030   # def = 2030
 
 # * C price used as incentive for afforestation

--- a/config/scenario_config.csv
+++ b/config/scenario_config.csv
@@ -1,4 +1,4 @@
-;cc;nocc;nocc_hist;SSP1;SSP2;SSP3;SSP4;SSP5;SDP;SDP-EI;SDP-RC;SDP-MC;VLLO;SSP1-POP-GDP;SSP2-POP-GDP;SSP3-POP-GDP;SSP5-POP-GDP;AR-natveg;AR-plant;BASE;NPI;NPI-revert;NDC;coupling;emulator;input;eat_lancet_diet_v1;eat_lancet_diet_v2;ForestryEndo;ForestryExo;ForestryOff;rcp1p9;rcp2p6;rcp4p5;rcp6p0;rcp7p0;rcp8p5
+f;cc;nocc;nocc_hist;SSP1;SSP2;SSP3;SSP4;SSP5;SDP;SDP-EI;SDP-RC;SDP-MC;VLLO;SSP1-POP-GDP;SSP2-POP-GDP;SSP3-POP-GDP;SSP5-POP-GDP;AR-natveg;AR-plant;BASE;NPI;NPI-revert;NDC;coupling;emulator;input;eat_lancet_diet_v1;eat_lancet_diet_v2;ForestryEndo;ForestryExo;ForestryOff;rcp1p9;rcp2p6;rcp4p5;rcp6p0;rcp7p0;rcp8p5
 gms$c_timesteps;;;;;;;;;;;;;;;;;;;;;;;;less_TS;less_TS;;;;;;;;;;;;
 gms$c09_pop_scenario;;;;SSP1;SSP2;SSP3;SSP4;SSP5;SSP1;SSP1;SSP1;SSP1;SSP1;SSP1;SSP2;SSP3;SSP5;;;;;;;;;;;;;;;;;;;;
 gms$c09_gdp_scenario;;;;SSP1;SSP2;SSP3;SSP4;SSP5;SSP1;SDP_EI;SDP_RC;SDP_MC;SSP1;SSP1;SSP2;SSP3;SSP5;;;;;;;;;;;;;;;;;;;;
@@ -16,7 +16,7 @@ gms$s15_exo_foodscen_start;;;;;;;;;2025;2025;2025;2025;2025;;;;;;;;;;;;;;2025;20
 gms$s15_exo_foodscen_target;;;;;;;;;2050;2050;2050;2070;2070;;;;;;;;;;;;;;2050;2050;;;;;;;;;
 gms$s15_exo_waste;;;;0;0;0;0;0;1;1;1;1;1;;;;;;;;;;;;;;;;;;;;;;;;
 gms$s15_waste_scen;;;;;;;;;1.2;1.3;1.2;1.25;1.25;;;;;;;;;;;;;;;;;;;;;;;;
-gms$s15_exo_diet;;;;0;0;0;0;0;1;1;1;1;1;;;;;;;;;;;;;;1;3;;;;;;;;;
+gms$s15_exo_diet;;;;0;0;0;0;0;1;1;1;1;3;;;;;;;;;;;;;;1;3;;;;;;;;;
 gms$c15_kcal_scen;;;;;;;;;healthy_BMI;no_underweight;healthy_BMI;healthy_BMI;healthy_BMI;;;;;;;;;;;;;;healthy_BMI;;;;;;;;;;
 gms$c15_EAT_scen;;;;;;;;;FLX;;FLX;FLX;FLX;;;;;;;;;;;;;;FLX;;;;;;;;;;
 gms$s15_exo_monogastric;;;;;;;;;1;0;1;1;1;;;;;;;;;;;;;;1;1;;;;;;;;;

--- a/modules/56_ghg_policy/price_aug22/declarations.gms
+++ b/modules/56_ghg_policy/price_aug22/declarations.gms
@@ -17,6 +17,7 @@ parameters
  p56_fader(t_all)                                 GHG policy fader (1)
  p56_fader_reg(t_all,i)                           Regional GHG policy fader (1)
  pcm_carbon_stock(j,land,c_pools,stockType)       Carbon stock in vegetation soil and litter for different land types (mio. tC)
+ p56_fader_cpriceaff(t_all)                       Fader for C price induced afforestation (1)
 ;
 
 equations

--- a/modules/56_ghg_policy/price_aug22/equations.gms
+++ b/modules/56_ghg_policy/price_aug22/equations.gms
@@ -72,7 +72,7 @@
 
  q56_reward_cdr_aff(j2) ..
                  v56_reward_cdr_aff(j2) =e=
-               s56_c_price_induced_aff*
+               sum(ct, p56_fader_cpriceaff(ct)) *
                sum(ac,
                (sum(aff_effect,(1-s56_buffer_aff)*vm_cdr_aff(j2,ac,aff_effect)) * sum((cell(i2,j2),ct), p56_c_price_aff(ct,i2,ac)))
                / ((1+sum((cell(i2,j2),ct),pm_interest(ct,i2)))**(ac.off*5)))

--- a/modules/56_ghg_policy/price_aug22/input.gms
+++ b/modules/56_ghg_policy/price_aug22/input.gms
@@ -77,6 +77,8 @@ scalars
   s56_fader_end                   End year of GHG policy fade-in (1) / 2050 /
   s56_fader_target                Target value of GHG policy fade-in in end year / 1 /
   s56_fader_functional_form       Switch for functional form of GHG policy fader (1=linear 2=sigmoid) / 1 /
+  s56_fader_cpriceaff_start       Start year of C price induced afforestation fade-in (1) / 2030 /
+  s56_fader_cpriceaff_end         End year of C price induced afforestation fade-in (1) / 2030 /
 ;
 
 $setglobal c56_pollutant_prices  R34M410-SSP2-NPi2025

--- a/modules/56_ghg_policy/price_aug22/preloop.gms
+++ b/modules/56_ghg_policy/price_aug22/preloop.gms
@@ -57,6 +57,8 @@ elseif s56_fader_functional_form = 2,
   m_sigmoid_time_interpol(p56_fader,s56_fader_start,s56_fader_end,0,s56_fader_target);
 );
 
+m_linear_time_interpol(p56_fader_cpriceaff,s56_fader_cpriceaff_start,s56_fader_cpriceaff_end,0,s56_c_price_induced_aff);
+
 p56_fader_reg(t_all,i) = p56_fader(t_all) * p56_region_fader_shr(t_all,i) + p56_fader(t_all) * (1-p56_region_fader_shr(t_all,i));
 im_pollutant_prices(t_all,i,pollutants_fader,emis_source)$(s56_ghgprice_fader = 1) = im_pollutant_prices(t_all,i,pollutants_fader,emis_source) * p56_fader_reg(t_all,i);
 

--- a/scripts/start/projects/project_ScenarioMIP.R
+++ b/scripts/start/projects/project_ScenarioMIP.R
@@ -21,7 +21,7 @@ source("scripts/start_functions.R")
 source("config/default.cfg")
 
 # create additional information to describe the runs
-cfg$info$flag <- "SMIP63"
+cfg$info$flag <- "SMIP65"
 cfg$qos <- "standby"
 
 cfg$results_folder <- "output/:title:"
@@ -57,6 +57,8 @@ cfg$gms$s29_treecover_target <- 0
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 1
 cfg$gms$s44_start_year <- 2030
+cfg$gms$s56_fader_cpriceaff_start <- 2030
+cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_target <- 0
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -71,6 +73,8 @@ cfg$gms$s29_treecover_target <- 0
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 1
 cfg$gms$s44_start_year <- 2030
+cfg$gms$s56_fader_cpriceaff_start <- 2030
+cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_target <- 0
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -85,6 +89,8 @@ cfg$gms$s29_treecover_target <- 0
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 1
 cfg$gms$s44_start_year <- 2030
+cfg$gms$s56_fader_cpriceaff_start <- 2030
+cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_target <- 0
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -100,6 +106,8 @@ cfg$gms$s29_treecover_target <- 0.01
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 0
 cfg$gms$s44_start_year <- 2030
+cfg$gms$s56_fader_cpriceaff_start <- 2030
+cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_scenario_start <- 2030
 cfg$gms$s59_scm_target <- 0.1
 cfg$gms$c60_1stgen_biodem <- "const2030"
@@ -111,12 +119,14 @@ cfg <- setScenario(cfg,c("SSP2","NPI","AR-plant","nocc_hist"))
 cfg$gms$c56_mute_ghgprices_until <- "y2030"
 cfg$path_to_report_ghgprices <- "input/REMIND_generic_C_SMIPv06-VLHO-SSP2-EcPrice1250-var-rem-7.mif"
 cfg$path_to_report_bioenergy    <- "input/REMIND_generic_C_SMIPv06-VLHO-SSP2-EcPrice1250-var-rem-7.mif"
-cfg$gms$s29_treecover_scenario_start <- 2030
+cfg$gms$s29_treecover_scenario_start <- 2050
 cfg$gms$s29_treecover_target <- 0.02
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 0
 cfg$gms$s44_start_year <- 2050
-cfg$gms$s59_scm_scenario_start <- 2030
+cfg$gms$s56_fader_cpriceaff_start <- 2040
+cfg$gms$s56_fader_cpriceaff_end <- 2050
+cfg$gms$s59_scm_scenario_start <- 2050
 cfg$gms$s59_scm_target <- 0.2
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -128,12 +138,14 @@ cfg$gms$c56_mute_ghgprices_until <- "y2030"
 cfg$path_to_report_ghgprices <- "input/REMIND_generic_C_SMIPv06-VLLO-SSP1-PkPrice500-def-rem-7.mif"
 cfg$path_to_report_bioenergy    <- "input/REMIND_generic_C_SMIPv06-VLLO-SSP1-PkPrice500-def-rem-7.mif"
 cfg$gms$s29_treecover_scenario_start <- 2025
-cfg$gms$s29_treecover_target <- 0.02
+cfg$gms$s29_treecover_target <- 0.03
 cfg$gms$s44_bii_target <- 0.7
-cfg$gms$c44_bii_decrease <- 0
+cfg$gms$c44_bii_decrease <- 1
 cfg$gms$s44_start_year <- 2030
+cfg$gms$s56_fader_cpriceaff_start <- 2030
+cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_scenario_start <- 2025
-cfg$gms$s59_scm_target <- 0.2
+cfg$gms$s59_scm_target <- 0.3
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
 
@@ -150,6 +162,8 @@ cfg$gms$s29_treecover_target <- 0
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 1
 cfg$gms$s44_start_year <- 2030
+cfg$gms$s56_fader_cpriceaff_start <- 2030
+cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_target <- 0
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -160,12 +174,14 @@ cfg <- setScenario(cfg,c("SSP2","NPI","AR-natveg","nocc_hist"))
 cfg$gms$c56_mute_ghgprices_until <- "y2030"
 cfg$path_to_report_ghgprices <- "input/REMIND_generic_C_SMIPv06-VLHO-SSP2-EcBudg400-var_natveg-rem-7.mif"
 cfg$path_to_report_bioenergy    <- "input/REMIND_generic_C_SMIPv06-VLHO-SSP2-EcBudg400-var_natveg-rem-7.mif"
-cfg$gms$s29_treecover_scenario_start <- 2030
+cfg$gms$s29_treecover_scenario_start <- 2050
 cfg$gms$s29_treecover_target <- 0.02
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 0
 cfg$gms$s44_start_year <- 2050
-cfg$gms$s59_scm_scenario_start <- 2030
+cfg$gms$s56_fader_cpriceaff_start <- 2040
+cfg$gms$s56_fader_cpriceaff_end <- 2050
+cfg$gms$s59_scm_scenario_start <- 2050
 cfg$gms$s59_scm_target <- 0.2
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -177,12 +193,14 @@ cfg$gms$c56_mute_ghgprices_until <- "y2030"
 cfg$path_to_report_ghgprices <- "input/REMIND_generic_C_SMIPv06-VLLO-SSP1-PkPrice500-def-rem-7.mif"
 cfg$path_to_report_bioenergy    <- "input/REMIND_generic_C_SMIPv06-VLLO-SSP1-PkPrice500-def-rem-7.mif"
 cfg$gms$s29_treecover_scenario_start <- 2025
-cfg$gms$s29_treecover_target <- 0.02
+cfg$gms$s29_treecover_target <- 0.03
 cfg$gms$s44_bii_target <- 0.7
-cfg$gms$c44_bii_decrease <- 0
+cfg$gms$c44_bii_decrease <- 1
 cfg$gms$s44_start_year <- 2030
+cfg$gms$s56_fader_cpriceaff_start <- 2030
+cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_scenario_start <- 2025
-cfg$gms$s59_scm_target <- 0.2
+cfg$gms$s59_scm_target <- 0.3
 cfg$gms$c60_1stgen_biodem <- "const2030"
 cfg$gms$s32_annual_aff_limit <- 1
 start_run(cfg, codeCheck = FALSE)

--- a/scripts/start/projects/project_ScenarioMIP.R
+++ b/scripts/start/projects/project_ScenarioMIP.R
@@ -102,6 +102,7 @@ cfg$gms$c56_mute_ghgprices_until <- "y2030"
 cfg$path_to_report_ghgprices <- "input/REMIND_generic_C_SMIPv06-L-SSP2-PkPrice400-var-rem-7.mif"
 cfg$path_to_report_bioenergy    <- "input/REMIND_generic_C_SMIPv06-L-SSP2-PkPrice400-var-rem-7.mif"
 cfg$gms$s29_treecover_scenario_start <- 2030
+cfg$gms$s29_treecover_scenario_target <- 2050
 cfg$gms$s29_treecover_target <- 0.01
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 0
@@ -109,6 +110,7 @@ cfg$gms$s44_start_year <- 2030
 cfg$gms$s56_fader_cpriceaff_start <- 2030
 cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_scenario_start <- 2030
+cfg$gms$s59_scm_scenario_target <- 2050
 cfg$gms$s59_scm_target <- 0.1
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -120,6 +122,7 @@ cfg$gms$c56_mute_ghgprices_until <- "y2030"
 cfg$path_to_report_ghgprices <- "input/REMIND_generic_C_SMIPv06-VLHO-SSP2-EcPrice1250-var-rem-7.mif"
 cfg$path_to_report_bioenergy    <- "input/REMIND_generic_C_SMIPv06-VLHO-SSP2-EcPrice1250-var-rem-7.mif"
 cfg$gms$s29_treecover_scenario_start <- 2050
+cfg$gms$s29_treecover_scenario_target <- 2070
 cfg$gms$s29_treecover_target <- 0.02
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 0
@@ -127,6 +130,7 @@ cfg$gms$s44_start_year <- 2050
 cfg$gms$s56_fader_cpriceaff_start <- 2040
 cfg$gms$s56_fader_cpriceaff_end <- 2050
 cfg$gms$s59_scm_scenario_start <- 2050
+cfg$gms$s59_scm_scenario_target <- 2070
 cfg$gms$s59_scm_target <- 0.2
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -138,6 +142,7 @@ cfg$gms$c56_mute_ghgprices_until <- "y2030"
 cfg$path_to_report_ghgprices <- "input/REMIND_generic_C_SMIPv06-VLLO-SSP1-PkPrice500-def-rem-7.mif"
 cfg$path_to_report_bioenergy    <- "input/REMIND_generic_C_SMIPv06-VLLO-SSP1-PkPrice500-def-rem-7.mif"
 cfg$gms$s29_treecover_scenario_start <- 2025
+cfg$gms$s29_treecover_scenario_target <- 2050
 cfg$gms$s29_treecover_target <- 0.03
 cfg$gms$s44_bii_target <- 0.7
 cfg$gms$c44_bii_decrease <- 1
@@ -145,6 +150,7 @@ cfg$gms$s44_start_year <- 2030
 cfg$gms$s56_fader_cpriceaff_start <- 2030
 cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_scenario_start <- 2025
+cfg$gms$s59_scm_scenario_target <- 2050
 cfg$gms$s59_scm_target <- 0.3
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -175,6 +181,7 @@ cfg$gms$c56_mute_ghgprices_until <- "y2030"
 cfg$path_to_report_ghgprices <- "input/REMIND_generic_C_SMIPv06-VLHO-SSP2-EcBudg400-var_natveg-rem-7.mif"
 cfg$path_to_report_bioenergy    <- "input/REMIND_generic_C_SMIPv06-VLHO-SSP2-EcBudg400-var_natveg-rem-7.mif"
 cfg$gms$s29_treecover_scenario_start <- 2050
+cfg$gms$s29_treecover_scenario_target <- 2070
 cfg$gms$s29_treecover_target <- 0.02
 cfg$gms$s44_bii_target <- 0
 cfg$gms$c44_bii_decrease <- 0
@@ -182,6 +189,7 @@ cfg$gms$s44_start_year <- 2050
 cfg$gms$s56_fader_cpriceaff_start <- 2040
 cfg$gms$s56_fader_cpriceaff_end <- 2050
 cfg$gms$s59_scm_scenario_start <- 2050
+cfg$gms$s59_scm_scenario_target <- 2070
 cfg$gms$s59_scm_target <- 0.2
 cfg$gms$c60_1stgen_biodem <- "const2030"
 start_run(cfg, codeCheck = FALSE)
@@ -193,6 +201,7 @@ cfg$gms$c56_mute_ghgprices_until <- "y2030"
 cfg$path_to_report_ghgprices <- "input/REMIND_generic_C_SMIPv06-VLLO-SSP1-PkPrice500-def-rem-7.mif"
 cfg$path_to_report_bioenergy    <- "input/REMIND_generic_C_SMIPv06-VLLO-SSP1-PkPrice500-def-rem-7.mif"
 cfg$gms$s29_treecover_scenario_start <- 2025
+cfg$gms$s29_treecover_scenario_target <- 2050
 cfg$gms$s29_treecover_target <- 0.03
 cfg$gms$s44_bii_target <- 0.7
 cfg$gms$c44_bii_decrease <- 1
@@ -200,6 +209,7 @@ cfg$gms$s44_start_year <- 2030
 cfg$gms$s56_fader_cpriceaff_start <- 2030
 cfg$gms$s56_fader_cpriceaff_end <- 2030
 cfg$gms$s59_scm_scenario_start <- 2025
+cfg$gms$s59_scm_scenario_target <- 2050
 cfg$gms$s59_scm_target <- 0.3
 cfg$gms$c60_1stgen_biodem <- "const2030"
 cfg$gms$s32_annual_aff_limit <- 1

--- a/scripts/start/projects/project_WetHorizons.R
+++ b/scripts/start/projects/project_WetHorizons.R
@@ -12,9 +12,10 @@
 
 ## Load lucode2 and gms to use setScenario later
 library(lucode2)
-library(gms)
+library(magclass)
 library(gdx2)
 library(magpie4)
+library(gms)
 
 # Load start_run(cfg) function which is needed to start MAgPIE runs
 source("scripts/start_functions.R")
@@ -23,7 +24,7 @@ source("scripts/start_functions.R")
 source("config/default.cfg")
 
 # create additional information to describe the runs
-cfg$info$flag <- "WH03"
+cfg$info$flag <- "WH06"
 
 cfg$results_folder <- "output/:title:"
 cfg$results_folder_highres <- "output"
@@ -44,89 +45,239 @@ cfg$repositories <- append(
 )
 
 cfg$gms$c_timesteps <- "5year"
-ssp <- "SSP2"
 
-# Reference
-cfg$title <- .title(cfg, paste(ssp, "Ref", sep = "-"))
-cfg <- setScenario(cfg, c(ssp, "NPI", "rcp7p0"))
-cfg$gms$c56_mute_ghgprices_until <- "y2150"
-cfg$gms$c56_pollutant_prices <- "R32M46-SSP2EU-NPi"
-cfg$gms$c60_2ndgen_biodem    <- "R32M46-SSP2EU-NPi"
-start_run(cfg, codeCheck = FALSE)
+ssps <- c("SSP1","SSP2","SSP3","SSP5")
 
-# PkBudg650
-cfg$title <- .title(cfg, paste(ssp, "PkBudg650", sep = "-"))
-cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
-cfg$gms$c56_mute_ghgprices_until <- "y2025"
-cfg$gms$c56_pollutant_prices <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c60_2ndgen_biodem    <- "R32M46-SSP2EU-PkBudg650"
-start_run(cfg, codeCheck = FALSE)
+for (ssp in ssps) {
+  if (ssp %in% c("SSP1","SSP2","SSP5")) {
+    cfg$title <- .title(cfg, paste(ssp, "1p5deg", "noPeatland", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg650")
+  } else {
+    cfg$title <- .title(cfg, paste(ssp, "2deg", "noPeatland", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp2p6"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg1000")
+  }
+  cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
+  cfg$gms$s58_rewetting_exo <- 0
+  cfg$gms$s58_rewet_exo_start_value <- 0
+  cfg$gms$s58_rewet_exo_target_value <- 0.5
+  cfg$gms$s58_annual_rewetting_limit <- 0.02
+  cfg$gms$s58_intact_prot_exo <- 0
+  cfg$gms$tc <- "endo_jan22"
+  x <- try(modelstat(file.path("output",cfg$title,"fulldata.gdx")),silent = TRUE)
+  if(is.null(x) | (is.magpie(x) & any(!x %in% c(2,7)))) {
+    download_and_update(cfg)
+    start_run(cfg,codeCheck=FALSE)
+    message(paste0("TAU run started: ",cfg$title))
+    Sys.sleep(10)
+  }
+}
 
-#PkBudg650 without peatland policy
-cfg$title <- .title(cfg, paste(ssp, "PkBudg650", "noPeatland", sep = "-"))
-cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
-cfg$gms$c56_mute_ghgprices_until <- "y2025"
-cfg$gms$c56_pollutant_prices <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c60_2ndgen_biodem    <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
-start_run(cfg, codeCheck = FALSE)
+### wait until model runs with endogenous TAU are finished, check is performed every 10 minutes
+success <- FALSE
+while (!success) {
+  z <- NULL
+  for (ssp in ssps) {
+    if (ssp %in% c("SSP1","SSP2","SSP5")) {
+      x <- try(modelstat(file.path("output",.title(cfg, paste(ssp, "1p5deg", "noPeatland", sep = "-")),"fulldata.gdx")),silent = TRUE)
+    } else {
+      x <- try(modelstat(file.path("output",.title(cfg, paste(ssp, "2deg", "noPeatland", sep = "-")),"fulldata.gdx")),silent = TRUE)
+    }
+    if (is.magpie(x) & all(x %in% c(2,7))) {
+      x <- add_dimension(collapseNames(x),dim = 3.1,add = "scen",nm = paste0(ssp))
+    } else x <- NULL
+    z <- mbind(z,x)
+  }
+  if (is.null(z)) {
+    message("Not any model run with endogenous TAU finished. Sleeping for 10 minutes.")
+    Sys.sleep(60*10)
+  } else if (dim(z)[3] < length(ssps)) {
+    message("At least on model run with endogenous TAU not yet finished. Sleeping for 10 minutes.")
+    Sys.sleep(60*10)
+  } else if (dim(z)[3] == length(ssps)) {
+    if (all(z %in% c(2,7))) success <- TRUE else stop("Modelstat different from 2 or 7 detected")
+  }
+}
 
-## Exo rewet scenarios
-# 15% of currently drained peatland rewetted by 2050
-cfg$title <- .title(cfg, paste(ssp, "PkBudg650", "NRL15", sep = "-"))
-cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
-cfg$gms$c56_mute_ghgprices_until <- "y2025"
-cfg$gms$c56_pollutant_prices <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c60_2ndgen_biodem    <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
-cfg$gms$s58_rewetting_exo <- 1
-cfg$gms$s58_rewet_exo_start_value <- 0
-cfg$gms$s58_rewet_exo_target_value <- 0.15
-cfg$gms$s58_annual_rewetting_limit <- 1
-cfg$gms$s58_intact_prot_exo <- 1
-start_run(cfg, codeCheck = FALSE)
 
-## Exo rewet scenarios
-# 25% of currently drained peatland rewetted by 2050
-cfg$title <- .title(cfg, paste(ssp, "PkBudg650", "NRL25", sep = "-"))
-cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
-cfg$gms$c56_mute_ghgprices_until <- "y2025"
-cfg$gms$c56_pollutant_prices <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c60_2ndgen_biodem    <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
-cfg$gms$s58_rewetting_exo <- 1
-cfg$gms$s58_rewet_exo_start_value <- 0
-cfg$gms$s58_rewet_exo_target_value <- 0.25
-cfg$gms$s58_annual_rewetting_limit <- 1
-cfg$gms$s58_intact_prot_exo <- 1
-start_run(cfg, codeCheck = FALSE)
+cfg$gms$tc <- "exo"
 
-## Exo rewet scenarios
-# 50% of currently drained peatland rewetted by 2050
-cfg$title <- .title(cfg, paste(ssp, "PkBudg650", "NRL50", sep = "-"))
-cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
-cfg$gms$c56_mute_ghgprices_until <- "y2025"
-cfg$gms$c56_pollutant_prices <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c60_2ndgen_biodem    <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
-cfg$gms$s58_rewetting_exo <- 1
-cfg$gms$s58_rewet_exo_start_value <- 0
-cfg$gms$s58_rewet_exo_target_value <- 0.5
-cfg$gms$s58_annual_rewetting_limit <- 1
-cfg$gms$s58_intact_prot_exo <- 1
-start_run(cfg, codeCheck = FALSE)
-
-## Exo rewet scenarios
-# 100% of currently drained peatland rewetted by 2050
-cfg$title <- .title(cfg, paste(ssp, "PkBudg650", "NRL100", sep = "-"))
-cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
-cfg$gms$c56_mute_ghgprices_until <- "y2025"
-cfg$gms$c56_pollutant_prices <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c60_2ndgen_biodem    <- "R32M46-SSP2EU-PkBudg650"
-cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
-cfg$gms$s58_rewetting_exo <- 1
-cfg$gms$s58_rewet_exo_start_value <- 0
-cfg$gms$s58_rewet_exo_target_value <- 1
-cfg$gms$s58_annual_rewetting_limit <- 1
-cfg$gms$s58_intact_prot_exo <- 1
-start_run(cfg, codeCheck = FALSE)
+for (ssp in ssps) {
+  
+  if (ssp %in% c("SSP1","SSP2","SSP5")) {
+    
+    # PkBudg650
+    cfg$title <- .title(cfg, paste(ssp, "1p5deg", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil"
+    cfg$gms$s58_rewetting_exo <- 0
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 0.5
+    cfg$gms$s58_annual_rewetting_limit <- 0.02
+    cfg$gms$s58_intact_prot_exo <- 0
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "1p5deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+    
+    ## Exo rewet scenarios
+    # 15% of currently drained peatland rewetted by 2050
+    cfg$title <- .title(cfg, paste(ssp, "1p5deg", "NRL15", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
+    cfg$gms$s58_rewetting_exo <- 1
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 0.15
+    cfg$gms$s58_annual_rewetting_limit <- 1
+    cfg$gms$s58_intact_prot_exo <- 1
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "1p5deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+    
+    ## Exo rewet scenarios
+    # 25% of currently drained peatland rewetted by 2050
+    cfg$title <- .title(cfg, paste(ssp, "1p5deg", "NRL25", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
+    cfg$gms$s58_rewetting_exo <- 1
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 0.25
+    cfg$gms$s58_annual_rewetting_limit <- 1
+    cfg$gms$s58_intact_prot_exo <- 1
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "1p5deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+    
+    ## Exo rewet scenarios
+    # 50% of currently drained peatland rewetted by 2050
+    cfg$title <- .title(cfg, paste(ssp, "1p5deg", "NRL50", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
+    cfg$gms$s58_rewetting_exo <- 1
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 0.5
+    cfg$gms$s58_annual_rewetting_limit <- 1
+    cfg$gms$s58_intact_prot_exo <- 1
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "1p5deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+    
+    ## Exo rewet scenarios
+    # 100% of currently drained peatland rewetted by 2050
+    cfg$title <- .title(cfg, paste(ssp, "1p5deg", "NRL100", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp1p9"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg650")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
+    cfg$gms$s58_rewetting_exo <- 1
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 1
+    cfg$gms$s58_annual_rewetting_limit <- 1
+    cfg$gms$s58_intact_prot_exo <- 1
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "1p5deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+  } else {
+    # PkBudg1000
+    cfg$title <- .title(cfg, paste(ssp, "2deg", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp2p6"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil"
+    cfg$gms$s58_rewetting_exo <- 0
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 0.5
+    cfg$gms$s58_annual_rewetting_limit <- 0.02
+    cfg$gms$s58_intact_prot_exo <- 0
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "2deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+    
+    ## Exo rewet scenarios
+    # 15% of currently drained peatland rewetted by 2050
+    cfg$title <- .title(cfg, paste(ssp, "2deg", "NRL15", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp2p6"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
+    cfg$gms$s58_rewetting_exo <- 1
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 0.15
+    cfg$gms$s58_annual_rewetting_limit <- 1
+    cfg$gms$s58_intact_prot_exo <- 1
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "2deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+    
+    ## Exo rewet scenarios
+    # 25% of currently drained peatland rewetted by 2050
+    cfg$title <- .title(cfg, paste(ssp, "2deg", "NRL25", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp2p6"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
+    cfg$gms$s58_rewetting_exo <- 1
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 0.25
+    cfg$gms$s58_annual_rewetting_limit <- 1
+    cfg$gms$s58_intact_prot_exo <- 1
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "2deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+    
+    ## Exo rewet scenarios
+    # 50% of currently drained peatland rewetted by 2050
+    cfg$title <- .title(cfg, paste(ssp, "2deg", "NRL50", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp2p6"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
+    cfg$gms$s58_rewetting_exo <- 1
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 0.5
+    cfg$gms$s58_annual_rewetting_limit <- 1
+    cfg$gms$s58_intact_prot_exo <- 1
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "2deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+    
+    ## Exo rewet scenarios
+    # 100% of currently drained peatland rewetted by 2050
+    cfg$title <- .title(cfg, paste(ssp, "2deg", "NRL100", sep = "-"))
+    cfg <- setScenario(cfg, c(ssp, "NDC", "rcp2p6"))
+    cfg$gms$c56_mute_ghgprices_until <- "y2025"
+    cfg$gms$c56_pollutant_prices <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c60_2ndgen_biodem    <- paste0("R34M410-",ssp,"-PkBudg1000")
+    cfg$gms$c56_emis_policy <- "reddnatveg_nosoil_nopeat"
+    cfg$gms$s58_rewetting_exo <- 1
+    cfg$gms$s58_rewet_exo_start_value <- 0
+    cfg$gms$s58_rewet_exo_target_value <- 1
+    cfg$gms$s58_annual_rewetting_limit <- 1
+    cfg$gms$s58_intact_prot_exo <- 1
+    download_and_update(cfg)
+    write.magpie(readGDX(file.path("output",.title(cfg, paste(ssp, "2deg", "noPeatland", sep = "-")),"fulldata.gdx"), "ov_tau", select=list(type="level")),"modules/13_tc/input/f13_tau_scenario.csv")
+    start_run(cfg, codeCheck = FALSE)
+    
+  }
+}


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- **56_ghg_policy** added optional temporal fader for start of C prive driven afforestation
- **scenario_config** update of VLLO scenario to EAT-Lancet 2
- updated start scripts for ScenarioMIP and WetHorizons

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [x] RSE review done (at least 1)
