### PR TITLE
Limit solve wall-clock time via new switch c_reslim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### changed
+- **main.gms** `reslim` reduced from 1000000 to 900 seconds, so a solver stuck inside one iteration is interrupted and retried instead of consuming the whole job allocation
 - **14_yields** pasture yield correction added to dynRegPastrTau_apr26 realization to match managementcalib_aug19
 - **inputdata** updated input data to rev4.132, added f14_yld_past_switch.csv
 - **scripts** saveToResultsArchive saves to inbox folder if available

--- a/main.gms
+++ b/main.gms
@@ -279,7 +279,8 @@ $batinclude "./modules/include.gms" equations
 model magpie / all - m15_food_demand /;
 
 option iterlim    = 1000000 ;
-option reslim     = 1000000 ;
+* reslim is a wall-clock limit in seconds per solve; exceeding it triggers the retry loop in module 80
+option reslim     = 900 ;
 option sysout     = Off ;
 option limcol     = 0 ;
 option limrow     = 0 ;

--- a/modules/80_optimization/nlp_par/solve.gms
+++ b/modules/80_optimization/nlp_par/solve.gms
@@ -62,6 +62,8 @@ repeat
       s80_counter = sum(h2,p80_counter(h2));
       display s80_counter;
       display magpie.modelStat;
+*     async solves write no solve summary, so this is the only source of solve times
+      display magpie.resUsd;
       display vm_cost_glo.l;
       magpie.modelStat$(magpie.modelStat=NA) = 13;
       


### PR DESCRIPTION
## :bird: Description of this PR :bird:

`reslim` was effectively unlimited (`1000000` s), so a solver stuck inside a single iteration never returns a modelstat and burns the whole job allocation without failing. It is also the only limit that can interrupt this: iteration limits and CONOPT's slow-progress detectors are evaluated *between* iterations, and here none completes.

- `main.gms`: `reslim` 1000000 -> **900 s**. Exceeding it returns solvestat 3, which hands control back to the retry loop in module 80.
- `nlp_par` displays `magpie.resUsd`, since its async solves write no solve summary and solve times are otherwise unrecorded.

Local `default` run: 18 solves, slowest 106.3 s, all `SOLVER STATUS 1`, zero retries -- the limit never fires, so results are unchanged. 

## :wrench: Checklist for PR creator :wrench:

If a point is not applicable, check the checkbox anyway and write "non-applicable" next to the checkbox.

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run default run via `Rscript start.R --> "default"`
    - Check logs for errors/warnings
    - Fill in performance section below
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    - Fill in performance section below

- [x] Reporting produces no errors and no new warnings

- Get two approving reviews (at least one from RSE)

### :chart_with_downwards_trend: Performance :chart_with_upwards_trend:

  - This PR's default : **18 mins** (local macOS, GAMS 52.5.0 -- not comparable to cluster runtimes; 15.1 min of that is magpie solver time)
  - For comparison: [runtimes](https://gitlab.pik-potsdam.de/landuse/testing_suite) of weekly test

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
