### PR TITLE
Dockerfile upgrade to ubuntu 26.04, R 4.6, gams 54.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **CI** test-code.yaml: use ubuntu-latest and checkout@v7
 - **Makefile** `make reset-renv` resets renv
 - **.Rprofile** add r-universe repo, use envvars if present
+- **Dockerfile** now based on ubuntu 26.04, R 4.6, gams 54.1
 
 ### added
 - **scenario_config_susmip.csv** A set of sceanrios for the SusMIP excercise in the PRISMA project

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,17 +137,6 @@ RUN echo "Verifying installations..." && \
 
 ENV MAGPIE_IMAGE_VERSION="2.0"
 
-# can be removed once we have https://github.com/magpiemodel/magpie/pull/884 in master
-RUN printf "\
-  - som\n\
-  - ssp1\n\
-  - ssp2\n\
-  - ssp3\n\
-  - ssp4\n\
-  - ssp5\n\
-  - sdp\n\
-  - default\n" >> .codeCheck
-
 # Default command: Start MAgPIE interactively
 # Users can run: docker run -it magpie
 # Or specify a run script: docker run magpie Rscript start.R default direct

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,21 @@
 # docker run -it -v /path/to/your/gamslice.txt:/opt/gams/gamslice.txt \
 #            -v $(pwd):/opt/magpie magpie
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
+ARG UBUNTU_CODENAME=resolute # check https://en.wikipedia.org/wiki/Ubuntu_version_history
+RUN bash -c "[[ `cat /etc/os-release | grep '^VERSION_CODENAME=' | cut -d= -f2` = '${UBUNTU_CODENAME}' ]] || exit 1"
 
-# Install system dependencies (before WORKDIR to maximize cache hits)
+ARG LOCALE=C.UTF-8
+ENV LC_ALL=${LOCALE}
+ENV LANG=${LOCALE}
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt update && \
+  DEBIAN_FRONTEND=noninteractive apt install -y \
+    texlive-full && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
@@ -32,12 +44,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     curl \
     git \
     unzip \
+    vim \
     # Build tools
     build-essential \
     cmake \
-    # R and dependencies
-    r-base \
-    r-base-dev \
     # System libraries required for R packages
     libfontconfig1 \
     libfontconfig1-dev \
@@ -59,26 +69,49 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libuv1-dev \
     pari-gp \
     qpdf \
-    # Pandoc
     pandoc \
-    # Other utilities
-    ca-certificates \
-    # basic LaTeX tools
-    texlive-latex-recommended \
-    && rm -rf /var/lib/apt/lists/*
+    ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
 
-# Install basic latex packages
-RUN tlmgr init-usertree && \
-  tlmgr option repository https://ftp.tu-chemnitz.de/pub/tug/historic/systems/texlive/2023/tlnet-final && \
-  tlmgr install sourcesanspro sourcecodepro pagecolor framed
+# install rig (R version manager) and R
+RUN curl -L https://rig.r-pkg.org/deb/rig.gpg -o /etc/apt/trusted.gpg.d/rig.gpg && \
+  sh -c 'echo "deb http://rig.r-pkg.org/deb rig main" > /etc/apt/sources.list.d/rig.list' && \
+  apt update && \
+  DEBIAN_FRONTEND=noninteractive apt install -y r-rig
+ARG R_VERSION=4.6 # do not pass patch level; NOT 4.6.0
+RUN rig add ${R_VERSION}
+
+# Set up R package manager pak
+ENV RSPM="https://packagemanager.posit.co/cran/__linux__/${UBUNTU_CODENAME}/latest"
+RUN Rscript -e 'stopifnot(R.version$arch == "x86_64")'
+ENV R_UNIVERSE_URL="https://pik-piam.r-universe.dev/bin/linux/${UBUNTU_CODENAME}-x86_64/${R_VERSION}/"
+RUN echo "options(repos = c(pikpiam = Sys.getenv('R_UNIVERSE_URL'), CRAN = Sys.getenv('RSPM')))" > ~/.Rprofile
+
+RUN Rscript -e 'install.packages("pak"); pak::pkg_install("languageserver")'
+
+WORKDIR /opt/magpie
+RUN git clone https://github.com/magpiemodel/magpie.git .
+
+# Install R package dependencies using renv
+# We use a temporarily mounted directory to cache build artifacts between
+# docker builds and in the end copy it to the original renv cache location
+# to not confuse renv when we start runs later.
+# Installing piam packages failed for unknown reasons, starting with a
+# clean cache folder (hence renv-cache-2) solved it.
+RUN --mount=type=cache,target=/tmp/renv-cache-2 \
+    RENV_PATHS_CACHE=/tmp/renv-cache-2 \
+    RENV_CONFIG_INSTALL_VERBOSE=true \
+    Rscript -e '"dummy evaluation to start the renv auto-setup"' && \
+    mkdir -p /root/.cache/R/renv/cache && \
+    cp -r /tmp/renv-cache-2/* /root/.cache/R/renv/cache/ 2>/dev/null
+# cache setup leads to broken symlinks into the cache, but can be fixed with:
+RUN Rscript -e "renv::repair()"
 
 # Install GAMS
 # Note: GAMS requires a license file. This downloads GAMS but you need to provide your own license.
 # The license file (gamslice.txt) should be mounted or copied into the container.
-ARG GAMS_VERSION=51.3.0
+ARG GAMS_VERSION=54.1.0
 ARG GAMS_DOWNLOAD_URL=https://d37drm4t2jghv5.cloudfront.net/distributions/${GAMS_VERSION}/linux/linux_x64_64_sfx.exe
-
-# Download and install GAMS
 RUN cd /tmp && \
     wget -q ${GAMS_DOWNLOAD_URL} -O gams_linux.exe && \
     chmod +x gams_linux.exe && \
@@ -86,40 +119,13 @@ RUN cd /tmp && \
     ./gams_linux.exe -d /opt/gams > /dev/null && \
     rm gams_linux.exe && \
     cp -r /opt/gams/**/* /opt/gams
-
-# Add GAMS to PATH
 ENV GAMS_PATH="/opt/gams"
 ENV PATH="${GAMS_PATH}:${PATH}"
-
 
 # Copy GAMS license file if provided
 # To use this, you need to have gamslice.txt in the same directory as the Dockerfile
 # and uncomment the following line:
 # COPY gamslice.txt /opt/gams/gamslice.txt
-
-# Set up R package manager pak
-ENV RSPM='https://packagemanager.posit.co/cran/__linux__/noble/latest'
-RUN echo "options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev', CRAN = Sys.getenv('RSPM')))" > $HOME/.Rprofile
-
-RUN Rscript -e 'install.packages("pak"); pak::pkg_install("languageserver")'
-
-# Set working directory
-WORKDIR /opt/magpie
-
-# Clone the MAgPIE project
-RUN git clone --depth=1 https://github.com/magpiemodel/magpie.git .
-
-# Install R package dependencies using renv
-# We use a temporarily mounted directory to cache build artifacts between
-# docker builds and in the end copy it to the original renv cache location
-# to not confuse renv when we start runs later.
-RUN --mount=type=cache,target=/tmp/renv-cache \
-    RENV_PATHS_CACHE=/tmp/renv-cache \
-    RENV_CONFIG_INSTALL_VERBOSE=true \
-    RENV_CONFIG_PAK_ENABLED=true \
-    Rscript -e '"dummy evaluation to start the renv auto-setup"' && \
-    mkdir -p /root/.cache/R/renv/cache && \
-    cp -r /tmp/renv-cache/* /root/.cache/R/renv/cache/ 2>/dev/null
 
 # Verify installations
 RUN echo "Verifying installations..." && \
@@ -129,9 +135,18 @@ RUN echo "Verifying installations..." && \
     tex --version && \
     gams || echo "GAMS installed but may require license activation"
 
-# Set environment variables
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
+ENV MAGPIE_IMAGE_VERSION="2.0"
+
+# can be removed once we have https://github.com/magpiemodel/magpie/pull/884 in master
+RUN printf "\
+  - som\n\
+  - ssp1\n\
+  - ssp2\n\
+  - ssp3\n\
+  - ssp4\n\
+  - ssp5\n\
+  - sdp\n\
+  - default\n" >> .codeCheck
 
 # Default command: Start MAgPIE interactively
 # Users can run: docker run -it magpie


### PR DESCRIPTION
## :bird: Description of this PR :bird:
- Dockerfile update: ubuntu26, R4.6, gams 54.1
- corresponding docker image will be the base for piam apptainer setup
- merging this PR should trigger [github action](https://github.com/magpiemodel/magpie/blob/develop/.github/workflows/build-magpie-image.yml) that builds and uploads the dockerfile here: https://github.com/orgs/magpiemodel/packages/container/magpie-image/versions

## :wrench: Checklist for PR creator :wrench:

If a point is not applicable, check the checkbox anyway and write "non-applicable" next to the checkbox.

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run default run via `Rscript start.R --> "default"`
    - Check logs for errors/warnings
    - Fill in performance section below
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    - Fill in performance section below

- [x] Reporting produces no errors and no new warnings

- Get two approving reviews (at least one from RSE)

### :chart_with_downwards_trend: Performance :chart_with_upwards_trend:

  - This PR's default :  ** mins
  - For comparison: [runtimes](https://gitlab.pik-potsdam.de/landuse/testing_suite) of weekly test

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
