### PR TITLE
renv 1.2.4, rlang::global_entrace, .renvignore

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -44,3 +44,7 @@ if (isTRUE(rownames(installed.packages(priority = "NA")) == "renv")) {
 if (tryCatch(utils::packageVersion("piamenv") < "0.5.5", error = function(error) TRUE)) {
   renv::install("piamenv", prompt = FALSE)
 }
+
+if (requireNamespace("rlang", quietly = TRUE)) {
+  rlang::global_entrace()
+}

--- a/.renvignore
+++ b/.renvignore
@@ -1,0 +1,4 @@
+/input/
+/logs/
+/modules/
+/output/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **14_yields** pasture yield correction added to dynRegPastrTau_apr26 realization to match managementcalib_aug19
 - **inputdata** updated input data to rev4.132, added f14_yld_past_switch.csv
 - **scripts** saveToResultsArchive saves to inbox folder if available
-- **renv/activate.R** updated to version 1.2.3
+- **renv/activate.R** updated to version 1.2.4
 - **CI** test-code.yaml: use ubuntu-latest and checkout@v7
 - **Makefile** `make reset-renv` resets renv
 - **.Rprofile** add r-universe repo, use envvars if present

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "1.2.3"
+  version <- "1.2.4"
   attr(version, "md5") <- NULL
   attr(version, "sha") <- NULL
 


### PR DESCRIPTION
## :bird: Description of this PR :bird:

renv 1.2.4: improves pak integration, bugfixes, see https://github.com/rstudio/renv/releases/tag/v1.2.4
rlang::global_entrace: prints stack traces on error (instead of just the error, but not where it happened; has been default in the piam module (outside renv) for a long time)
.renvignore: prevents warning during bootstrapping that renv is scanning too many files


## :wrench: Checklist for PR creator :wrench:

If a point is not applicable, check the checkbox anyway and write "non-applicable" next to the checkbox.

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run default run via `Rscript start.R --> "default"`
    - Check logs for errors/warnings
    - Fill in performance section below
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    - Fill in performance section below

- [x] Reporting produces no errors and no new warnings

- Get two approving reviews (at least one from RSE)

### :chart_with_downwards_trend: Performance :chart_with_upwards_trend:

  - This PR's default :  ** mins
  - For comparison: [runtimes](https://gitlab.pik-potsdam.de/landuse/testing_suite) of weekly test

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
