### PR TITLE
update to renv 1.1.7

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -27,7 +27,7 @@ if (!"https://rse.pik-potsdam.de/r/packages" %in% getOption("repos")) {
 # bootstrapping, will only run once after this repo is freshly cloned
 if (isTRUE(rownames(installed.packages(priority = "NA")) == "renv")) {
   message("R package dependencies are not installed in this renv, installing now...")
-  renv::install("rmarkdown", prompt = FALSE) # rmarkdown is required to find dependencies in Rmd files
+  renv::hydrate("rmarkdown", prompt = FALSE) # rmarkdown is required to find dependencies in Rmd files
   renv::hydrate(prompt = FALSE, report = FALSE) # auto-detect and install all dependencies
   message("Finished installing R package dependencies.")
   if (!("upstream" %in% gert::git_remote_list()$name)) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **inputdata** updated input data to rev4.128, including fix for mismatch between historic urban land in LUH3 and projected future urban land, which is still based on LUH2
 - **inputdata** updated input data to rev4.129, which now includes new protected area data for China not covered in the WDPA data base.
 - **60_bioenergy** set `i60_res_2ndgenBE_dem` also for historical period to `off` if `c60_res_2ndgenBE_dem` is set to `off` (do not apply scenario harmonization on it)
+- **renv/activate.R** updated to version 1.1.7
 
 ### added
 -

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,8 @@
 local({
 
   # the requested version of renv
-  version <- "1.1.5"
+  version <- "1.1.7"
+  attr(version, "md5") <- NULL
   attr(version, "sha") <- NULL
 
   # the project directory
@@ -168,6 +169,16 @@ local({
     if (quiet)
       return(invisible())
   
+    # also check for config environment variables that should suppress messages
+    # https://github.com/rstudio/renv/issues/2214
+    enabled <- Sys.getenv("RENV_CONFIG_STARTUP_QUIET", unset = NA)
+    if (!is.na(enabled) && tolower(enabled) %in% c("true", "1"))
+      return(invisible())
+  
+    enabled <- Sys.getenv("RENV_CONFIG_SYNCHRONIZED_CHECK", unset = NA)
+    if (!is.na(enabled) && tolower(enabled) %in% c("false", "0"))
+      return(invisible())
+  
     msg <- sprintf(fmt, ...)
     cat(msg, file = stdout(), sep = if (appendLF) "\n" else "")
   
@@ -215,6 +226,16 @@ local({
     section <- header(sprintf("Bootstrapping renv %s", friendly))
     catf(section)
   
+    # try to install renv from cache
+    md5 <- attr(version, "md5", exact = TRUE)
+    if (length(md5)) {
+      pkgpath <- renv_bootstrap_find(version)
+      if (length(pkgpath) && file.exists(pkgpath)) {
+        file.copy(pkgpath, library, recursive = TRUE)
+        return(invisible())
+      }
+    }
+  
     # attempt to download renv
     catf("- Downloading renv ... ", appendLF = FALSE)
     withCallingHandlers(
@@ -240,7 +261,6 @@ local({
   
     # add empty line to break up bootstrapping from normal output
     catf("")
-  
     return(invisible())
   }
   
@@ -257,12 +277,20 @@ local({
     repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
     if (!is.na(repos)) {
   
-      # check for RSPM; if set, use a fallback repository for renv
-      rspm <- Sys.getenv("RSPM", unset = NA)
-      if (identical(rspm, repos))
-        repos <- c(RSPM = rspm, CRAN = cran)
+      # split on ';' if present
+      parts <- strsplit(repos, ";", fixed = TRUE)[[1L]]
   
-      return(repos)
+      # split into named repositories if present
+      idx <- regexpr("=", parts, fixed = TRUE)
+      keys <- substring(parts, 1L, idx - 1L)
+      vals <- substring(parts, idx + 1L)
+      names(vals) <- keys
+  
+      # if we have a single unnamed repository, call it CRAN
+      if (length(vals) == 1L && identical(keys, ""))
+        names(vals) <- "CRAN"
+  
+      return(vals)
   
     }
   
@@ -508,6 +536,51 @@ local({
     }
   
     return(FALSE)
+  
+  }
+  
+  renv_bootstrap_find <- function(version) {
+  
+    path <- renv_bootstrap_find_cache(version)
+    if (length(path) && file.exists(path)) {
+      catf("- Using renv %s from global package cache", version)
+      return(path)
+    }
+  
+  }
+  
+  renv_bootstrap_find_cache <- function(version) {
+  
+    md5 <- attr(version, "md5", exact = TRUE)
+    if (is.null(md5))
+      return()
+  
+    # infer path to renv cache
+    cache <- Sys.getenv("RENV_PATHS_CACHE", unset = "")
+    if (!nzchar(cache)) {
+      root <- Sys.getenv("RENV_PATHS_ROOT", unset = NA)
+      if (!is.na(root))
+        cache <- file.path(root, "cache")
+    }
+  
+    if (!nzchar(cache)) {
+      tools <- asNamespace("tools")
+      if (is.function(tools$R_user_dir)) {
+        root <- tools$R_user_dir("renv", "cache")
+        cache <- file.path(root, "cache")
+      }
+    }
+  
+    # start completing path to cache
+    file.path(
+      cache,
+      renv_bootstrap_cache_version(),
+      renv_bootstrap_platform_prefix(),
+      "renv",
+      version,
+      md5,
+      "renv"
+    )
   
   }
   
@@ -979,7 +1052,7 @@ local({
   
   renv_bootstrap_validate_version_release <- function(version, description) {
     expected <- description[["Version"]]
-    is.character(expected) && identical(expected, version)
+    is.character(expected) && identical(c(expected), c(version))
   }
   
   renv_bootstrap_hash_text <- function(text) {
@@ -1179,6 +1252,18 @@ local({
   
     warning(paste(msg, collapse = "\n"), call. = FALSE)
   
+  }
+  
+  renv_bootstrap_cache_version <- function() {
+    # NOTE: users should normally not override the cache version;
+    # this is provided just to make testing easier
+    Sys.getenv("RENV_CACHE_VERSION", unset = "v5")
+  }
+  
+  renv_bootstrap_cache_version_previous <- function() {
+    version <- renv_bootstrap_cache_version()
+    number <- as.integer(substring(version, 2L))
+    paste("v", number - 1L, sep = "")
   }
   
   renv_json_read <- function(file = NULL, text = NULL) {


### PR DESCRIPTION
## :bird: Description of this PR :bird:
- renv 1.1.6 fixed a bug that led to unprotected renv cache folders/files, see [renv changelog](https://rstudio.github.io/renv/news/index.html#renv-116):
> Fixed an issue where cache callbacks (e.g. those run by setting RENV_CACHE_USER and RENV_CACHE_MODE, or via the renv.cache.callback option) were not run after [renv::hydrate()](https://rstudio.github.io/renv/reference/hydrate.html). ([#2179](https://github.com/rstudio/renv/issues/2179))

## :wrench: Checklist for PR creator :wrench:

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)

### :chart_with_downwards_trend: Performance changes :chart_with_upwards_trend:
  
  - Current develop branch default : ** mins
  - This PR's default :  ** mins

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
- [x] content review done (at least 1)
- [x] RSE review done (at least 1)
