### PR TITLE
Add pasture to module 39 regional calibration

### DIFF
--- a/config/default.cfg
+++ b/config/default.cfg
@@ -84,33 +84,38 @@ cfg$crop_calib_max <- 1.5            # def= 1.5
 # If TRUE, calibration factors from the iteration with the lowest divergence are used.
 cfg$best_calib <- TRUE   # def = TRUE
 
-# Settings for land conversion cost calibration (cropland)
+# Settings for land conversion cost calibration (cropland and pasture)
 # The calibration routine derives a time-series of regional calibration factors for
-# costs of cropland expansion and rewards for cropland reduction,
-# with the goal to match historical regional cropland in the period 1995-2015.
+# costs of cropland/pasture expansion and rewards for cropland/pasture reduction,
+# with the goal to match historical regional cropland and pasture area in the period 1995-2015.
+# Cropland and pasture are calibrated concurrently (same solve, two factor files), since
+# they compete for land and calibrating them sequentially would cause oscillation.
 # * (TRUE): Land conversion cost calibration will be performed
-# * (ifneeded): Land conversion cost calibration will only be executed if the input file "f39_calib.csv" is missing
+# * (ifneeded): Land conversion cost calibration will only be executed if the input file "f39_calib.csv" or "f39_calib_past.csv" is missing
 # * (FALSE): Land conversion cost calibration will not be performed
 cfg$recalibrate_landconversion_cost <- "ifneeded" #def "ifneeded"
 # Up to which accuracy shall be recalibrated?
 cfg$calib_accuracy_landconversion_cost <- 0.01         # def = 0.01
+cfg$calib_accuracy_landconversion_cost_past <- 0.01    # def = 0.01
 # What is the maximum number of iterations if the precision goal is not reached?
 cfg$calib_maxiter_landconversion_cost <- 20           # def = 20
 # Restart from existing calibration factors (TRUE or FALSE)
 cfg$restart_landconversion_cost <- FALSE           # def = FALSE
-# Set upper limit for cropland calibration factor
+# Set upper limit for cropland/pasture calibration factor
 cfg$cost_calib_max_landconversion_cost <- 2.5         # def= 2.5
-# Set lower limit for cropland calibration factor
+cfg$cost_calib_max_landconversion_cost_past <- 2.5    # def= 2.5
+# Set lower limit for cropland/pasture calibration factor
 cfg$cost_calib_min_landconversion_cost <- 0.1            # def= 0.1
+cfg$cost_calib_min_landconversion_cost_past <- 0.1       # def= 0.1
 # Selection type of calibration factors.
 # If FALSE, calibration factors from the last iteration are used.
 # If TRUE, calibration factors from the iteration with the lowest divergence are used.
 cfg$best_calib_landconversion_cost <- TRUE     # def = TRUE
-# Target data set that will be used for cropland calibration at regional level
-# * "MAgPIEown": same data set as used for initialization of cropland
-# * "FAO": Data from FAOSTAT on cropland area
+# Target data set that will be used for cropland/pasture calibration at regional level
+# * "MAgPIEown": same data set as used for initialization of cropland/pasture
+# * "FAO": Data from FAOSTAT on cropland/pasture area
 cfg$cost_calib_hist_data <- "MAgPIEown"            # def = "MAgPIEown"
-# Should the calibration try to match the level (cropland area) or gradient (cropland expansion)?
+# Should the calibration try to match the level (cropland/pasture area) or gradient (cropland/pasture expansion)?
 # 1 is level, 0 is gradient, anything between a weighted average
 cfg$level_gradient_mix  <- 0.3 # def = 0.3
 

--- a/modules/39_landconversion/calib/declarations.gms
+++ b/modules/39_landconversion/calib/declarations.gms
@@ -17,6 +17,7 @@ parameters
  i39_cost_establish(t,i,land)   Land expansion costs (USD17MER per hectare)
  i39_reward_reduction(t,i,land)   Reward for land reduction (USD17MER per hectare)
  i39_calib(t,i,type39)        Calibration factor for costs of cropland expansion and rewards for cropland reduction (1)
+ i39_calib_past(t,i,type39)   Calibration factor for costs of pasture expansion and rewards for pasture reduction (1)
 ;
 
 *#################### R SECTION START (OUTPUT DECLARATIONS) ####################

--- a/modules/39_landconversion/calib/input.gms
+++ b/modules/39_landconversion/calib/input.gms
@@ -8,16 +8,26 @@
 scalars
  s39_cost_establish_crop       Cost for cropland expansion before calibration (USD17MER per hectare) / 12300 /
  s39_reward_crop_reduction     Reward for cropland reduction before calibration (USD17MER per hectare) / 7380 /
- s39_cost_establish_past       Cost for pasture land expansion (USD17MER per hectare)    / 9840 /
+ s39_cost_establish_past       Cost for pasture land expansion before calibration (USD17MER per hectare)    / 9840 /
+ s39_reward_past_reduction     Reward for pasture reduction before calibration (USD17MER per hectare) / 7380 /
  s39_cost_establish_forestry   Cost for forestry land expansion (USD17MER per hectare)    / 1230 /
  s39_cost_establish_urban      Cost for urban land expansion (USD17MER per hectare)    / 12300 /
- s39_ignore_calib        Switch for ignoring calibration factors (1) / 0 /
+ s39_ignore_calib        Switch for ignoring cropland calibration factors (1) / 0 /
+ s39_ignore_calib_past   Switch for ignoring pasture calibration factors (1) / 0 /
 ;
 
 $onEmpty
 table f39_calib(t_all,i,type39) Calibration factor for costs of cropland expansion (1)
 $ondelim
 $if exist "./modules/39_landconversion/input/f39_calib.csv" $include "./modules/39_landconversion/input/f39_calib.csv"
+$offdelim
+;
+$offEmpty
+
+$onEmpty
+table f39_calib_past(t_all,i,type39) Calibration factor for costs of pasture expansion (1)
+$ondelim
+$if exist "./modules/39_landconversion/input/f39_calib_past.csv" $include "./modules/39_landconversion/input/f39_calib_past.csv"
 $offdelim
 ;
 $offEmpty

--- a/modules/39_landconversion/calib/preloop.gms
+++ b/modules/39_landconversion/calib/preloop.gms
@@ -14,3 +14,10 @@ if(sum((t,i,type39),i39_calib(t,i,type39)) = 0 OR s39_ignore_calib = 1,
   i39_calib(t,i,"cost") = 1;
   i39_calib(t,i,"reward") = 0;
 );
+
+i39_calib_past(t,i,type39) = f39_calib_past(t,i,type39);
+* set default values in case of missing input file or s39_ignore_calib_past = 1
+if(sum((t,i,type39),i39_calib_past(t,i,type39)) = 0 OR s39_ignore_calib_past = 1,
+  i39_calib_past(t,i,"cost") = 1;
+  i39_calib_past(t,i,"reward") = 0;
+);

--- a/modules/39_landconversion/calib/presolve.gms
+++ b/modules/39_landconversion/calib/presolve.gms
@@ -5,12 +5,13 @@
 *** |  MAgPIE License Exception, version 1.0 (see LICENSE file).
 *** |  Contact: magpie@pik-potsdam.de
 
-* Global cost for cropland expansion are scaled with a calibration factor (i39_calib).
-* The calibration factor has been derived with the goal of matching regional cropland in 2015 with historic data.
-* In addition, regions with a calibration factor > 1 and with a decline of cropland between 1995 and 2015 in historic data see a reward for cropland reduction.
+* Global cost for cropland and pasture expansion are scaled with a calibration factor (i39_calib / i39_calib_past).
+* The calibration factor has been derived with the goal of matching regional cropland/pasture in 2015 with historic data.
+* In addition, regions with a calibration factor > 1 and with a decline of cropland/pasture between 1995 and 2015 in historic data see a reward for land reduction.
 
 i39_cost_establish(t,i,"crop") = s39_cost_establish_crop * i39_calib(t,i,"cost");
 i39_reward_reduction(t,i,"crop") = s39_reward_crop_reduction * i39_calib(t,i,"reward");
-i39_cost_establish(t,i,"past") = s39_cost_establish_past;
+i39_cost_establish(t,i,"past") = s39_cost_establish_past * i39_calib_past(t,i,"cost");
+i39_reward_reduction(t,i,"past") = s39_reward_past_reduction * i39_calib_past(t,i,"reward");
 i39_cost_establish(t,i,"forestry") = s39_cost_establish_forestry;
 i39_cost_establish(t,i,"urban") = s39_cost_establish_urban;

--- a/modules/39_landconversion/calib/realization.gms
+++ b/modules/39_landconversion/calib/realization.gms
@@ -6,12 +6,12 @@
 *** |  Contact: magpie@pik-potsdam.de
 
 *' @description
-*' This realization accounts for land conversion costs of cropland, pasture, forestry and urban land. 
-*' Costs for expansion of pasture, forestry and urban land are global and static over time.
-*' For cropland, a regional and time-dependent calibration factor is applied on 
-*' global costs for land expansion, complemented by a reward for cropland reduction in selected regions, 
-*' for a better match of regional cropland in 2015 with historic data.
-*' The calibration factor for costs of cropland expansion is lifted to a minium of 1 in all regions by 2050.
+*' This realization accounts for land conversion costs of cropland, pasture, forestry and urban land.
+*' Costs for expansion of forestry and urban land are global and static over time.
+*' For cropland and pasture, a regional and time-dependent calibration factor is applied on
+*' global costs for land expansion, complemented by a reward for cropland/pasture reduction in selected regions,
+*' for a better match of regional cropland and pasture area in 2015 with historic data.
+*' The calibration factors for costs of cropland and pasture expansion are lifted to a minium of 1 in all regions by 2050.
 *'
 *' @limitations Data availability for land conversion costs is very limited.
 

--- a/modules/39_landconversion/input/files
+++ b/modules/39_landconversion/input/files
@@ -1,2 +1,3 @@
 * list of files that are required here
 f39_calib.csv
+f39_calib_past.csv

--- a/scripts/calibration/landconversion_cost.R
+++ b/scripts/calibration/landconversion_cost.R
@@ -76,25 +76,30 @@ calibrationRun <- function(putfolder, calibMagpieName, logoption, useGDX) {
   cat("=== CALIBRATION_RUN END ===\n")
 }
 
-getValData <- function(histData, gdxFile) {
+# FAO validation.mif variable name (Resources|Land Cover|+|<...>) for each calibrated land type
+faoLandCoverName <- c(crop = "Cropland", past = "Pastures and Rangelands")
+
+getValData <- function(histData, gdxFile, landType = "crop") {
   require(magpie4)
   require(magclass)
   require(gdx2)
-  cat("=== retrieve validation data ===\n")
+  cat(paste0("=== retrieve validation data (landType = ", landType, ") ===\n"))
   y <- readGDX(gdxFile,"t")
-  magpie <- land(gdxFile)[, y, "crop"]
+  magpie <- land(gdxFile)[, y, landType]
   if (histData == "MAgPIEown") {
-    hist <- dimSums(readGDX(gdxFile, "f10_land")[, , "crop"], dim = 1.2)
-    valdata <- hist[, y, "crop"]
+    hist <- dimSums(readGDX(gdxFile, "f10_land")[, , landType], dim = 1.2)
+    valdata <- hist[, y, landType]
   } else if (histData == "FAO") {
-    if(file.exists("calib_data.rds")) {
-      val <- readRDS("calib_data.rds")
+    rdsFile <- paste0("calib_data_", landType, ".rds")
+    if(file.exists(rdsFile)) {
+      val <- readRDS(rdsFile)
     } else {
       val <- read.report("input/validation.mif", as.list = FALSE)
-      val <- val[getRegions(magpie),getYears(magpie),"historical.FAO_crop_past.Resources|Land Cover|+|Cropland (million ha)"]
+      faoVar <- paste0("historical.FAO_crop_past.Resources|Land Cover|+|", faoLandCoverName[[landType]], " (million ha)")
+      val <- val[getRegions(magpie),getYears(magpie),faoVar]
       names(dimnames(val)) <- names(dimnames(magpie))
-      getNames(val) <- "crop"
-      saveRDS(val, file = "calib_data.rds")
+      getNames(val) <- landType
+      saveRDS(val, file = rdsFile)
     }
     valdata <- val[,y,]
   } else {
@@ -119,15 +124,15 @@ expandHist <- function(valdata){
 
 # get ratio between modelled area and reference area
 
-getCalibFactor <- function(gdxFile, mode, histData) {
+getCalibFactor <- function(gdxFile, mode, histData, landType = "crop") {
 
   require(magclass)
   cat("=== GET_CALIB_FACTOR START ===\n")
   cat(paste0("GDX file: ", gdxFile, "\n"))
-  cat(paste0("Mode: ", mode, ", histData: ", histData, "\n"))
+  cat(paste0("Mode: ", mode, ", histData: ", histData, ", landType: ", landType, "\n"))
 
-  valdata <- getValData(histData = histData, gdxFile = gdxFile)
-  magpie <- land(gdxFile)[, getYears(valdata), "crop"]
+  valdata <- getValData(histData = histData, gdxFile = gdxFile, landType = landType)
+  magpie <- land(gdxFile)[, getYears(valdata), landType]
 
   if (mode == "gradient") {
     cat(">>> gradient calibration \n")
@@ -170,12 +175,12 @@ timeSeriesReward <- function(calibFactor) {
 }
 
 # Calculate the correction factor and save it
-updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, calibrationStep, nMaxcalib, bestCalib, histData, putfolder, levelGradientMix) {
+updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, calibrationStep, nMaxcalib, bestCalib, histData, putfolder, levelGradientMix, landType = "crop") {
   require(magclass)
   require(magpie4)
   require(gdx2)
 
-  cat(paste0("=== UPDATE_CALIB ITERATION ", calibrationStep, " START ===\n"))
+  cat(paste0("=== UPDATE_CALIB ITERATION ", calibrationStep, " (landType = ", landType, ") START ===\n"))
   cat(paste0("GDX file: ", gdxFile, "\n"))
   cat(paste0("calibAccuracy: ", calibAccuracy, "\n"))
 
@@ -184,10 +189,10 @@ updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, cal
   }
 
 
-  
-  # we calculate two different divergence measures: divergence of level (cropland and divergence of gradient (cropland expansion)
-  calibDivergenceLevel <- getCalibFactor(gdxFile, mode = "level", histData = histData)
-  calibDivergenceGradient <- getCalibFactor(gdxFile, mode = "gradient", histData = histData)
+
+  # we calculate two different divergence measures: divergence of level (land area) and divergence of gradient (land expansion)
+  calibDivergenceLevel <- getCalibFactor(gdxFile, mode = "level", histData = histData, landType = landType)
+  calibDivergenceGradient <- getCalibFactor(gdxFile, mode = "gradient", histData = histData, landType = landType)
   # mixing calibration approaches for making the best of both approaches
   calibDivergence <- levelGradientMix * calibDivergenceLevel + (1 - levelGradientMix) * calibDivergenceGradient
   
@@ -207,7 +212,7 @@ updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, cal
   } else {
     cat(">>> First iteration - initializing calibration factors (cost=1 for expanding countries, cost=2.5 for contracting, reward=0)\n")
     oldCalib <- new.magpie(cells_and_regions = getCells(calibDivergence), years = getYears(calibDivergence), names = c("cost", "reward"), fill = NA)
-    oldCalib[,,"cost"] <- (expandHist(getValData(histData = histData, gdxFile = gdxFile)) < 0) * (costMax - 1) + 1
+    oldCalib[,,"cost"] <- (expandHist(getValData(histData = histData, gdxFile = gdxFile, landType = landType)) < 0) * (costMax - 1) + 1
     oldCalib[,,"reward"] <- 0
   }
 
@@ -224,7 +229,7 @@ updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, cal
   calibFactorCost <- setNames(oldCalib[, , "cost"], NULL) * calib_correction ^ reinforcement
   calibFactorReward <- setNames(oldCalib[, , "reward"], NULL) + (calib_correction - 1) * reinforcement
   # no rewards in case that validation data shows no contraction
-  calibFactorReward[expandHist(getValData(histData = histData, gdxFile = gdxFile)) >= 0] <- 0
+  calibFactorReward[expandHist(getValData(histData = histData, gdxFile = gdxFile, landType = landType)) >= 0] <- 0
   calibFactorReward[calibFactorReward < 0] <- 0
 
   cat(">>> Account for costMax and costMin\n")
@@ -244,13 +249,13 @@ updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, cal
     try(write.magpie(round(x, 3), file, append = (calibrationStep != 1)))
   }
 
-  writeLog(calibDivergenceLevel, paste0(putfolder, "/land_conversion_divergence_level.cs3"), calibrationStep)
-  writeLog(calibDivergenceGradient, paste0(putfolder,  "/land_conversion_divergence_gradient.cs3"), calibrationStep)
-  writeLog(calibDivergence, paste0(putfolder,  "/land_conversion_divergence.cs3"), calibrationStep)
-  writeLog(calibFactorCost, paste0(putfolder,  "/land_conversion_cost_next_calib_factor.cs3"), calibrationStep)
-  writeLog(calibFactorReward, paste0(putfolder,  "/land_conversion_reward_next_calib_factor.cs3"), calibrationStep)
-  writeLog(setNames(oldCalib[, , "reward"], NULL), paste0(putfolder,  "/land_conversion_reward_current_calib_factor.cs3"), calibrationStep)
-  writeLog(setNames(oldCalib[, , "cost"], NULL), paste0(putfolder,  "/land_conversion_cost_current_calib_factor.cs3"), calibrationStep)
+  writeLog(calibDivergenceLevel, paste0(putfolder, "/land_conversion_divergence_level_", landType, ".cs3"), calibrationStep)
+  writeLog(calibDivergenceGradient, paste0(putfolder,  "/land_conversion_divergence_gradient_", landType, ".cs3"), calibrationStep)
+  writeLog(calibDivergence, paste0(putfolder,  "/land_conversion_divergence_", landType, ".cs3"), calibrationStep)
+  writeLog(calibFactorCost, paste0(putfolder,  "/land_conversion_cost_next_calib_factor_", landType, ".cs3"), calibrationStep)
+  writeLog(calibFactorReward, paste0(putfolder,  "/land_conversion_reward_next_calib_factor_", landType, ".cs3"), calibrationStep)
+  writeLog(setNames(oldCalib[, , "reward"], NULL), paste0(putfolder,  "/land_conversion_reward_current_calib_factor_", landType, ".cs3"), calibrationStep)
+  writeLog(setNames(oldCalib[, , "cost"], NULL), paste0(putfolder,  "/land_conversion_cost_current_calib_factor_", landType, ".cs3"), calibrationStep)
 
   # in case of sufficient convergence, stop here (no additional update of calibration factors!)
   # also stop in case there is no convergence, e.g. because the calib factors are at upper or lower bounds.
@@ -264,9 +269,9 @@ updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, cal
     # or the "best" based on the iteration value with the lowest standard deviation of regional divergence.
     if (bestCalib == TRUE) {
       cat("Choosing the best calibration...\n")
-      divergenceData <- read.magpie(paste0(putfolder, "/land_conversion_divergence.cs3"))
-      factors_cost <- read.magpie( paste0(putfolder, "/land_conversion_cost_current_calib_factor.cs3"))
-      factors_reward <- read.magpie( paste0(putfolder, "/land_conversion_reward_current_calib_factor.cs3"))
+      divergenceData <- read.magpie(paste0(putfolder, "/land_conversion_divergence_", landType, ".cs3"))
+      factors_cost <- read.magpie( paste0(putfolder, "/land_conversion_cost_current_calib_factor_", landType, ".cs3"))
+      factors_reward <- read.magpie( paste0(putfolder, "/land_conversion_reward_current_calib_factor_", landType, ".cs3"))
       # The best iteration is chosen for each region as the calibration factors where the sum of divergence over all timesteps is minimal.
       # In case multiple iterations have the same value, the first value is returned by which.min
       calibCostBest <- calibRewardBest <- factors_cost[,,1] * 0
@@ -279,8 +284,10 @@ updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, cal
       getNames(calibCostBest) <- NULL
       getNames(calibRewardBest) <- NULL
  
-      writeLog(calibCostBest,  paste0(putfolder, "/land_conversion_cost_current_calib_factor.cs3"), "best")
-      writeLog(calibRewardBest,  paste0(putfolder, "/land_conversion_reward_current_calib_factor.cs3"), "best")
+      # tag with the iteration at which "best" was determined (rather than a fixed "best" literal), since this
+      # branch may run again on a later iteration while a concurrently-calibrated land type has not yet converged
+      writeLog(calibCostBest,  paste0(putfolder, "/land_conversion_cost_current_calib_factor_", landType, ".cs3"), paste0("best_iter", calibrationStep))
+      writeLog(calibRewardBest,  paste0(putfolder, "/land_conversion_reward_current_calib_factor_", landType, ".cs3"), paste0("best_iter", calibrationStep))
   
       calibCostBest <- timeSeriesCost(calibCostBest)
       calibRewardBest <- timeSeriesReward(calibRewardBest)
@@ -292,7 +299,7 @@ updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, cal
       calibBestFull[is.na(calibBestFull)] <- 1
 
       comment <- c(
-        " description: Regional land conversion cost calibration file",
+        paste0(" description: Regional land conversion cost calibration file (landType = ", landType, ")"),
         " unit: -",
         paste0(" note: Best calibration factor from the run"),
         " origin: scripts/calibration/landconversion_cost.R (path relative to model main directory)",
@@ -319,7 +326,7 @@ updateCalib <- function(gdxFile, calibAccuracy, calibFile, costMax, costMin, cal
     calibFull[is.na(calibFull)] <- 1
 
     comment <- c(
-      " description: Regional land conversion cost calibration file",
+      paste0(" description: Regional land conversion cost calibration file (landType = ", landType, ")"),
       " unit: -",
       paste0(" note: Calibration step ", calibrationStep),
       " origin: scripts/calibration/landconversion_cost.R (path relative to model main directory)",
@@ -342,6 +349,10 @@ calibrateLandconversion <- function(nMaxcalib = 20,
                              costMin = 0.2,
                              calibMagpieName = "magpie_calib",
                              calibFile = "modules/39_landconversion/input/f39_calib.csv",
+                             calibFilePast = "modules/39_landconversion/input/f39_calib_past.csv",
+                             calibAccuracyPast = calibAccuracy,
+                             costMaxPast = costMax,
+                             costMinPast = costMin,
                              putfolder = "land_conversion_cost_calib_run",
                              dataWorkspace = NULL,
                              logoption = 3,
@@ -354,6 +365,7 @@ calibrateLandconversion <- function(nMaxcalib = 20,
   if (!restart) {
     cat(paste0("\nStarting land conversion cost calibration from default values\n"))
     if (file.exists(calibFile)) file.remove(calibFile)
+    if (file.exists(calibFilePast)) file.remove(calibFilePast)
   } else {
     if (file.exists(calibFile)) cat(paste0("\nStarting land conversion cost calibration from existing values\n")) else cat(paste0("\nStarting land conversion cost calibration from default values\n"))
   }
@@ -381,9 +393,18 @@ calibrateLandconversion <- function(nMaxcalib = 20,
         file.copy(paste0(putfolder, "/fulldata.gdx"), paste0(putfolder, "/", "fulldata_calib", i, ".gdx"), overwrite = TRUE)
       }
 
-      done <- updateCalib(gdxFile = "fulldata.gdx", calibAccuracy = calibAccuracy, costMax = costMax, costMin = costMin, 
+      # crop and pasture are calibrated concurrently from the same solve: crop and pasture compete for
+      # land, so calibrating them sequentially (crop first, then pasture) would shift the land allocation
+      # before pasture is calibrated, causing oscillation between iterations.
+      doneCrop <- updateCalib(gdxFile = "fulldata.gdx", calibAccuracy = calibAccuracy, costMax = costMax, costMin = costMin,
                            calibFile = calibFile, calibrationStep = i, nMaxcalib = nMaxcalib, bestCalib = bestCalib, histData = histData,
-                           putfolder = putfolder, levelGradientMix = levelGradientMix)
+                           putfolder = putfolder, levelGradientMix = levelGradientMix, landType = "crop")
+
+      donePast <- updateCalib(gdxFile = "fulldata.gdx", calibAccuracy = calibAccuracyPast, costMax = costMaxPast, costMin = costMinPast,
+                           calibFile = calibFilePast, calibrationStep = i, nMaxcalib = nMaxcalib, bestCalib = bestCalib, histData = histData,
+                           putfolder = putfolder, levelGradientMix = levelGradientMix, landType = "past")
+
+      done <- doneCrop && donePast
 
       if (done && useGDX == 2) {
         useGDX <- 0
@@ -398,7 +419,8 @@ calibrateLandconversion <- function(nMaxcalib = 20,
     # delete calib_magpie_gms in the main folder
     unlink(paste0(calibMagpieName, ".*"))
     unlink("fulldata.gdx")
-    unlink("calib_data.rds")
+    unlink("calib_data_crop.rds")
+    unlink("calib_data_past.rds")
 
     cat("\nLand conversion cost calibration finished\n")
   }, logfile = "calibration_debug.log", putfolder = putfolder)

--- a/scripts/start_functions.R
+++ b/scripts/start_functions.R
@@ -483,9 +483,10 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE,
   }
 
   land_calib_file <- "modules/39_landconversion/input/f39_calib.csv"
+  land_calib_file_past <- "modules/39_landconversion/input/f39_calib_past.csv"
   if(cfg$recalibrate_landconversion_cost=="ifneeded") {
-    # recalibrate if file does not exist
-    if(!file.exists(land_calib_file)) cfg$recalibrate_landconversion_cost <- TRUE else cfg$recalibrate_landconversion_cost <- FALSE
+    # recalibrate if either the cropland or the pasture calibration file does not exist
+    if(!file.exists(land_calib_file) || !file.exists(land_calib_file_past)) cfg$recalibrate_landconversion_cost <- TRUE else cfg$recalibrate_landconversion_cost <- FALSE
   }
   if(cfg$recalibrate_landconversion_cost){
     #if(cfg$gms$landconversion!="devstate") stop("Land conversion cost calibration works only with realization devstate")
@@ -497,6 +498,10 @@ start_run <- function(cfg, scenario = NULL, codeCheck = TRUE, lock_model = TRUE,
                             costMax = cfg$cost_calib_max_landconversion_cost,
                             costMin = cfg$cost_calib_min_landconversion_cost,
                             calibFile = land_calib_file,
+                            calibFilePast = land_calib_file_past,
+                            calibAccuracyPast = cfg$calib_accuracy_landconversion_cost_past,
+                            costMaxPast = cfg$cost_calib_max_landconversion_cost_past,
+                            costMinPast = cfg$cost_calib_min_landconversion_cost_past,
                             dataWorkspace = cfg$val_workspace,
                             logoption = 3,
                             debug = cfg$debug,


### PR DESCRIPTION
## :bird: Description of this PR :bird:

Extend MAgPIE's regional land-conversion cost calibration (module 39) to pasture by mirroring the existing cropland mechanism, including a pasture reduction reward that never previously existed, so pasture area is calibrated to historical data by default across all regions, not just cropland.

## **Changes**

- **GAMS (`modules/39_landconversion/calib/`)**: new `i39_calib_past` parameter and `f39_calib_past.csv` input; pasture land-conversion cost is now regionally calibrated (previously a static constant), and pasture gets a reduction reward via a new `s39_reward_past_reduction` scalar — a mechanism cropland already had but pasture never did.
- **R (`scripts/calibration/landconversion_cost.R`)**: generalized the crop-only calibration routine to a `landType` parameter (previously hard coded as "crop"); `calibrateLandconversion()` now calibrates crop and pasture concurrently from the same GAMS solve each iteration (not sequentially), since they compete for land and sequential calibration would oscillate.
- **Config (`config/default.cfg`, `scripts/start_functions.R`)**: added `*_landconversion_cost_past` settings mirroring the existing cropland ones; the `"ifneeded"` recalibration skip now requires both `f39_calib.csv` and `f39_calib_past.csv` to exist before skipping.


## **Testing**

Both runs confirmed as a clean comparison: same `yields`/`landconversion `realizations, `recalibrate_landconversion_cost` is the only meaningful difference (no in default, yes in the new-feature run `calib_pastr_H12_default),` so this isolates the pasture calibration's effect.

### **World, 2015 (baseline → feature)**
- Pasture: 3258.9 → 3147.9 Mha (−111.1 Mha, −3.4%)
- Cropland: 1520.6 → 1529.6 Mha (+9.1 Mha, +0.6%)

Q: The small cropland uptick is not necessariy a result of something module 39's pasture calibration targets directly. Maybe a a land-competition byproduct of releasing ~111 Mha of pasture (mostly from one region — see below)?

How effective was the calibration":

- **Cropland**: 11/12 regions converged within ±1% of f10_land.
- **Pasture**: 9/12 regions converged within ±1%. The two real misses were OAS (pinned at costMax, still 3.2% over target) and MEA (pinned at costMin, 1.7% over — nearly converged despite hitting the bound).

## **Results**
Adding a summary of headline results here and figures below.

**Tau** is essentially unchanged, as expected since module 39 does not affect the incentives, which implies the calibration isn't destabilizing the yield/intensification side of the model.
- However, I flag here that crop and pasture intensification are linked via the Tau spillover factor and its value affects the calibration outcomes (default 0.25 used throughout this PR). 

**Emissions** change as a result of changing land use patterns across and within regions. This is a side effect of the regional pasture-area calibration and leads to a ~5% increase in cumulative historical LUC emissions. Small but significant.

**No errors or warnings**. The new csv files still need to be added to pre-processing. CHANGELO.md stil needs to be uodated.

**Runtime = 30.8 mins for crop+pastr calibrated model**

<img width="1764" height="707" alt="image" src="https://github.com/user-attachments/assets/af23f753-4b2a-41c6-9d67-9cf671c611ce" />
<img width="1725" height="688" alt="image" src="https://github.com/user-attachments/assets/545a65ab-65e4-48b2-939c-7f7809684110" />
<img width="1707" height="688" alt="image" src="https://github.com/user-attachments/assets/a3212497-9aac-470b-b8af-c650ef9b806f" />
<img width="1434" height="830" alt="image" src="https://github.com/user-attachments/assets/842f47f4-a725-4952-b95e-03aa93f7fd2f" />
<img width="1434" height="830" alt="image" src="https://github.com/user-attachments/assets/cbc0b746-155f-4250-b394-aa864c013485" />
<img width="1434" height="830" alt="image" src="https://github.com/user-attachments/assets/8ac41f07-462e-4735-bd9d-bfdc23a9fb01" />
<img width="1434" height="830" alt="image" src="https://github.com/user-attachments/assets/3d004233-1c80-4fbf-b81c-5c8b300970c8" />
<img width="1434" height="830" alt="image" src="https://github.com/user-attachments/assets/ea1ef5fc-c5c3-4c9c-bc94-5dd15b812c6d" />

