### PR TITLE
bugfix 2nd gen bioenergy demand in historic period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -
 
 ### fixed
--
+- **60_bioenergy** Harmonize 2nd gen bioenergy demand for historic period based on default trajectory "R34M410-SSP2-NPi2025"
 
 
 ## [4.12.0] - 2025-09-08

--- a/modules/60_bioenergy/1st2ndgen_priced_feb24/preloop.gms
+++ b/modules/60_bioenergy/1st2ndgen_priced_feb24/preloop.gms
@@ -22,15 +22,15 @@ $elseif "%c60_2ndgen_biodem%" == "emulator"
   i60_bioenergy_dem(t,i) = f60_bioenergy_dem_emulator(t)/card(i);
 $elseif "%c60_2ndgen_biodem%" == "none"
   i60_bioenergy_dem(t,i) = 0;
-** Harmonize till 2020 if not coupled or emulator 
+** Harmonize until sm_fix_SSP2 if not coupled or emulator 
 loop(t$(m_year(t) <= sm_fix_SSP2),
-  i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"R32M46-SSP2EU-NPi");
+  i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"R34M410-SSP2-NPi2025");
 );
 $else
   i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"%c60_2ndgen_biodem%") * p60_region_BE_shr(t,i)
                          + f60_bioenergy_dem(t,i,"%c60_2ndgen_biodem_noselect%") * (1-p60_region_BE_shr(t,i));
-** Harmonize till 2020 if not coupled or emulator 
+** Harmonize until sm_fix_SSP2 if not coupled or emulator 
 loop(t$(m_year(t) <= sm_fix_SSP2),
-  i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"R32M46-SSP2EU-NPi");
+  i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"R34M410-SSP2-NPi2025");
 );
 $endif

--- a/modules/60_bioenergy/1stgen_priced_dec18/preloop.gms
+++ b/modules/60_bioenergy/1stgen_priced_dec18/preloop.gms
@@ -22,15 +22,15 @@ $elseif "%c60_2ndgen_biodem%" == "emulator"
   i60_bioenergy_dem(t,i) = f60_bioenergy_dem_emulator(t)/card(i);
 $elseif "%c60_2ndgen_biodem%" == "none"
   i60_bioenergy_dem(t,i) = 0;
-** Harmonize till 2020 if not coupled or emulator 
+** Harmonize until sm_fix_SSP2 if not coupled or emulator 
 loop(t$(m_year(t) <= sm_fix_SSP2),
-  i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"R32M46-SSP2EU-NPi");
+  i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"R34M410-SSP2-NPi2025");
 );
 $else
   i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"%c60_2ndgen_biodem%") * p60_region_BE_shr(t,i)
                          + f60_bioenergy_dem(t,i,"%c60_2ndgen_biodem_noselect%") * (1-p60_region_BE_shr(t,i));
-** Harmonize till 2020 if not coupled or emulator 
+** Harmonize until sm_fix_SSP2 if not coupled or emulator 
 loop(t$(m_year(t) <= sm_fix_SSP2),
-  i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"R32M46-SSP2EU-NPi");
+  i60_bioenergy_dem(t,i) = f60_bioenergy_dem(t,i,"R34M410-SSP2-NPi2025");
 );
 $endif


### PR DESCRIPTION

## :bird: Description of this PR :bird:

- **60_bioenergy** Harmonize 2nd gen bioenergy demand for historic period based on default trajectory "R34M410-SSP2-NPi2025"

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [x] RSE review done (at least 1)
