### PR TITLE
new target: reset-renv, merge master, repos setting

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -21,8 +21,12 @@ options(renv.config.synchronized.check = FALSE,
 source("renv/activate.R")
 
 # unique strips names which breaks renv, so use duplicated
-options(repos = c(getOption("repos"), pikpiam = "https://pik-piam.r-universe.dev", pik = "https://rse.pik-potsdam.de/r/packages"))
-options(repos = getOption("repos")[!duplicated(getOption("repos"))])
+if (!"pikpiam" %in% names(getOption("repos"))) {
+  options(repos = c(getOption("repos"), pikpiam = Sys.getenv("R_UNIVERSE_URL", "https://pik-piam.r-universe.dev")))
+}
+if (!"pik" %in% names(getOption("repos"))) {
+  options(repos = c(getOption("repos"), pik = "https://rse.pik-potsdam.de/r/packages"))
+}
 
 # bootstrapping, will only run once after this repo is freshly cloned
 if (isTRUE(rownames(installed.packages(priority = "NA")) == "renv")) {

--- a/.codeCheck
+++ b/.codeCheck
@@ -4,3 +4,11 @@ capitalExclusionList:
   - type
   - age
   - k
+  - som
+  - ssp1
+  - ssp2
+  - ssp3
+  - ssp4
+  - ssp5
+  - sdp
+  - default

--- a/.github/workflows/build-magpie-image.yml
+++ b/.github/workflows/build-magpie-image.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'Dockerfile'
+
+name: build-magpie-image
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/magpiemodel/magpie-image:latest
+            ghcr.io/magpiemodel/magpie-image:${{ github.sha }}

--- a/.github/workflows/build-magpie-image.yml
+++ b/.github/workflows/build-magpie-image.yml
@@ -8,6 +8,7 @@ name: build-magpie-image
 
 jobs:
   build:
+    if: github.repository == 'magpiemodel/magpie'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-magpie-image.yml
+++ b/.github/workflows/build-magpie-image.yml
@@ -3,6 +3,7 @@ on:
     branches: [develop]
     paths:
       - 'Dockerfile'
+  workflow_dispatch: # need empty workflow_dispatch so we can manually trigger in web ui
 
 name: build-magpie-image
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1305,3 +1305,4 @@ First open source release of the framework. See [MAgPIE 4.0 paper](https://doi.o
 [4.0.0]: https://github.com/magpiemodel/magpie/releases/tag/v4.0
 
 [REMIND model]: https://www.pik-potsdam.de/research/transformation-pathways/models/remind
+bla

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **scripts** saveToResultsArchive saves to inbox folder if available
 - **renv/activate.R** updated to version 1.2.3
 - **CI** test-code.yaml: use ubuntu-latest and checkout@v7
+- **Makefile** `make reset-renv` resets renv
+- **.Rprofile** add r-universe repo, use envvars if present
 
 ### added
 - **scenario_config_susmip.csv** A set of sceanrios for the SusMIP excercise in the PRISMA project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1305,4 +1305,3 @@ First open source release of the framework. See [MAgPIE 4.0 paper](https://doi.o
 [4.0.0]: https://github.com/magpiemodel/magpie/releases/tag/v4.0
 
 [REMIND model]: https://www.pik-potsdam.de/research/transformation-pathways/models/remind
-bla

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ restore-renv: ## Restore renv to the state described in interactively
 	Rscript -e 'piamenv::restoreRenv()'
 
 reset-renv: ## reset renv to state of a freshly cloned repo
+	chmod +w -R renv
 	rm -r renv
 	git restore renv
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help docs update-renv update-renv-all archive-renv restore-renv check check-fix start output
+.PHONY: help docs update-renv update-renv-all archive-renv restore-renv reset-renv check check-fix start output
 .DEFAULT_GOAL := help
 
 # extracts the help text and formats it nicely
@@ -29,6 +29,10 @@ archive-renv: ## Write renv.lock to archive.
 restore-renv: ## Restore renv to the state described in interactively
               ## selected renv.lock from the archive or a run folder.
 	Rscript -e 'piamenv::restoreRenv()'
+
+reset-renv: ## reset renv to state of a freshly cloned repo
+	rm -r renv
+	git restore renv
 
 check: ## Check if the GAMS code follows the coding etiquette
        ## using gms::codeCheck.


### PR DESCRIPTION
## :bird: Description of this PR :bird:

- merge master into develop (changes from https://github.com/magpiemodel/magpie/pull/906)
- set repos differently (no functional changes, preparation for piam-apptainer setup)
- `make reset-renv` resets renv

## :wrench: Checklist for PR creator :wrench:

If a point is not applicable, check the checkbox anyway and write "non-applicable" next to the checkbox.

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run default run via `Rscript start.R --> "default"`
    - Check logs for errors/warnings
    - Fill in performance section below
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    - Fill in performance section below

- [x] Reporting produces no errors and no new warnings

- Get two approving reviews (at least one from RSE)

### :chart_with_downwards_trend: Performance :chart_with_upwards_trend:

  - This PR's default :  ** mins
  - For comparison: [runtimes](https://gitlab.pik-potsdam.de/landuse/testing_suite) of weekly test

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
