### PR TITLE
shinyresults inbox & renv 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### changed
--
+- **scripts** saveToResultsArchive saves to inbox folder if available
+- **renv/activate.R** updated to version 1.2.2
 
 ### added
 - **80_optimization/nlp_ipopt** New realization, using IPOPT instead of CONOPT4 (and the fallback CONOPT3) as the NLP solver for the MAgPIE model.

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "1.1.7"
+  version <- "1.2.2"
   attr(version, "md5") <- NULL
   attr(version, "sha") <- NULL
 
@@ -226,13 +226,17 @@ local({
     section <- header(sprintf("Bootstrapping renv %s", friendly))
     catf(section)
   
+    # ensure the target library path exists; required for file.copy(..., recursive = TRUE)
+    dir.create(library, showWarnings = FALSE, recursive = TRUE)
+  
     # try to install renv from cache
     md5 <- attr(version, "md5", exact = TRUE)
     if (length(md5)) {
       pkgpath <- renv_bootstrap_find(version)
       if (length(pkgpath) && file.exists(pkgpath)) {
-        file.copy(pkgpath, library, recursive = TRUE)
-        return(invisible())
+        ok <- file.copy(pkgpath, library, recursive = TRUE)
+        if (isTRUE(ok))
+          return(invisible())
       }
     }
   
@@ -1231,6 +1235,21 @@ local({
   }
   
   renv_bootstrap_run <- function(project, libpath, version) {
+    tryCatch(
+      renv_bootstrap_run_impl(project, libpath, version),
+      error = function(e) {
+        msg <- paste(
+          "failed to bootstrap renv: the project will not be loaded.",
+          paste("Reason:", conditionMessage(e)),
+          "Use `renv::activate()` to re-initialize the project.",
+          sep = "\n"
+        )
+        warning(msg, call. = FALSE)
+      }
+    )
+  }
+  
+  renv_bootstrap_run_impl <- function(project, libpath, version) {
   
     # perform bootstrap
     bootstrap(version, libpath)

--- a/scripts/helper.R
+++ b/scripts/helper.R
@@ -5,6 +5,10 @@
 #' Ensures that run statistics have a valid id, saves the quitte object as an
 #' RDS file named after that id in the results archive, and updates the file
 #' list used by shinyresults.
+#' If an inbox folder (`paste0(normalizePath(resultsarchive), "-inbox")`)
+#' exists the rds file is put there instead. This is useful to then sync only
+#' the inbox files to another machine, before moving them to the actual
+#' results archive, potentially via cronjob.
 #'
 #' @param qu A quitte object to be saved.
 #' @param runstatistics Path to the runstatistics.rda file.
@@ -32,11 +36,13 @@ saveToResultsArchive <- function(qu, runstatistics, submit,
     save(stats, file = runstatistics, compress = "xz")
   }
 
+  inbox <- paste0(normalizePath(resultsarchive), "-inbox")
+  if (dir.exists(inbox)) {
+    resultsarchive <- inbox
+  }
+
   # Save report to results archive
   saveRDS(qu, file = paste0(resultsarchive, "/", stats$id, ".rds"), version = 2)
-  withr::with_dir(resultsarchive, {
-    system("find -type f -name '1*.rds' -printf '%f\n' | sort > fileListForShinyresults")
-  })
 }
 
 chooseSubmit <- function(title, slurmModes) {

--- a/scripts/output/extra/highres.R
+++ b/scripts/output/extra/highres.R
@@ -31,7 +31,6 @@ cfg <- gms::loadConfig(file.path(outputdir, "config.yml"))
 gdx <- file.path(outputdir,"fulldata.gdx")
 rds <- paste0(outputdir, "/report.rds")
 runstatistics <- paste0(outputdir,"/runstatistics.rda")
-resultsarchive <- "/p/projects/rd3mod/models/results/magpie"
 ###############################################################################
 
 # Load start_run(cfg) function which is needed to start MAgPIE runs


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- upgrade to renv 1.2.2
- shinyresults inbox: This is useful to then sync only the inbox files to another machine, before moving them to the actual results archive
- a new cronjob uploads to RSE server, moves inbox files to the actual archive, and updates fileListForShinyresults: `/p/projects/rd3mod/cronjob-scripts/upload_magpie.sh`

## :wrench: Checklist for PR creator :wrench:

If a point is not applicable, check the checkbox anyway and write "non-applicable" next to the checkbox.

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run default run via `Rscript start.R --> "default"`
    - Check logs for errors/warnings
    - Fill in performance section below
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    - Fill in performance section below

- [x] Reporting produces no errors and no new warnings

- Get two approving reviews (at least one from RSE)

### :chart_with_downwards_trend: Performance :chart_with_upwards_trend:

  - This PR's default :  ** mins
  - For comparison: [runtimes](https://gitlab.pik-potsdam.de/landuse/testing_suite) of weekly test

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
