### PR TITLE
Fix parenthesis placement in forestry discounting formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -
 
 ### fixed
+- **32_forestry** fixed parenthesis placement in discounting formula for establishment costs
 - **scripts/start_functions.R** added all extra `cfg` arguments in `start_run()` to the config check call
 - **highres.R** temporary f32_max_aff_area.cs4 is now deleted in case of error
 

--- a/modules/32_forestry/dynamic_may24/equations.gms
+++ b/modules/32_forestry/dynamic_may24/equations.gms
@@ -161,7 +161,7 @@ q32_cost_establishment(i2)..
    (sum((cell(i2,j2),type32,ac_est), v32_land(j2,type32,ac_est) * p32_est_cost(type32)))
      * sum(ct,pm_interest(ct,i2)/(1+pm_interest(ct,i2)))
    + sum((ct,kforestry), v32_prod_forestry_future(i2) * p32_forestry_product_dist(ct,i2,kforestry) * im_timber_prod_cost(kforestry))
-     / ((1+sum(ct,pm_interest(ct,i2))**sum(ct, p32_rotation_regional(ct,i2)*5)));
+     / ((1+sum(ct,pm_interest(ct,i2)))**sum(ct, p32_rotation_regional(ct,i2)*5));
 
 
 *' Recurring costs are paid for plantations where the trees have to be regularly monitored


### PR DESCRIPTION
## :bird: Description of this PR :bird:

This fixes a parenthesis placement bug in modules/32_forestry/dynamic_may24/equations.gms that caused incorrect discounting of establishment costs by raising pm_interest to the rotation years instead of (1+pm_interest). The change corrects the compound-interest expression.

The bug was found by Claude Opus 4.5, confirmed by Florian. Below are results from a default and bugfixed MAgPIE run.

<img width="3000" height="2100" alt="establishment_area" src="https://github.com/user-attachments/assets/fdb38b19-cf87-4d42-84af-2672496dd929" />
<img width="3000" height="2100" alt="forestry_costs" src="https://github.com/user-attachments/assets/46e12e4e-cfbf-42c2-bef1-407eb701f6b6" />
<img width="4200" height="3000" alt="land_cover_change_facet" src="https://github.com/user-attachments/assets/eec0c5eb-3231-4363-8438-6b92112e4e9b" />
<img width="3000" height="3300" alt="luc_emissions_components" src="https://github.com/user-attachments/assets/cdceae74-4cba-4bfe-9fd7-7271a354fb1d" />
<img width="3000" height="2100" alt="luc_emissions_total" src="https://github.com/user-attachments/assets/dd60d335-46c6-410e-88b2-7c5ebcd53d93" />
<img width="3000" height="2100" alt="plantation_area" src="https://github.com/user-attachments/assets/ff75151f-07f6-4667-8a33-065bf0074040" />
<img width="4200" height="2400" alt="selected_costs_facet" src="https://github.com/user-attachments/assets/e889aa03-dc2a-4e09-9e60-2bc25436d142" />
<img width="3000" height="3300" alt="timber_harvest_source" src="https://github.com/user-attachments/assets/1d245967-d9be-4c9b-8f1d-8bfb2febcc6f" />

- Briefly explain the purpose of this pull request

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [ ] content review done (at least 1)
- [ ] RSE review done (at least 1)
