### PR TITLE
59_som: carry soil pcm_carbon_stock forward each timestep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scripts/projects/fsec.R** Removed FSEC_nitrogenPollution (grid-level nitrogen pollution downscaling) from the FSEC run output pipeline.
 
 ### fixed
+- **59_som** Carry the soil carbon stock (`pcm_carbon_stock(...,"soilc",...)`) forward each timestep in `postsolve` (both `cellpool_jan23` and `static_jan19`), so the soil term in `vm_emissions_reg` (`q52_emis_co2_actual`) is a per-timestep flux instead of a cumulative-since-initialisation change.
 - **21_trade** Bugfix and refinement of bilateral trade realization to avoid infeasibiliteis in SSP4 and SSP5.
 
 

--- a/modules/59_som/cellpool_jan23/postsolve.gms
+++ b/modules/59_som/cellpool_jan23/postsolve.gms
@@ -9,6 +9,9 @@ pc59_som_pool(j,land) = v59_som_pool.l(j,land);
 pc59_land_before(j,land) = vm_land.l(j,land);
 pc59_carbon_density(j,land)$(pc59_land_before(j,land) > 1e-10) = pc59_som_pool(j,land) / pc59_land_before(j,land);
 
+*** Carry the soil carbon stock forward to the next timestep (as done for the above-ground pools in 56_ghg_policy).
+pcm_carbon_stock(j,land,"soilc",stockType) = vm_carbon_stock.l(j,land,"soilc",stockType);
+
 *#################### R SECTION START (OUTPUT DEFINITIONS) #####################
  ov59_som_target(t,j,land,"marginal")                      = v59_som_target.m(j,land);
  ov59_som_pool(t,j,land,"marginal")                        = v59_som_pool.m(j,land);

--- a/modules/59_som/static_jan19/postsolve.gms
+++ b/modules/59_som/static_jan19/postsolve.gms
@@ -5,7 +5,8 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
-
+*** Carry the soil carbon stock forward to the next timestep (as done for the above-ground pools in 56_ghg_policy).
+pcm_carbon_stock(j,land,"soilc",stockType) = vm_carbon_stock.l(j,land,"soilc",stockType);
 
 *#################### R SECTION START (OUTPUT DEFINITIONS) #####################
  ov_nr_som(t,j,"marginal")                                       = vm_nr_som.m(j);


### PR DESCRIPTION
## :bird: Description of this PR :bird:

In both SOM realizations (`cellpool_jan23`, `static_jan19`) the previous-timestep soil carbon stock `pcm_carbon_stock(...,"soilc",...)` was set once in `preloop` and never updated — unlike the above-ground pools, which `56_ghg_policy/price_aug22/postsolve.gms` carries forward every timestep.

Consequently the soil term in `q52_emis_co2_actual` (`vm_emissions_reg`) and the soil pricing term in `q56_emis_pricing_co2` computed `(initial_stock − current_stock)/m_timestep_length` — a *cumulative-since-initialisation* change — instead of the per-timestep flux the equation claims to compute. In a default H12 run the per-pool soil CO₂ was off by ~17× and did not sum to the net soil stock change (above-ground pools were correct).

**Fix:** add the missing soil carry-forward in both SOM postsolves, mirroring the `ag_pools` line:
```gams
pcm_carbon_stock(j,land,"soilc",stockType) = vm_carbon_stock.l(j,land,"soilc",stockType);
```

`static_jan19` is affected too: its soil stock is `area × density`, which changes between timesteps with land use and (climate-driven) density. "Static" refers to the absence of SOM pool dynamics, not a constant stock.

**Impact:** default runs are unaffected — default `c56_emis_policy`/`c56_cap_policy` (`reddnatveg_nosoil`) exclude soil, and reporting routes dynamic-SOM soil through `magpie4::emisSOC`. Only soil-inclusive emission policies, or post-processing that reads per-pool soil `vm_emissions_reg` directly, are affected.

## :wrench: Checklist for PR creator :wrench:

If a point is not applicable, check the checkbox anyway and write "non-applicable" next to the checkbox.

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run default run via `Rscript start.R --> "default"`
    - Check logs for errors/warnings
    - Fill in performance section below
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    - Fill in performance section below

- [x] Reporting produces no errors and no new warnings

- Get two approving reviews (at least one from RSE)

### :chart_with_downwards_trend: Performance :chart_with_upwards_trend:

  - This PR's default :  ** mins
  - For comparison: [runtimes](https://gitlab.pik-potsdam.de/landuse/testing_suite) of weekly test

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
