### PR TITLE
Bioplastic fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -
 
 ### fixed
+- **62_material** fixed inconsistency for historical bioplastic substrate demand
 - **21_trade** included trade costs into exo realization
 - **default.cfg** input data upgraded to rev4.120 to use corrected clusters using aligned population data
 

--- a/modules/62_material/exo_flexreg_apr16/presolve.gms
+++ b/modules/62_material/exo_flexreg_apr16/presolve.gms
@@ -28,7 +28,7 @@ p62_scaling_factor(i)$(p62_dem_food_lastcalibyear(i) > 0) = sum(kfo, vm_dem_food
 * it in the final biomass demand equation. 
 if (sum(sameas(t_past,t),1) = 1,
   p62_bioplastic_substrate_double_counted(t,i,kall) = p62_bioplastic_substrate(t,i,kall);
-  p62_bioplastic_substrate_lastcalibyear(i,kall) = p62_bioplastic_substrate(t,i,kall);
+  p62_bioplastic_substrate_lastcalibyear(i,kall) = max(p62_bioplastic_substrate(t,i,kall), f62_dem_material(t,i,kall));
 else
   if (s62_include_bioplastic = 0,
     p62_bioplastic_substrate_double_counted(t,i,kall) = 0;

--- a/modules/62_material/exo_flexreg_apr16/presolve.gms
+++ b/modules/62_material/exo_flexreg_apr16/presolve.gms
@@ -28,7 +28,7 @@ p62_scaling_factor(i)$(p62_dem_food_lastcalibyear(i) > 0) = sum(kfo, vm_dem_food
 * it in the final biomass demand equation. 
 if (sum(sameas(t_past,t),1) = 1,
   p62_bioplastic_substrate_double_counted(t,i,kall) = p62_bioplastic_substrate(t,i,kall);
-  p62_bioplastic_substrate_lastcalibyear(i,kall) = max(p62_bioplastic_substrate(t,i,kall), f62_dem_material(t,i,kall));
+  p62_bioplastic_substrate_lastcalibyear(i,kall) = min(p62_bioplastic_substrate(t,i,kall), f62_dem_material(t,i,kall));
 else
   if (s62_include_bioplastic = 0,
     p62_bioplastic_substrate_double_counted(t,i,kall) = 0;


### PR DESCRIPTION
## :bird: Description of this PR :bird:

This PR fixes an issue, where overall material demand (vm_dem_material) can become negative.

**Explanation of the issue:** 
We have historical material demand from FAO, which after the lastCalibYear is projected to the future by using the food demand growth as scaling factor (i.e. assuming the same growth in material demand as in food demand). FAO does not differentiate between different uses of the material demand, so we assume that the FAO material demand does also include the demand for bioplastic substrate (which thus is also scaled according to food demand growth).
Additionally, we have historical demand for bioplastic substrate calculated based on data from the Institute for Bioplastics and Biocomposites (IfBB).
As we project demand bioplastic substrate separately from overall material demand, we need to remove the bioplastic substrate demand that is part of the FAO material demand, as we would otherwise double-count some bioplastic substrate demand.
We do this, by scaling the bioplastic substrate demand in the lastCalibYear with food demand growth and substracting this in the material demand equation (q62_dem_material):

`Total material demand = FAO material demand in lastCalibYear * scaling factor - bioplastic substrate in lastCalibYear * scaling factor + bioplastic substrate demand based on scenario`

The issue arise due to the two datasets (FAO and our calculations based on IfBB) being inconsistent: In some cases we have a higher demand for bioplastic substrate in the lastCalibYear (based on IfBB) then overall material demand (from FAO), while our approach is based on the assumption, that bioplastic substrate demand is a subcategory of overall material demand.

This issue arises for begr and betr (where FAO does not report material demand at all), and in some cases for sugar (CHA, IND, JPN, REF), potato (CAZ, IND, SSA) and tece (IND). See here: 

<img width="2362" height="1771" alt="image" src="https://github.com/user-attachments/assets/db06b016-86d7-43a0-8ed5-fc8af304dac1" />

The inconsistency previously did not lead to any issues, as the `bioplastic substrate demand based on scenario` typically is large enough to balance out the negative `FAO material demand in lastCalibYear * scaling factor - bioplastic substrate in lastCalibYear * scaling factor`. It now got noticed due the demand spike for sugar in JPN, leading to a large scaling factor, which leads to a larger negative value for `FAO material demand in lastCalibYear * scaling factor - bioplastic substrate in lastCalibYear * scaling factor` which is then no longer balanced out by  `bioplastic substrate demand based on scenario`.

**Fix:**
We fix the issue by setting `bioplastic substrate in lastCalibYear = min(bioplastic substrate in lastCalibYear, FAO material demand in lastCalibYear)` to ensure consistency between overall material demand and bioplastic substrate demand. 

**Alternatives:**
With the above solution we assume that in the region/crop categories that were inconsistent between the datasets, all of the material demand is used for bioplastic, which probably is not true, but should be fine as it only concerns small values. 
To remove the inconsistency in the first place, we could also try to revise our disaggregation of the global bioplastic substrate demand to take into account the regional material demand, as we currently only use regional population shares. We could also revise the conversion ratios from bioplastic demand to demand for different crop types as substrate, which currently is assumed to be the same globally.


## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [x] RSE review done (at least 1)
