### PR TITLE
apptainer hook

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -20,9 +20,7 @@ options(renv.config.synchronized.check = FALSE,
 
 source("renv/activate.R")
 
-if (!"https://rse.pik-potsdam.de/r/packages" %in% getOption("repos")) {
-  options(repos = c(getOption("repos"), pik = "https://rse.pik-potsdam.de/r/packages"))
-}
+options(repos = unique(c(getOption("repos"), pikpiam = "https://pik-piam.r-universe.dev", pik = "https://rse.pik-potsdam.de/r/packages")))
 
 # bootstrapping, will only run once after this repo is freshly cloned
 if (isTRUE(rownames(installed.packages(priority = "NA")) == "renv")) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scripts/start/extra/ipopt.R** Start script for solving MAgPIE with IPOPT.
 - **Dockerfile** Re-added a Dockerfile, which can be used to build a local docker image as well as a GH codespace
 - **.devcontainer/devcontainer.json** A new configuration for development containers, which allow for reproducible, prepared development environments
+- **scripts** added $RSCRIPT_SLURM_HOOK to run on slurm compute nodes via apptainer
 
 ### removed
 -

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -677,7 +677,7 @@ cfg$gms$s21_trade_bal_damper <- 0.65 # def 0.65
 # * sm_fix_SSP2 for scenario applications.
 cfg$gms$s21_stddev_lib_factor <- 1 # def = 1
 
-# * Multiplier term on the import supply ratio itself (changing 
+# * Multiplier term on the import supply ratio itself (changing
 # * amount traded between partners). This factor is applied with
 # * a linear fade in to avoid large jumps, until s21_import_supply_scenario_targetyear.
 cfg$gms$s21_import_supply_scenario <- 1 # def = 1
@@ -1004,7 +1004,7 @@ cfg$gms$s32_aff_bii_coeff <- 0    # def = 0
 # * ("npi"): prescribed afforestation based on NPI (National Policies Implemented) policies
 # * ("ndc"): prescribed afforestation based on NPI+NDC (National Determined Contributions) policies
 # * ("affexp"): afforestation expansion policy with NPI-2025 baseline + country-specific forest expansion targets after 2030 as a share
-# *             of available potential forests and at a given annual rate, differentiated between developing and developed counties 
+# *             of available potential forests and at a given annual rate, differentiated between developing and developed counties
 cfg$gms$c32_aff_policy <- "npi"              # def = "npi"
 
 # Year in which NPI NDC reversal should take place (e.g. 2025)
@@ -2334,7 +2334,7 @@ cfg$sequential <- NA
 # *              standby (24h max, 3 CPUs, preemption possible)
 # *              standby_highMem (same as standby but with 16 CPUs and 80GB of memory)
 # *              NULL (educated guess of best option based on available resources)
-cfg$qos <- "priority"               # def = NULL
+cfg$qos <- NULL               # def = NULL
 
 # How should log information be treated?
 # (0:no output, 2:write to full.log 3:show in console)

--- a/config/default.cfg
+++ b/config/default.cfg
@@ -2334,7 +2334,7 @@ cfg$sequential <- NA
 # *              standby (24h max, 3 CPUs, preemption possible)
 # *              standby_highMem (same as standby but with 16 CPUs and 80GB of memory)
 # *              NULL (educated guess of best option based on available resources)
-cfg$qos <- NULL               # def = NULL
+cfg$qos <- "priority"               # def = NULL
 
 # How should log information be treated?
 # (0:no output, 2:write to full.log 3:show in console)

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "1.2.2"
+  version <- "1.2.3"
   attr(version, "md5") <- NULL
   attr(version, "sha") <- NULL
 

--- a/scripts/run_submit/submit_medium.sh
+++ b/scripts/run_submit/submit_medium.sh
@@ -6,4 +6,4 @@
 #SBATCH --mail-type=END,FAIL
 #SBATCH --cpus-per-task=3
 
-Rscript submit.R
+$RSCRIPT_SLURM_HOOK Rscript submit.R

--- a/scripts/run_submit/submit_priority.sh
+++ b/scripts/run_submit/submit_priority.sh
@@ -8,4 +8,4 @@
 #SBATCH --mem-per-cpu=5G
 #SBATCH --time=24:00:00
 
-Rscript submit.R
+apptainer exec /p/tmp/pascalfu/piam-apptainer/piam.sif Rscript submit.R

--- a/scripts/run_submit/submit_priority.sh
+++ b/scripts/run_submit/submit_priority.sh
@@ -8,4 +8,4 @@
 #SBATCH --mem-per-cpu=5G
 #SBATCH --time=24:00:00
 
-apptainer exec /p/tmp/pascalfu/piam-apptainer/piam.sif Rscript submit.R
+$RSCRIPT_SLURM_HOOK Rscript submit.R

--- a/scripts/run_submit/submit_priority_highMem.sh
+++ b/scripts/run_submit/submit_priority_highMem.sh
@@ -8,4 +8,4 @@
 #SBATCH --mem-per-cpu=5G
 #SBATCH --time=24:00:00
 
-Rscript submit.R
+$RSCRIPT_SLURM_HOOK Rscript submit.R

--- a/scripts/run_submit/submit_short.sh
+++ b/scripts/run_submit/submit_short.sh
@@ -8,4 +8,4 @@
 #SBATCH --mem-per-cpu=5G
 #SBATCH --time=24:00:00
 
-Rscript submit.R
+$RSCRIPT_SLURM_HOOK Rscript submit.R

--- a/scripts/run_submit/submit_short_highMem.sh
+++ b/scripts/run_submit/submit_short_highMem.sh
@@ -8,5 +8,4 @@
 #SBATCH --mem-per-cpu=5G
 #SBATCH --time=24:00:00
 
-Rscript submit.R
-
+$RSCRIPT_SLURM_HOOK Rscript submit.R

--- a/scripts/run_submit/submit_standby.sh
+++ b/scripts/run_submit/submit_standby.sh
@@ -8,4 +8,4 @@
 #SBATCH --mem-per-cpu=5G
 #SBATCH --time=24:00:00
 
-Rscript submit.R
+$RSCRIPT_SLURM_HOOK Rscript submit.R

--- a/scripts/run_submit/submit_standby_highMem.sh
+++ b/scripts/run_submit/submit_standby_highMem.sh
@@ -8,4 +8,4 @@
 #SBATCH --mem-per-cpu=5G
 #SBATCH --time=24:00:00
 
-Rscript submit.R
+$RSCRIPT_SLURM_HOOK Rscript submit.R

--- a/scripts/slurmOutput.yml
+++ b/scripts/slurmOutput.yml
@@ -1,5 +1,5 @@
 slurmjobs:
-  SLURM standby:          "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --mem-per-cpu=5G --cpus-per-task=3 --qos=standby --time=200"
-  SLURM standby highMem:  "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --mem-per-cpu=5G --cpus-per-task=16 --qos=standby --time=24:00:00"
-  SLURM priority:         "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --mem-per-cpu=5G --cpus-per-task=3 --qos=priority --time=200"
-  SLURM priority highMem: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --mem-per-cpu=5G --cpus-per-task=16 --qos=priority --time=24:00:00"
+  SLURM standby:          "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --wrap=\"$RSCRIPT_SLURM_HOOK Rscript %SCRIPT\" --mem-per-cpu=5G --cpus-per-task=3 --qos=standby --time=200"
+  SLURM standby highMem:  "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --wrap=\"$RSCRIPT_SLURM_HOOK Rscript %SCRIPT\" --mem-per-cpu=5G --cpus-per-task=16 --qos=standby --time=24:00:00"
+  SLURM priority:         "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --wrap=\"$RSCRIPT_SLURM_HOOK Rscript %SCRIPT\" --mem-per-cpu=5G --cpus-per-task=3 --qos=priority --time=200"
+  SLURM priority highMem: "sbatch --job-name=scripts-output --output=logs/out-%NAME-%j.out --error=logs/out-%NAME-%j.err --mail-type=END,FAIL --wrap=\"$RSCRIPT_SLURM_HOOK Rscript %SCRIPT\" --mem-per-cpu=5G --cpus-per-task=16 --qos=priority --time=24:00:00"

--- a/scripts/slurmStart.yml
+++ b/scripts/slurmStart.yml
@@ -1,4 +1,4 @@
 slurmjobs:
-  SLURM priority: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --cpus-per-task=3 --time=24:00:00 --qos=priority"
+  SLURM priority: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"apptainer exec /p/tmp/pascalfu/piam-apptainer/piam.sif Rscript %SCRIPT\" --cpus-per-task=3 --time=24:00:00 --qos=priority"
   SLURM standby:  "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --cpus-per-task=3 --time=24:00:00 --qos=standby"
   SLURM medium:   "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --cpus-per-task=3 --qos=medium"

--- a/scripts/slurmStart.yml
+++ b/scripts/slurmStart.yml
@@ -1,4 +1,4 @@
 slurmjobs:
-  SLURM priority: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"apptainer exec /p/tmp/pascalfu/piam-apptainer/piam.sif Rscript %SCRIPT\" --cpus-per-task=3 --time=24:00:00 --qos=priority"
-  SLURM standby:  "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --cpus-per-task=3 --time=24:00:00 --qos=standby"
-  SLURM medium:   "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"Rscript %SCRIPT\" --cpus-per-task=3 --qos=medium"
+  SLURM priority: "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"$RSCRIPT_SLURM_HOOK Rscript %SCRIPT\" --cpus-per-task=3 --time=24:00:00 --qos=priority"
+  SLURM standby:  "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"$RSCRIPT_SLURM_HOOK Rscript %SCRIPT\" --cpus-per-task=3 --time=24:00:00 --qos=standby"
+  SLURM medium:   "sbatch --job-name=%NAME --output=logs/%NAME-%j.out --mail-type=END,FAIL --wrap=\"$RSCRIPT_SLURM_HOOK Rscript %SCRIPT\" --cpus-per-task=3 --qos=medium"


### PR DESCRIPTION
## :bird: Description of this PR :bird:

in our apptainer setup on hpc $RSCRIPT_SLURM_HOOK will resolve to
`apptainer exec /path/to/piam.sif`, running Rscript in an apptainer. In other context (non-hpc, or piam module setup) it resolves to an empty string, so Rscript will just directly be called (as before).


## :wrench: Checklist for PR creator :wrench:

If a point is not applicable, check the checkbox anyway and write "non-applicable" next to the checkbox.

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run default run via `Rscript start.R --> "default"`
    - Check logs for errors/warnings
    - Fill in performance section below
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    - Fill in performance section below

- [x] Reporting produces no errors and no new warnings

- Get two approving reviews (at least one from RSE)

### :chart_with_downwards_trend: Performance :chart_with_upwards_trend:

  - This PR's default :  ** mins
  - For comparison: [runtimes](https://gitlab.pik-potsdam.de/landuse/testing_suite) of weekly test

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
