### PR TITLE
Changes default cellular input data back to ssp245

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -23,7 +23,7 @@ cfg$model <- "main.gms"   #def = "main.gms"
 
 # which input data sets should be used?
 cfg$input <- c(regional    = "rev4.121_h12_magpie.tgz",
-               cellular    = "rev4.121_h12_fd712c0b_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1.tgz",
+               cellular    = "rev4.121_h12_1b5c3817_cellularmagpie_c200_MRI-ESM2-0-ssp245_lpjml-8e6c5eb1.tgz",
                validation  = "rev4.121_h12_validation.tgz",
                additional  = "additional_data_rev4.63.tgz",
                calibration = "calibration_H12_FAO_13Aug25.tgz")


### PR DESCRIPTION
## :bird: Description of this PR :bird:

This PR fixes an accidental change to the scenario of the cellular input data (wrong ssp370, corrected ssp245).

<img width="1181" height="1062" alt="Productivity_Landuse_Intensity_Indicator_Tau" src="https://github.com/user-attachments/assets/407b54ec-b045-4694-93b8-d515c76b9e48" />

<img width="1181" height="1062" alt="Emissions_CO2_Land_RAW_Land_use_Change" src="https://github.com/user-attachments/assets/b8ce07a7-6dc8-44e4-98d1-49e358720f94" />

<img width="1181" height="1062" alt="Resources_Land_Cover_Change_Cropland" src="https://github.com/user-attachments/assets/dc2ef718-ff7a-414d-a33e-4d2df5f8275d" />

<img width="1181" height="1062" alt="Trade_Net_Trade" src="https://github.com/user-attachments/assets/0751a02e-3308-433f-ab9c-e9fb2f368753" />

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [ ] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : 47 mins
  - This PR's default :  44 mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
