### PR TITLE
NPI/NDC A/R placement weight: forest establishment headroom x carbon density

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### changed
 - **21_trade** Changed preprocessing calculation of bilateral trade flexibility band into the future, no longer based on historical standard deviations and rather based on mean historical ranges
+- **scripts/npi_ndc** NPI/NDC/ndcdelay afforestation/reforestation (A/R) is now placed on cells by forest establishment headroom (potential minus current forest) times potential-forest carbon density, replacing the 2005 cropland+pasture area weight, so more of the prescribed target is delivered (less potential-clipping) and placement prefers higher-carbon cells; the reference year is pinned to the last observed year so the weight stays identical across climate scenarios.
 
 ### added
 - **15_food** Added flexible source-to-target food substitution with configurable food baskets and kcal/protein replacement basis

--- a/scripts/npi_ndc/start_npi_ndc.R
+++ b/scripts/npi_ndc/start_npi_ndc.R
@@ -21,7 +21,8 @@ calc_NPI_NDC <- function(policyregions = "iso",
                          outfolder_ad_aolc   = c("policies/","../../modules/35_natveg/input/"),
                          outfolder_aff   = c("policies/","../../modules/32_forestry/input/"),
                          out_ad_file     = "npi_ndc_ad_aolc_pol.cs3",
-                         out_aff_file    = "npi_ndc_aff_pol.cs3") {
+                         out_aff_file    = "npi_ndc_aff_pol.cs3",
+                         carbon_stock_file = "../../modules/52_carbon/input/lpj_carbon_stocks_0.5.mz") {
 
   require(magclass)
   require(madrat)
@@ -37,6 +38,13 @@ calc_NPI_NDC <- function(policyregions = "iso",
 
   #read in cellular land cover (stock) from landuse initialization
   land_stock <- read.magpie(land_stock_file)
+
+  # carbon density and refYear for the afforestation/reforestation (A/R) weight below; refYear = last
+  # observed year (<= sm_fix) keeps the weight, and thus the pinned historic A/R, RCP-invariant
+  refYear <- max(getYears(land_stock, as.integer = TRUE))
+  carbon  <- read.magpie(carbon_stock_file)
+  stopifnot(identical(getItems(carbon, dim = 1), getItems(land_stock, dim = 1)))
+  vegc <- as.numeric(collapseNames(carbon[, refYear, "secdforest.vegc"]))
 
   # use pol_mapping to update spatial mapping of cells to regions
   # so that not only countries can be used for policies but also smaller
@@ -199,6 +207,13 @@ calc_NPI_NDC <- function(policyregions = "iso",
   addline("## Afforestation - AFF (Mha)")
   addline("## Ref: BaseYear (1), Baseline (2)")
 
+  # A/R placement weight: establishment headroom (cf. GAMS pm_max_forest_est, but at 0.5 deg and fixed
+  # at refYear) x potential-forest carbon density
+  forestNow <- setNames(setYears(forest_stock[, refYear, ], NULL), NULL)
+  affWeight <- pmax(setNames(setYears(potential_forest_cell[, refYear, ], NULL), NULL) - forestNow, 0)
+  affWeight[] <- as.numeric(affWeight) * vegc
+  affWeight <- affWeight + 10^-10
+
   cat("Compute NPI  AFF policy")
   addline("")
   addline("###############")
@@ -207,7 +222,7 @@ calc_NPI_NDC <- function(policyregions = "iso",
   npi_aff <- droplevels(subset(pol_def, policy=="npi" & landpool=="affore"))
   addtable(npi_aff[,c(-2,-3)])
   npi_aff <- calc_policy(npi_aff, land_stock, pol_type="aff", pol_mapping=pol_mapping,
-                         weight=dimSums(land_stock[,2005,c("crop","past")]) + 10^-10,
+                         weight=affWeight,
                          map_file=map_file)
   getNames(npi_aff) <- "npi"
   cat(paste0(" (time elapsed: ",format(proc.time()["elapsed"]-ptm,width=6,nsmall=2,digits=2),"s)\n"))
@@ -220,7 +235,7 @@ calc_NPI_NDC <- function(policyregions = "iso",
   ndc_aff <- droplevels(subset(pol_def, policy=="ndc" & landpool=="affore"))
   addtable(ndc_aff[,c(-2,-3)])
   ndc_aff <- calc_policy(ndc_aff, land_stock, pol_type="aff", pol_mapping=pol_mapping,
-                         weight=dimSums(land_stock[,2005,c("crop","past")]) + 10^-10,
+                         weight=affWeight,
                          map_file=map_file)
   getNames(ndc_aff) <- "ndc"
   #set all values before 2015 to NPI values; copy the values til 2010 from the NPI data
@@ -276,7 +291,7 @@ calc_NPI_NDC <- function(policyregions = "iso",
     ndcdelay_def$policy     <- "ndcdelay"
     addtable(ndcdelay_def[,c(-2,-3)])
     ndcdelay_aff <- calc_policy(ndcdelay_def, land_stock, pol_type="aff", pol_mapping=pol_mapping,
-                                weight=dimSums(land_stock[,2005,c("crop","past")]) + 10^-10,
+                                weight=affWeight,
                                 map_file=map_file)
     getNames(ndcdelay_aff) <- "ndcdelay"
     # mirror ndc: years <= 2025 follow the NPI baseline


### PR DESCRIPTION
## :bird: Description of this PR :bird:

NPI/NDC/ndcdelay afforestation/reforestation (A/R) targets (Mha per policy region, mostly countries) are disaggregated to 0.5° cells in `scripts/npi_ndc/start_npi_ndc.R`. This PR replaces the weight for that step, 2005 cropland+pasture area, with forest establishment headroom (potential forest minus current forest, floored at 0) times potential-forest carbon density (LPJmL `secdforest.vegc`).

- **Why:** 2005 agricultural area does not show where forest can establish, so GAMS cuts part of the target where a cluster lacks suitable area (`p32_aff_pot`). Headroom places the target where it can be delivered, and the carbon density factor mildly prefers high-carbon cells. The affexp policy already weights by headroom.
- **Climate-scenario invariance:** all inputs are taken at the last year of `avl_land_t` (currently 2015), so the weight is identical across climate scenarios (bit-identical for ssp119 and ssp245) and the shared history up to `sm_fix_SSP2` is kept.
- No input data change; affexp is unchanged.

Note that the test runs for thisPR do **not** include the grassland-adjusted potential forest layer that will ship with rev4.134. https://github.com/pik-piam/mrmagpie/pull/69

<img width="3600" height="2400" alt="10_Resources-Land-Cover-Forest-Planted-Forest_regional" src="https://github.com/user-attachments/assets/c40d200a-fe54-4d14-97d6-bf0b8ecad803" />
<img width="2700" height="1650" alt="10_Resources-Land-Cover-Forest-Planted-Forest_global" src="https://github.com/user-attachments/assets/97ee2766-18b3-4d20-9d49-096e70550786" />
<img width="3600" height="2400" alt="09_Resources-Land-Cover-Forest-Planted-Forest-Natural-CO2-price-AR_regional" src="https://github.com/user-attachments/assets/7b60514d-52fe-49ab-836a-038edfbf4843" />
<img width="2700" height="1650" alt="09_Resources-Land-Cover-Forest-Planted-Forest-Natural-CO2-price-AR_global" src="https://github.com/user-attachments/assets/18808f58-57fc-4798-98d7-ddcf60ba8695" />
<img width="3600" height="2400" alt="08_Emissions-CO2-Land-Land-use-Change-Regrowth-NPI-NDC-AR_regional" src="https://github.com/user-attachments/assets/ec3a8c55-ae96-4bb8-b2ed-be8a5a7f79ba" />
<img width="2700" height="1650" alt="08_Emissions-CO2-Land-Land-use-Change-Regrowth-NPI-NDC-AR_global" src="https://github.com/user-attachments/assets/bc67e92f-9702-457c-9e7e-577e607277b0" />
<img width="3600" height="2400" alt="07_Resources-Land-Cover-Forest-Planted-Forest-Natural-NPI-NDC-AR_regional" src="https://github.com/user-attachments/assets/ffe9f46c-b38b-48cd-8b46-bb428ad68a74" />
<img width="2700" height="1650" alt="07_Resources-Land-Cover-Forest-Planted-Forest-Natural-NPI-NDC-AR_global" src="https://github.com/user-attachments/assets/247fa694-c4d7-4a13-8356-8b743e0a4f03" />
<img width="3600" height="2400" alt="06_Productivity-Landuse-Intensity-Indicator-Tau_regional" src="https://github.com/user-attachments/assets/757403a8-ab76-4d0d-9e99-57e0b6e503bd" />
<img width="2700" height="1650" alt="06_Productivity-Landuse-Intensity-Indicator-Tau_global" src="https://github.com/user-attachments/assets/9d6d4da7-4c34-4abf-aac1-ed6bde333131" />
<img width="3600" height="2400" alt="05_Resources-Land-Cover-Other-Land_regional" src="https://github.com/user-attachments/assets/5c8a7ba7-7425-4804-86a9-32f79703c993" />
<img width="2700" height="1650" alt="05_Resources-Land-Cover-Other-Land_global" src="https://github.com/user-attachments/assets/34ccc1bd-91d7-40cb-bfcc-01ad9edd8532" />
<img width="3600" height="2400" alt="04_Resources-Land-Cover-Forest_regional" src="https://github.com/user-attachments/assets/e8cd7427-a733-4bb2-9280-e10ea68f1cd7" />
<img width="2700" height="1650" alt="04_Resources-Land-Cover-Forest_global" src="https://github.com/user-attachments/assets/fb708109-0425-420c-a79c-a71358365e6c" />
<img width="3600" height="2400" alt="03_Resources-Land-Cover-Pastures-and-Rangelands_regional" src="https://github.com/user-attachments/assets/d182ed0c-84cf-40c1-b0df-7201bff80ec0" />
<img width="2700" height="1650" alt="03_Resources-Land-Cover-Pastures-and-Rangelands_global" src="https://github.com/user-attachments/assets/68421aef-18a1-4adc-9a6d-22c79884b466" />
<img width="3600" height="2400" alt="02_Resources-Land-Cover-Cropland_regional" src="https://github.com/user-attachments/assets/1018b8f7-f26d-48e1-99b8-a519b033e92f" />
<img width="2700" height="1650" alt="02_Resources-Land-Cover-Cropland_global" src="https://github.com/user-attachments/assets/aa9bf9c2-e196-4ac2-9e52-cbd661e519c0" />
<img width="3600" height="2400" alt="01_Emissions-CO2-Land-Land-use-Change_regional" src="https://github.com/user-attachments/assets/e016eb0b-e5da-4b0e-b814-016affc8baf3" />
<img width="2700" height="1650" alt="01_Emissions-CO2-Land-Land-use-Change_global" src="https://github.com/user-attachments/assets/6a6ab477-b588-4785-9858-4bcb3d622bf9" />


## :wrench: Checklist for PR creator :wrench:

If a point is not applicable, check the checkbox anyway and write "non-applicable" next to the checkbox.

- [x] Label pull request [from the label list](https://github.com/magpiemodel/magpie/labels).
  - **Low risk**: Simple bugfixes (missing files, updated documentation, typos) or changes  in start or output scripts
  - **Medium risk**: Uncritical changes in the model core (e.g. moderate modifications in non-default realizations)
  - **High risk**: Critical changes in model core or default settings (e.g. changing a model default or adjusting a core mechanic in the model)

- [x] Self-review own code
  - No hard coded numbers and cluster/country/region names.
  - The new code doesn't contain declared but unused parameters or variables.
  - [`magpie4`](https://github.com/pik-piam/magpie4) R library has been updated accordingly and backwards compatible where necessary.
  - `scenario_config.csv` has been updated accordingly (important if `default.cfg` has been updated)

- [x] Document changes 
  - Add changes to `CHANGELOG.md`
  - Where relevant, put In-code documentation comments
  - Properly address updates in interfaces in the module documentations
  - run [`goxygen::goxygen()`](https://github.com/pik-piam/goxygen) and verify the modified code is properly documented

- [x] Perform test runs
  - **Low risk**: 
    - Run a compilation check via `Rscript start.R --> "compilation check"`
  - **Medium risk**: 
    - Run default run via `Rscript start.R --> "default"`
    - Check logs for errors/warnings
    - Fill in performance section below
  - **High risk**:
    - Run test runs via `Rscript start.R --> "test runs"`
    - Check logs for errors/warnings
    - Default run from the PR target branch for comparison
    - Provide relevant comparison plots (land-use, emissions, food prices, land-use intensity,...)
    - Fill in performance section below

- [x] Reporting produces no errors and no new warnings

- Get two approving reviews (at least one from RSE)

### :chart_with_downwards_trend: Performance :chart_with_upwards_trend:

  - This PR's default :  31.6 mins
  - For comparison: [runtimes](https://gitlab.pik-potsdam.de/landuse/testing_suite) of weekly test

## :rotating_light: Checklist for reviewer :rotating_light:

- PR is labeled correctly
- Code changes look reasonable
  - No hard coded numbers and cluster/country/region names.
  - No unnecessary increase in module interfaces
  - model behavior/performance is satisfactory.
- Changes are properly documented
  - `CHANGELOG` is updated correctly
  - Updates in interfaces have been properly addressed in the module documentations
  - In-code documentation looks appropriate
