### PR TITLE
update start script and miniforge path

### DIFF
--- a/config/projects/scenario_config_miti_consv.csv
+++ b/config/projects/scenario_config_miti_consv.csv
@@ -1,6 +1,6 @@
-;MitiConsv;AR0;AR200;AR350;AR500;30by30
-gms$c22_protect_scenario;;;;;;30by30
-gms$s32_max_aff_area;;;382;532;682;
+;MitiConsv;AR0;AR150;AR250;AR350;BH
+gms$c22_protect_scenario;;;;;;BH
+gms$s32_max_aff_area;;;332;432;532;
 gms$s56_c_price_induced_aff ;;0;1;1;1;
 gms$s56_buffer_aff;0;;;;;
-input['calibration'];calibration_rev18_MitiConsv_04Apr25.tgz;;;;;
+input['calibration'];calibration_rev21_MitiConsv_01Jul25.tgz;;;;;

--- a/scripts/output/extra/runSEALSallocation.R
+++ b/scripts/output/extra/runSEALSallocation.R
@@ -92,7 +92,7 @@ if (length(list.files(dirBaseFiles)) == 0) {
 }
 
 ### Path to miniforge installation
-miniforgePath <- "/p/projects/rd3mod/miniforge3/bin/activate"
+miniforgePath <- "/p/projects/rd3mod/miniforge3/v25-3-0_3/bin/activate"
 
 # create output directory
 dirProject <- "./output/seals"

--- a/scripts/start/projects/paper_MitiConsv.R
+++ b/scripts/start/projects/paper_MitiConsv.R
@@ -9,7 +9,7 @@
 # description: Land-based mitigation and habitat conservation
 # -------------------------------------------------------------
 
-rev <- "rev19"
+rev <- "rev21"
 
 cres <- "c200"
 
@@ -48,9 +48,6 @@ cfg$gms$factor_costs <- "sticky_feb18"
 # SNV habitat defintion
 cfg$gms$land_snv <- "secdforest, other"
 
-# marginal land scenario
-cfg$gms$c29_marginal_land <- "q33_marginal"
-
 start_run(cfg = cfg)
 calib_tgz <- magpie4::submitCalibration(paste(rev, "MitiConsv", sep = "_"))
 
@@ -60,16 +57,15 @@ calib_tgz <- magpie4::submitCalibration(paste(rev, "MitiConsv", sep = "_"))
 
 prefix <- paste(rev, "MitiConsv", cres, sep = "_")
 
-
 scenarios <- c(
-  "SSP2-PB650-NPi", "SSP2-PB650-NDC",
-  "SSP2-PB650-NPi-30by30", "SSP2-PB650-NDC-30by30",
-  "SSP2-PB650-AR200", "SSP2-PB650-AR200-30by30",
-  "SSP2-PB650-AR350", "SSP2-PB650-AR350-30by30",
-  "SSP2-PB650-AR500", "SSP2-PB650-AR500-30by30",
+  "SSP2-PB750-NPi", "SSP2-PB750-NDC",
+  "SSP2-PB750-AR150",  "SSP2-PB750-AR250", "SSP2-PB750-AR350",
+  "SSP2-PB750-NPi-BH", "SSP2-PB750-NDC-BH",
+  "SSP2-PB750-AR250-BH", "SSP2-PB750-AR350-BH", "SSP2-PB750-AR150-BH",
+  "SSP2-PB750-NPi-KBA", "SSP2-PB750-NDC-KBA",
+  "SSP2-PB750-AR250-KBA", "SSP2-PB750-AR350-KBA", "SSP2-PB750-AR150-KBA",
   "SSP2-REF"
 )
-
 
 for (scen in scenarios) {
   scen <- unlist(strsplit(scen, "-"))
@@ -99,58 +95,53 @@ for (scen in scenarios) {
   cfg$gms$land_snv <- "secdforest, other"
 
   # Set path to coupled output
-  pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-NPi-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-NPi-rem-7.mif"
+  pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_Jun25/remind/output/C_rev11_MitiConsv_SSP2-NPi-rem-9/REMIND_generic_C_rev11_MitiConsv_SSP2-NPi-rem-9.mif"
 
   # No ghg price in NPI run
   cfg$gms$c56_mute_ghgprices_until <- "y2100"
 
-  if (any(c("NPi", "NDC") %in% scen)) {
-    cfg <- setScenario(cfg, "NDC")
-    # Update path to coupled output
-    pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-NDC-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-NDC-rem-7.mif"
-    if ("30by30" %in% scen) {
-      pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-NDC-30by30-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-NDC-30by30-rem-7.mif"
-    }
-    if ("NPi" %in% scen) {
-      cfg <- setScenario(cfg, "NPI")
-      pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-NPi-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-NPi-rem-7.mif"
-      if ("30by30" %in% scen) {
-        pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-NPi-30by30-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-NPi-30by30-rem-7.mif"
-      }
-    }
+  if ("NPi" %in% scen) {
+    cfg <- setScenario(cfg, "NPI")
+    pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_Jun25/remind/output/C_rev11_MitiConsv_SSP2-PB750-NPi-rem-9/REMIND_generic_C_rev11_MitiConsv_SSP2-PB750-NPi-rem-9.mif"
     cfg$gms$c56_mute_ghgprices_until <- "y2030"
     cfg <- setScenario(cfg, "AR0", scenario_config = "config/projects/scenario_config_miti_consv.csv")
   }
 
-  if ("AR200" %in% scen) {
-    pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-AR200-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-AR200-rem-7.mif"
-    if ("30by30" %in% scen) {
-      pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-AR200-30by30-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-AR200-30by30-rem-7.mif"
-    }
+  if ("NDC" %in% scen) {
+    cfg <- setScenario(cfg, "NDC")
+    # Update path to coupled output
+    pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_Jun25/remind/output/C_rev11_MitiConsv_SSP2-PB750-NDC-rem-9/REMIND_generic_C_rev11_MitiConsv_SSP2-PB750-NDC-rem-9.mif"
     cfg$gms$c56_mute_ghgprices_until <- "y2030"
-    cfg <- setScenario(cfg, "AR200", scenario_config = "config/projects/scenario_config_miti_consv.csv")
+    cfg <- setScenario(cfg, "AR0", scenario_config = "config/projects/scenario_config_miti_consv.csv")
+  }
+
+  if ("AR150" %in% scen) {
+    cfg <- setScenario(cfg, "NDC")
+    pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_Jun25/remind/output/C_rev11_MitiConsv_SSP2-PB750-AR150-rem-9/REMIND_generic_C_rev11_MitiConsv_SSP2-PB750-AR150-rem-9.mif"
+    cfg$gms$c56_mute_ghgprices_until <- "y2030"
+    cfg <- setScenario(cfg, "AR150", scenario_config = "config/projects/scenario_config_miti_consv.csv")
+  }
+
+  if ("AR250" %in% scen) {
+    cfg <- setScenario(cfg, "NDC")
+    pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_Jun25/remind/output/C_rev11_MitiConsv_SSP2-PB750-AR250-rem-9/REMIND_generic_C_rev11_MitiConsv_SSP2-PB750-AR250-rem-9.mif"
+    cfg$gms$c56_mute_ghgprices_until <- "y2030"
+    cfg <- setScenario(cfg, "AR250", scenario_config = "config/projects/scenario_config_miti_consv.csv")
   }
 
   if ("AR350" %in% scen) {
-    pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-AR350-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-AR350-rem-7.mif"
-    if ("30by30" %in% scen) {
-      pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-AR350-30by30-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-AR350-30by30-rem-7.mif"
-    }
+    cfg <- setScenario(cfg, "NDC")
+    pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_Jun25/remind/output/C_rev11_MitiConsv_SSP2-PB750-AR350-rem-9/REMIND_generic_C_rev11_MitiConsv_SSP2-PB750-AR350-rem-9.mif"
     cfg$gms$c56_mute_ghgprices_until <- "y2030"
     cfg <- setScenario(cfg, "AR350", scenario_config = "config/projects/scenario_config_miti_consv.csv")
   }
 
-  if ("AR500" %in% scen) {
-    pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-AR500-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-AR500-rem-7.mif"
-    if ("30by30" %in% scen) {
-      pathToCoupledOutput <- "/p/projects/magpie/users/vjeetze/magpie/projects/MitiConsv/C_MitiConsv_May25/remind/output/C_rev9_MitiConsv_SSP2-PB650-AR500-30by30-rem-7/REMIND_generic_C_rev9_MitiConsv_SSP2-PB650-AR500-30by30-rem-7.mif"
-    }
-    cfg$gms$c56_mute_ghgprices_until <- "y2030"
-    cfg <- setScenario(cfg, "AR500", scenario_config = "config/projects/scenario_config_miti_consv.csv")
+  if ("BH" %in% scen) {
+    cfg <- setScenario(cfg, "BH", scenario_config = "config/projects/scenario_config_miti_consv.csv")
   }
 
-  if ("30by30" %in% scen) {
-    cfg <- setScenario(cfg, "30by30", scenario_config = "config/projects/scenario_config_miti_consv.csv")
+  if ("KBA" %in% scen) {
+    cfg$gms$c22_protect_scenario <- "KBA"
   }
 
   # Settings taken from coupled runs


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- Just a minor PR that updates the 'mitigation and conservation' start script and updates the miniforge path for SEALS.

## :wrench: Checklist for PR creator :wrench:

- [ ] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [ ] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [ ] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
