### PR TITLE
fix renv issue with unnamed repos

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -20,7 +20,9 @@ options(renv.config.synchronized.check = FALSE,
 
 source("renv/activate.R")
 
-options(repos = unique(c(getOption("repos"), pikpiam = "https://pik-piam.r-universe.dev", pik = "https://rse.pik-potsdam.de/r/packages")))
+# unique strips names which breaks renv, so use duplicated
+options(repos = c(getOption("repos"), pikpiam = "https://pik-piam.r-universe.dev", pik = "https://rse.pik-potsdam.de/r/packages"))
+options(repos = getOption("repos")[!duplicated(getOption("repos"))])
 
 # bootstrapping, will only run once after this repo is freshly cloned
 if (isTRUE(rownames(installed.packages(priority = "NA")) == "renv")) {


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- in .Rprofile setting the repos with `unique` stripped names which broke renv::snapshot, effectively preventing new run folders from being created

## :wrench: Checklist for PR creator :wrench:

If a point is not applicable, check the checkbox anyway and write "non-applicable" next to the checkbox.

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run default run via `Rscript start.R --> "default"`
    - Check logs for errors/warnings
    - Fill in performance section below
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    - Fill in performance section below

- [x] Reporting produces no errors and no new warnings

- Get two approving reviews (at least one from RSE)

### :chart_with_downwards_trend: Performance :chart_with_upwards_trend:

  - This PR's default :  ** mins
  - For comparison: [runtimes](https://gitlab.pik-potsdam.de/landuse/testing_suite) of weekly test

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
